### PR TITLE
fixes #557

### DIFF
--- a/src/main/java/com/faforever/client/game/GameTileController.java
+++ b/src/main/java/com/faforever/client/game/GameTileController.java
@@ -46,6 +46,7 @@ public class GameTileController implements Controller<Node> {
   public ImageView mapImageView;
   private Consumer<Game> onSelectedListener;
   private Game game;
+  private GameTooltipController gameTooltipController;
 
   @Inject
   public GameTileController(MapService mapService, I18n i18n, JoinGameHelper joinGameHelper, ModService modService, UiService uiService) {
@@ -65,6 +66,16 @@ public class GameTileController implements Controller<Node> {
     modsLabel.visibleProperty().bind(modsLabel.textProperty().isNotEmpty());
     gameTypeLabel.managedProperty().bind(gameTypeLabel.visibleProperty());
     lockIconLabel.managedProperty().bind(lockIconLabel.visibleProperty());
+
+    Tooltip tooltip = new Tooltip();
+    gameTooltipController = uiService.loadFxml("theme/play/game_tooltip.fxml");
+    tooltip.setGraphic(gameTooltipController.getRoot());
+    Tooltip.install(gameCardRoot, tooltip);
+    tooltip.showingProperty().addListener((observable, oldValue, newValue) -> {
+      if (newValue && game != null) {
+        gameTooltipController.setGameInfoBean(game);
+      }
+    });
   }
 
   public Node getRoot() {
@@ -103,21 +114,6 @@ public class GameTileController implements Controller<Node> {
     ));
 
     lockIconLabel.visibleProperty().bind(game.passwordProtectedProperty());
-
-    Tooltip tooltip = new Tooltip();
-    Tooltip.install(gameCardRoot, tooltip);
-    tooltip.activatedProperty().addListener((observable, oldValue, newValue) -> {
-      if (newValue) {
-        GameTooltipController gameTooltipController = uiService.loadFxml("theme/play/game_tooltip.fxml");
-        gameTooltipController.setGameInfoBean(game);
-        tooltip.setGraphic(gameTooltipController.getRoot());
-      }
-    });
-    tooltip.showingProperty().addListener((observable, oldValue, newValue) -> {
-      if (!newValue) {
-        tooltip.setGraphic(null);
-      }
-    });
   }
 
   public void onClick(MouseEvent mouseEvent) {

--- a/src/test/java/com/faforever/client/game/GameTileControllerTest.java
+++ b/src/test/java/com/faforever/client/game/GameTileControllerTest.java
@@ -7,6 +7,7 @@ import com.faforever.client.mod.ModService;
 import com.faforever.client.test.AbstractPlainJavaFxTest;
 import com.faforever.client.theme.UiService;
 import javafx.scene.input.MouseButton;
+import javafx.scene.layout.VBox;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -51,6 +52,9 @@ public class GameTileControllerTest extends AbstractPlainJavaFxTest {
     when(modService.getFeaturedMod(game.getFeaturedMod())).thenReturn(CompletableFuture.completedFuture(
         FeaturedModBeanBuilder.create().defaultValues().get()
     ));
+
+    when(uiService.loadFxml("theme/play/game_tooltip.fxml")).thenReturn(gameTooltipController);
+    when(gameTooltipController.getRoot()).thenReturn(new VBox());
 
     loadFxml("theme/play/game_card.fxml", clazz -> instance);
 


### PR DESCRIPTION
Only sets game to the tooltip, when tooltip is shown and does not repeatively create a new tooltip if game is set! I found out that the activated property is not always changed when the tooltip is shown, so I used the shown property instead.