### PR TITLE
Fix for #298 (IRC reconnect)

### DIFF
--- a/src/test/java/com/faforever/client/chat/PircBotXChatServiceTest.java
+++ b/src/test/java/com/faforever/client/chat/PircBotXChatServiceTest.java
@@ -615,10 +615,11 @@ public class PircBotXChatServiceTest extends AbstractPlainJavaFxTest {
     assertThat(configuration.getRealName(), is(CHAT_USER_NAME));
     assertThat(configuration.getServers().get(0).getHostname(), is(LOOPBACK_ADDRESS.getHostAddress()));
     assertThat(configuration.getServers().get(0).getPort(), is(IRC_SERVER_PORT));
+    verify(outputIrc).joinChannel(DEFAULT_CHANNEL_NAME);
   }
 
   @Test
-  public void testReconnect() throws Exception {
+  public void testAutoReconnectAfterDisconnect() throws Exception {
     CompletableFuture<Boolean> firstStartFuture = new CompletableFuture<>();
     CompletableFuture<Boolean> secondStartFuture = new CompletableFuture<>();
     doAnswer(invocation -> {


### PR DESCRIPTION
Fixes #298.<br />There is no test. Realistic simulation of connection, disconnection, reconnection with rejoining is not working in the current codebase. Existing tests are working around this with some dirty hacks (not actually simulating a complete IRC server/client communication).