### PR TITLE
Issue #142 Tell when PM partner left/joined

### DIFF
--- a/src/main/java/com/faforever/client/chat/AbstractChatTabController.java
+++ b/src/main/java/com/faforever/client/chat/AbstractChatTabController.java
@@ -240,6 +240,10 @@ public abstract class AbstractChatTabController {
     }
   }
 
+  public String getReceiver() {
+    return receiver;
+  }
+
   public void setReceiver(String receiver) {
     this.receiver = receiver;
   }

--- a/src/main/java/com/faforever/client/chat/ChatController.java
+++ b/src/main/java/com/faforever/client/chat/ChatController.java
@@ -161,7 +161,7 @@ public class ChatController {
 
     if (!nameToChatTabController.containsKey(username)) {
       PrivateChatTabController tab = applicationContext.getBean(PrivateChatTabController.class);
-      tab.setUsername(username);
+      tab.setReceiver(username);
       addTab(username, tab);
     }
 

--- a/src/main/java/com/faforever/client/chat/ChatService.java
+++ b/src/main/java/com/faforever/client/chat/ChatService.java
@@ -32,6 +32,8 @@ public interface ChatService {
 
   void addUsersListener(String channelName, MapChangeListener<String, ChatUser> listener);
 
+  void addChatUsersByNameListener(MapChangeListener<String, ChatUser> listener);
+
   void addChannelsListener(MapChangeListener<String, Channel> listener);
 
   void removeUsersListener(String channelName, MapChangeListener<String, ChatUser> listener);

--- a/src/main/java/com/faforever/client/chat/MockChatService.java
+++ b/src/main/java/com/faforever/client/chat/MockChatService.java
@@ -129,6 +129,11 @@ public class MockChatService implements ChatService {
   }
 
   @Override
+  public void addChatUsersByNameListener(MapChangeListener<String, ChatUser> listener) {
+
+  }
+
+  @Override
   public void addChannelsListener(MapChangeListener<String, Channel> listener) {
 
   }

--- a/src/main/java/com/faforever/client/chat/PircBotXChatService.java
+++ b/src/main/java/com/faforever/client/chat/PircBotXChatService.java
@@ -51,7 +51,6 @@ import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -84,7 +83,7 @@ public class PircBotXChatService implements ChatService {
    * Maps channels by name.
    */
   private final ObservableMap<String, Channel> channels;
-  private final Map<String, ChatUser> chatUsersByName;
+  private final ObservableMap<String, ChatUser> chatUsersByName;
   private final ObjectProperty<ConnectionState> connectionState;
   private final IntegerProperty unreadMessagesCount;
   @Resource
@@ -120,7 +119,7 @@ public class PircBotXChatService implements ChatService {
     connectionState = new SimpleObjectProperty<>();
     eventListeners = new ConcurrentHashMap<>();
     channels = observableHashMap();
-    chatUsersByName = new HashMap<>();
+    chatUsersByName = observableHashMap();
     unreadMessagesCount = new SimpleIntegerProperty();
   }
 
@@ -415,6 +414,13 @@ public class PircBotXChatService implements ChatService {
   @Override
   public void addUsersListener(String channelName, MapChangeListener<String, ChatUser> listener) {
     getOrCreateChannel(channelName).addUsersListeners(listener);
+  }
+
+  @Override
+  public void addChatUsersByNameListener(MapChangeListener<String, ChatUser> listener) {
+    synchronized (chatUsersByName) {
+      chatUsersByName.addListener(listener);
+    }
   }
 
   @Override

--- a/src/main/java/com/faforever/client/chat/PrivateChatTabController.java
+++ b/src/main/java/com/faforever/client/chat/PrivateChatTabController.java
@@ -2,6 +2,7 @@ package com.faforever.client.chat;
 
 import com.faforever.client.audio.AudioController;
 import com.faforever.client.preferences.ChatPrefs;
+import com.google.common.annotations.VisibleForTesting;
 import javafx.application.Platform;
 import javafx.fxml.FXML;
 import javafx.scene.control.Tab;
@@ -27,7 +28,11 @@ public class PrivateChatTabController extends AbstractChatTabController {
   AudioController audioController;
   @Resource
   ChatService chatService;
-  private boolean isOffline;
+  private boolean userOffline;
+
+  public boolean isUserOffline() {
+    return userOffline;
+  }
 
   @Override
   public Tab getRoot() {
@@ -45,6 +50,7 @@ public class PrivateChatTabController extends AbstractChatTabController {
   @Override
   void postConstruct() {
     super.postConstruct();
+    userOffline = false;
     chatService.addChatUsersByNameListener(change -> {
       if (change.wasRemoved()) {
         onPlayerDisconnected(change.getKey(), change.getValueRemoved());
@@ -85,16 +91,18 @@ public class PrivateChatTabController extends AbstractChatTabController {
     }
   }
 
-  private void onPlayerDisconnected(String userName, ChatUser userItem) {
+  @VisibleForTesting
+  void onPlayerDisconnected(String userName, ChatUser userItem) {
     if (userName.equals(getReceiver())) {
-      isOffline = true;
+      userOffline = true;
       Platform.runLater(() -> onChatMessage(new ChatMessage(userName, Instant.now(), i18n.get("chat.operator") + ":", i18n.get("chat.privateMessage.playerLeft", userName), true)));
     }
   }
 
-  private void onPlayerConnected(String userName, ChatUser userItem) {
-    if (isOffline && userName.equals(getReceiver())) {
-      isOffline = false;
+  @VisibleForTesting
+  void onPlayerConnected(String userName, ChatUser userItem) {
+    if (userOffline && userName.equals(getReceiver())) {
+      userOffline = false;
       Platform.runLater(() -> onChatMessage(new ChatMessage(userName, Instant.now(), i18n.get("chat.operator") + ":", i18n.get("chat.privateMessage.playerReconnect", userName), true)));
     }
   }

--- a/src/main/resources/i18n/Messages.properties
+++ b/src/main/resources/i18n/Messages.properties
@@ -135,6 +135,9 @@ chat.filter.gameStatus=Game Status
 chat.filter.gameStatus.playing=Playing
 chat.filter.gameStatus.lobby=In lobby
 chat.filter.gameStatus.none=None
+chat.operator=SYSTEM
+chat.privateMessage.playerLeft={0} is now offline
+chat.privateMessage.playerReconnect={0} is back online
 
 games.create=Create game
 games.create.minRating=Min.
@@ -442,3 +445,5 @@ settings.fa.gameLocation=Game location (e. g. "C\:\\Games\\Supreme Commander - F
 urlPreviewDescription={0} ({1})
 
 achievement.unlockedTitle=Achievement unlocked!
+friend.nowOnlineNotification.title={0} is now online
+friend.nowOnlineNotification.action=Click here to start a conversation.

--- a/src/test/java/com/faforever/client/chat/PrivateChatTabControllerTest.java
+++ b/src/test/java/com/faforever/client/chat/PrivateChatTabControllerTest.java
@@ -1,6 +1,7 @@
 package com.faforever.client.chat;
 
 import com.faforever.client.audio.AudioController;
+import com.faforever.client.i18n.I18n;
 import com.faforever.client.notification.NotificationService;
 import com.faforever.client.notification.TransientNotification;
 import com.faforever.client.player.PlayerService;
@@ -20,6 +21,8 @@ import org.testfx.util.WaitForAsyncUtils;
 import java.io.IOException;
 import java.time.Instant;
 
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.*;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
@@ -39,6 +42,8 @@ public class PrivateChatTabControllerTest extends AbstractPlainJavaFxTest {
   AudioController audioController;
   @Mock
   NotificationService notificationService;
+  @Mock
+  I18n i18n;
 
   private PrivateChatTabController instance;
   private String playerName;
@@ -50,10 +55,13 @@ public class PrivateChatTabControllerTest extends AbstractPlainJavaFxTest {
     instance.playerService = playerService;
     instance.audioController = audioController;
     instance.notificationService = notificationService;
+    instance.i18n = i18n;
+
     WaitForAsyncUtils.waitForAsyncFx(3000, () -> instance.stage = new Stage());
 
     playerName = "testUser";
     PlayerInfoBean playerInfoBean = new PlayerInfoBean(playerName);
+    instance.setReceiver(playerName);
 
     when(preferencesService.getPreferences()).thenReturn(preferences);
     when(preferences.getChat()).thenReturn(chatPrefs);
@@ -102,5 +110,24 @@ public class PrivateChatTabControllerTest extends AbstractPlainJavaFxTest {
   @Test
   public void onChatMessageTestIsFoeHideFoe() {
 
+  }
+
+  @Test
+  public void onPlayerConnectedTest() {
+    assertFalse(instance.isUserOffline());
+
+    instance.onPlayerDisconnected(playerName, null);
+    instance.onPlayerConnected(playerName, null);
+
+    assertFalse(instance.isUserOffline());
+  }
+
+  @Test
+  public void onPlayerDisconnected() {
+    assertFalse(instance.isUserOffline());
+
+    instance.onPlayerDisconnected(playerName, null);
+
+    assertTrue(instance.isUserOffline());
   }
 }

--- a/src/test/java/com/faforever/client/user/UserServiceImplTest.java
+++ b/src/test/java/com/faforever/client/user/UserServiceImplTest.java
@@ -54,7 +54,7 @@ public class UserServiceImplTest {
 //
 //    instance.login("junit", "junitPw", true);
 //
-//    verify(login).setUsername("junit");
+//    verify(login).setReceiver("junit");
 //    verify(login).setPassword("junitPw");
 //    verify(login).setAutoLogin(true);
 //    verify(preferencesService).storeInBackground();


### PR DESCRIPTION
The client now sends virtual action messages into private chat windows when the chat partner leaves or rejoins. Rejoining is only detected if the chat partner joins #aeolus due to current architecture.