### PR TITLE
reveal {map,mod,log} folder

### DIFF
--- a/src/main/java/com/faforever/client/main/MainController.java
+++ b/src/main/java/com/faforever/client/main/MainController.java
@@ -4,6 +4,7 @@ import com.faforever.client.config.ClientProperties;
 import com.faforever.client.fx.AbstractViewController;
 import com.faforever.client.fx.Controller;
 import com.faforever.client.fx.JavaFxUtil;
+import com.faforever.client.fx.PlatformService;
 import com.faforever.client.fx.WindowController;
 import com.faforever.client.game.GameService;
 import com.faforever.client.i18n.I18n;
@@ -60,6 +61,7 @@ import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
 import javax.inject.Inject;
+import java.nio.file.Path;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
@@ -91,6 +93,7 @@ public class MainController implements Controller<Node> {
   private final EventBus eventBus;
   private final String mainWindowTitle;
   private final int ratingBeta;
+  private final PlatformService platformService;
   public Pane mainHeaderPane;
   public Labeled notificationsBadge;
   public Pane contentPane;
@@ -111,7 +114,7 @@ public class MainController implements Controller<Node> {
   @Inject
   public MainController(PreferencesService preferencesService, I18n i18n, NotificationService notificationService,
                         PlayerService playerService, GameService gameService, ClientUpdateService clientUpdateService,
-                        UiService uiService, EventBus eventBus, ClientProperties clientProperties) {
+                        UiService uiService, EventBus eventBus, ClientProperties clientProperties, PlatformService platformService) {
     this.preferencesService = preferencesService;
     this.i18n = i18n;
     this.notificationService = notificationService;
@@ -123,7 +126,8 @@ public class MainController implements Controller<Node> {
 
     this.mainWindowTitle = clientProperties.getMainWindowTitle();
     this.ratingBeta = clientProperties.getTrueSkill().getBeta();
-    
+    this.platformService = platformService;
+
     this.viewCache = CacheBuilder.newBuilder().build();
   }
 
@@ -456,5 +460,20 @@ public class MainController implements Controller<Node> {
 
   private AbstractViewController<?> loadView(NavigationItem item) {
     return noCatch(() -> viewCache.get(item, () -> uiService.loadFxml(item.getFxmlFile())));
+  }
+
+  public void onRevealMapFolder() {
+    Path mapPath = preferencesService.getPreferences().getForgedAlliance().getCustomMapsDirectory();
+    this.platformService.reveal(mapPath);
+  }
+
+  public void onRevealModFolder() {
+    Path modPath = preferencesService.getPreferences().getForgedAlliance().getModsDirectory();
+    this.platformService.reveal(modPath);
+  }
+
+  public void onRevealLogFolder() {
+    Path logPath = preferencesService.getFafLogDirectory();
+    this.platformService.reveal(logPath);
   }
 }

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -27,6 +27,9 @@ menu.support=Support
 menu.feedback=Feedback
 menu.exit=Exit
 menu.settings=Settings
+menu.revealMapFolder=Reveal map folder
+menu.revealLogFolder=Reveal log folder
+menu.revealModFolder=Reveal mod folder
 
 main.community.news=News
 main.chat=Chat

--- a/src/main/resources/i18n/messages_de_DE.properties
+++ b/src/main/resources/i18n/messages_de_DE.properties
@@ -524,6 +524,10 @@ view.table=Tabelle
 
 userMenu.showProfile=Zeige Profil
 
+menu.revealMapFolder=Kartenverzeichnis öffnen
+menu.revealLogFolder=Log-Verzeichnis öffnen
+menu.revealModFolder=Mod-Verzeichnis öffnen
+
 main.leaderboards=Rangliste
 //Still=needs to be translated:
 leaderboard.ranked1v1=1v1 Rating

--- a/src/main/resources/theme/main.fxml
+++ b/src/main/resources/theme/main.fxml
@@ -30,6 +30,10 @@
                                 <SeparatorMenuItem mnemonicParsing="false"/>
                                 <MenuItem disable="true" text="%menu.feedback"/>
                                 <SeparatorMenuItem mnemonicParsing="false"/>
+                                <MenuItem onAction="#onRevealLogFolder" text="%menu.revealLogFolder" />
+                                <MenuItem onAction="#onRevealMapFolder" text="%menu.revealMapFolder" />
+                                <MenuItem onAction="#onRevealModFolder" text="%menu.revealModFolder" />
+                                <SeparatorMenuItem mnemonicParsing="false"/>
                                 <MenuItem onAction="#onExitItemSelected" text="%menu.exit"/>
                             </items>
                             <styleClass>

--- a/src/test/java/com/faforever/client/main/MainControllerTest.java
+++ b/src/test/java/com/faforever/client/main/MainControllerTest.java
@@ -2,6 +2,7 @@ package com.faforever.client.main;
 
 import com.faforever.client.chat.ChatController;
 import com.faforever.client.config.ClientProperties;
+import com.faforever.client.fx.PlatformService;
 import com.faforever.client.fx.WindowController;
 import com.faforever.client.game.GameService;
 import com.faforever.client.i18n.I18n;
@@ -45,6 +46,8 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.testfx.util.WaitForAsyncUtils;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -66,11 +69,12 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class MainControllerTest extends AbstractPlainJavaFxTest {
-
   @Mock
   private PersistentNotificationsController persistentNotificationsController;
   @Mock
   private PreferencesService preferencesService;
+  @Mock
+  private PlatformService platformService;
   @Mock
   private LeaderboardController leaderboardController;
   @Mock
@@ -119,7 +123,7 @@ public class MainControllerTest extends AbstractPlainJavaFxTest {
         .setInitialStandardDeviation(500);
 
     instance = new MainController(preferencesService, i18n, notificationService, playerService, gameService, clientUpdateService,
-        uiService, eventBus, clientProperties);
+        uiService, eventBus, clientProperties, platformService);
 
     gameRunningProperty = new SimpleBooleanProperty();
 
@@ -307,5 +311,31 @@ public class MainControllerTest extends AbstractPlainJavaFxTest {
     Window window = instance.getRoot().getScene().getWindow();
     Rectangle2D bounds = new Rectangle2D(window.getX(), window.getY(), window.getWidth(), window.getHeight());
     assertTrue(Screen.getPrimary().getBounds().contains(bounds));
+  }
+
+  @Test
+  public void testOnRevealMapFolder() throws Exception {
+    Path expectedPath = Paths.get("C:\\test\\path_map");
+    when(forgedAlliancePrefs.getCustomMapsDirectory()).thenReturn(expectedPath);
+    when(preferences.getForgedAlliance()).thenReturn(forgedAlliancePrefs);
+    instance.onRevealMapFolder();
+    verify(platformService).reveal(expectedPath);
+  }
+
+  @Test
+  public void testOnRevealModFolder() throws Exception {
+    Path expectedPath = Paths.get("C:\\test\\path_mod");
+    when(forgedAlliancePrefs.getModsDirectory()).thenReturn(expectedPath);
+    when(preferences.getForgedAlliance()).thenReturn(forgedAlliancePrefs);
+    instance.onRevealModFolder();
+    verify(platformService).reveal(expectedPath);
+  }
+
+  @Test
+  public void testOnRevealLogFolder() throws Exception {
+    Path expectedPath = Paths.get("C:\\test\\path_log");
+    when(preferencesService.getFafLogDirectory()).thenReturn(expectedPath);
+    instance.onRevealLogFolder();
+    verify(platformService).reveal(expectedPath);
   }
 }


### PR DESCRIPTION
This would fix #514, #513 and #512. 

I'm not entirely sure about some aspects of this PR so this is more a **WIP**: 

 - This PR (hopefully) solves three (very similar) open issues and not only one. Should I split it? 
 - I added a static method `openFolder(Path)` to `com.faforever.client.io.FileUtils` which opens the windows explorer on a given path. This currently uses the `java.lang.ProcessBuilder` to call "explorer.exe <PATH>". Should that method be in that class? Should I add support for other OS? 
   - I tried using `java.awt.Desktop` to solve this but (a) using awt stuff in a swing/jfx app seems wrong and (b) I didn't work for me ("not supported").
- Instead of opening "the client's log file", it currently opens the FAF log folder. I'm not sure if thats *correct* and, if not, where to get the correct path. 
- Error handling: currently, there is none. Add a logger to the MainController and let it print the stacktraces?
- Testing: I'm not really sure on how to test this automatically. 