### PR TITLE
Fix for #294 (PlayerTooltip missing)

### DIFF
--- a/src/main/java/com/faforever/client/chat/ChatUserItemController.java
+++ b/src/main/java/com/faforever/client/chat/ChatUserItemController.java
@@ -276,10 +276,18 @@ public class ChatUserItemController {
       return;
     }
 
-    // FIXME #294
+    // Create the username tooltip
+    PlayerCardTooltipController playerCardTooltipController = applicationContext.getBean(PlayerCardTooltipController.class);
+    playerCardTooltipController.setPlayer(playerInfoBean);
+
+    Tooltip statusTooltip = new Tooltip();
+    statusTooltip.setGraphic(playerCardTooltipController.getRoot());
+    Tooltip.install(usernameLabel, statusTooltip);
+
+    // Create the clantag tooltip
+    // FIXME #310
     Tooltip tooltip = new Tooltip();
     Tooltip.install(clanLabel, tooltip);
-    Tooltip.install(usernameLabel, tooltip);
 
     Bindings.createStringBinding(
         () -> i18n.get("userInfo.ratingFormat", getGlobalRating(playerInfoBean), getLeaderboardRating(playerInfoBean)),
@@ -309,20 +317,6 @@ public class ChatUserItemController {
     Tooltip statusTooltip = new Tooltip();
     statusTooltip.setGraphic(gameStatusTooltipController.getRoot());
     Tooltip.install(statusImageView, statusTooltip);
-  }
-
-  @FXML
-  void onMouseEnterUsername() {
-    if (playerInfoBean.getChatOnly()) {
-      return;
-    } else {
-      PlayerCardTooltipController playerCardTooltipController = applicationContext.getBean(PlayerCardTooltipController.class);
-      playerCardTooltipController.setPlayer(playerInfoBean);
-
-      Tooltip statusTooltip = new Tooltip();
-      statusTooltip.setGraphic(playerCardTooltipController.getRoot());
-      Tooltip.install(usernameLabel, statusTooltip);
-    }
   }
 
   @FXML

--- a/src/main/java/com/faforever/client/chat/ChatUserItemController.java
+++ b/src/main/java/com/faforever/client/chat/ChatUserItemController.java
@@ -6,6 +6,7 @@ import com.faforever.client.game.GameService;
 import com.faforever.client.game.GameStatus;
 import com.faforever.client.game.GamesController;
 import com.faforever.client.game.JoinGameHelper;
+import com.faforever.client.game.PlayerCardTooltipController;
 import com.faforever.client.i18n.I18n;
 import com.faforever.client.notification.ImmediateNotification;
 import com.faforever.client.notification.NotificationService;
@@ -308,6 +309,20 @@ public class ChatUserItemController {
     Tooltip statusTooltip = new Tooltip();
     statusTooltip.setGraphic(gameStatusTooltipController.getRoot());
     Tooltip.install(statusImageView, statusTooltip);
+  }
+
+  @FXML
+  void onMouseEnterUsername() {
+    if (playerInfoBean.getChatOnly()) {
+      return;
+    } else {
+      PlayerCardTooltipController playerCardTooltipController = applicationContext.getBean(PlayerCardTooltipController.class);
+      playerCardTooltipController.setPlayer(playerInfoBean);
+
+      Tooltip statusTooltip = new Tooltip();
+      statusTooltip.setGraphic(playerCardTooltipController.getRoot());
+      Tooltip.install(usernameLabel, statusTooltip);
+    }
   }
 
   @FXML

--- a/src/main/java/com/faforever/client/chat/ChatUserItemController.java
+++ b/src/main/java/com/faforever/client/chat/ChatUserItemController.java
@@ -102,6 +102,7 @@ public class ChatUserItemController {
   private ChangeListener<String> avatarChangeListener;
   private ChangeListener<String> clanChangeListener;
   private ChangeListener<GameStatus> gameStatusChangeListener;
+  private PlayerCardTooltipController playerCardTooltipController;
 
   @FXML
   void initialize() {
@@ -276,18 +277,10 @@ public class ChatUserItemController {
       return;
     }
 
-    // Create the username tooltip
-    PlayerCardTooltipController playerCardTooltipController = applicationContext.getBean(PlayerCardTooltipController.class);
-    playerCardTooltipController.setPlayer(playerInfoBean);
-
-    Tooltip statusTooltip = new Tooltip();
-    statusTooltip.setGraphic(playerCardTooltipController.getRoot());
-    Tooltip.install(usernameLabel, statusTooltip);
-
-    // Create the clantag tooltip
-    // FIXME #310
+    // FIXME #294
     Tooltip tooltip = new Tooltip();
     Tooltip.install(clanLabel, tooltip);
+    Tooltip.install(usernameLabel, tooltip);
 
     Bindings.createStringBinding(
         () -> i18n.get("userInfo.ratingFormat", getGlobalRating(playerInfoBean), getLeaderboardRating(playerInfoBean)),
@@ -317,6 +310,24 @@ public class ChatUserItemController {
     Tooltip statusTooltip = new Tooltip();
     statusTooltip.setGraphic(gameStatusTooltipController.getRoot());
     Tooltip.install(statusImageView, statusTooltip);
+  }
+
+  @FXML
+  void onMouseEnterUsername() {
+    if (playerInfoBean.getChatOnly()) {
+      return;
+    }
+
+    if (playerCardTooltipController != null) {
+      return;
+    }
+
+    playerCardTooltipController = applicationContext.getBean(PlayerCardTooltipController.class);
+    playerCardTooltipController.setPlayer(playerInfoBean);
+
+    Tooltip statusTooltip = new Tooltip();
+    statusTooltip.setGraphic(playerCardTooltipController.getRoot());
+    Tooltip.install(usernameLabel, statusTooltip);
   }
 
   @FXML

--- a/src/main/resources/theme/chat_user_item.fxml
+++ b/src/main/resources/theme/chat_user_item.fxml
@@ -13,7 +13,6 @@
              styleClass="chat-user-control-country" HBox.hgrow="NEVER"/>
   <Label fx:id="clanLabel" minWidth="0.0" styleClass="chat-user-control-clan"/>
   <Label fx:id="usernameLabel" maxWidth="1.7976931348623157E308" minWidth="0.0" onMouseClicked="#onUsernameClicked"
-         onMouseEntered="#onMouseEnterUsername"
          styleClass="chat-user-control-username" text="&lt;Username&gt;" HBox.hgrow="ALWAYS"/>
   <ImageView fx:id="statusImageView" fitHeight="16.0" fitWidth="16.0" onMouseClicked="#onMouseClickGameStatus"
              onMouseEntered="#onMouseEnterGameStatus" pickOnBounds="true" preserveRatio="true"

--- a/src/main/resources/theme/chat_user_item.fxml
+++ b/src/main/resources/theme/chat_user_item.fxml
@@ -13,6 +13,7 @@
              styleClass="chat-user-control-country" HBox.hgrow="NEVER"/>
   <Label fx:id="clanLabel" minWidth="0.0" styleClass="chat-user-control-clan"/>
   <Label fx:id="usernameLabel" maxWidth="1.7976931348623157E308" minWidth="0.0" onMouseClicked="#onUsernameClicked"
+         onMouseEntered="#onMouseEnterUsername"
          styleClass="chat-user-control-username" text="&lt;Username&gt;" HBox.hgrow="ALWAYS"/>
   <ImageView fx:id="statusImageView" fitHeight="16.0" fitWidth="16.0" onMouseClicked="#onMouseClickGameStatus"
              onMouseEntered="#onMouseEnterGameStatus" pickOnBounds="true" preserveRatio="true"


### PR DESCRIPTION
Uses the existing PlayerCardTooltip, even though it doesn't add much information.

Note: clan tags still show an empty popup!

(Connects to #294 - waffle.io)