### PR TITLE
Bugfix/#599 game path not recognized

### DIFF
--- a/src/main/java/com/faforever/client/config/BaseConfig.java
+++ b/src/main/java/com/faforever/client/config/BaseConfig.java
@@ -1,6 +1,9 @@
 package com.faforever.client.config;
 
+import com.google.common.eventbus.DeadEvent;
 import com.google.common.eventbus.EventBus;
+import com.google.common.eventbus.Subscribe;
+import lombok.extern.java.Log;
 import org.springframework.context.MessageSource;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.support.ResourceBundleMessageSource;
@@ -22,6 +25,18 @@ public class BaseConfig {
 
   @Bean
   EventBus eventBus() {
-    return new EventBus((exception, context) -> exception.printStackTrace());
+    EventBus bus = new EventBus((exception, context) -> exception.printStackTrace());
+    bus.register(new DeadEventHandler());
+    return bus;
+  }
+
+  @Log
+  private static class DeadEventHandler {
+    @Subscribe
+    public void onDeadEvent(DeadEvent deadEvent) {
+      Object unhandledEvent = deadEvent.getEvent();
+      log.warning("No event handler registered for event of type " +
+          unhandledEvent.getClass().getSimpleName() + ": " + unhandledEvent);
+    }
   }
 }

--- a/src/main/java/com/faforever/client/config/BaseConfig.java
+++ b/src/main/java/com/faforever/client/config/BaseConfig.java
@@ -3,16 +3,18 @@ package com.faforever.client.config;
 import com.google.common.eventbus.DeadEvent;
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
-import lombok.extern.java.Log;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.MessageSource;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.context.support.ResourceBundleMessageSource;
 
 /**
  * This configuration has to be imported by other configurations and should only contain beans that are necessary to run
  * the application.
  */
-@org.springframework.context.annotation.Configuration
+@Slf4j
+@Configuration
 public class BaseConfig {
 
   @Bean
@@ -25,18 +27,17 @@ public class BaseConfig {
 
   @Bean
   EventBus eventBus() {
-    EventBus bus = new EventBus((exception, context) -> exception.printStackTrace());
+    EventBus bus = new EventBus();
     bus.register(new DeadEventHandler());
     return bus;
   }
 
-  @Log
   private static class DeadEventHandler {
     @Subscribe
     public void onDeadEvent(DeadEvent deadEvent) {
       Object unhandledEvent = deadEvent.getEvent();
-      log.warning("No event handler registered for event of type " +
-          unhandledEvent.getClass().getSimpleName() + ": " + unhandledEvent);
+      log.warn("No event handler registered for event of type '{}'",
+          unhandledEvent.getClass().getSimpleName());
     }
   }
 }

--- a/src/main/java/com/faforever/client/game/MissingGamePathNotifier.java
+++ b/src/main/java/com/faforever/client/game/MissingGamePathNotifier.java
@@ -2,8 +2,8 @@ package com.faforever.client.game;
 
 import com.faforever.client.i18n.I18n;
 import com.faforever.client.notification.Action;
+import com.faforever.client.notification.ImmediateNotification;
 import com.faforever.client.notification.NotificationService;
-import com.faforever.client.notification.PersistentNotification;
 import com.faforever.client.notification.Severity;
 import com.faforever.client.preferences.event.MissingGamePathEvent;
 import com.faforever.client.ui.preferences.event.GameDirectoryChooseEvent;
@@ -40,7 +40,7 @@ public class MissingGamePathNotifier {
     List<Action> actions = Collections.singletonList(
         new Action(i18n.get("missingGamePath.locate"), chooseEvent -> eventBus.post(new GameDirectoryChooseEvent()))
     );
-
-    notificationService.addNotification(new PersistentNotification(i18n.get("missingGamePath.notification"), Severity.WARN, actions));
+    String message = i18n.get("missingGamePath.notification");
+    notificationService.addNotification(new ImmediateNotification(message, message, Severity.WARN, actions));
   }
 }

--- a/src/main/java/com/faforever/client/game/MissingGamePathNotifier.java
+++ b/src/main/java/com/faforever/client/game/MissingGamePathNotifier.java
@@ -4,6 +4,7 @@ import com.faforever.client.i18n.I18n;
 import com.faforever.client.notification.Action;
 import com.faforever.client.notification.ImmediateNotification;
 import com.faforever.client.notification.NotificationService;
+import com.faforever.client.notification.PersistentNotification;
 import com.faforever.client.notification.Severity;
 import com.faforever.client.preferences.event.MissingGamePathEvent;
 import com.faforever.client.ui.preferences.event.GameDirectoryChooseEvent;
@@ -40,7 +41,12 @@ public class MissingGamePathNotifier {
     List<Action> actions = Collections.singletonList(
         new Action(i18n.get("missingGamePath.locate"), chooseEvent -> eventBus.post(new GameDirectoryChooseEvent()))
     );
-    String message = i18n.get("missingGamePath.notification");
-    notificationService.addNotification(new ImmediateNotification(message, message, Severity.WARN, actions));
+    String notificationText = i18n.get("missingGamePath.notification");
+
+    if (event.isImmediateUserActionRequired()) {
+      notificationService.addNotification(new ImmediateNotification(notificationText, notificationText, Severity.WARN, actions));
+    } else {
+      notificationService.addNotification(new PersistentNotification(notificationText, Severity.WARN, actions));
+    }
   }
 }

--- a/src/main/java/com/faforever/client/preferences/PreferencesService.java
+++ b/src/main/java/com/faforever/client/preferences/PreferencesService.java
@@ -287,7 +287,7 @@ public class PreferencesService {
   }
 
   private boolean isGamePathValid(Path binPath) {
-    return preferences.getForgedAlliance().getPath() != null
+    return binPath != null
         && (Files.isRegularFile(binPath.resolve(FORGED_ALLIANCE_EXE))
         || Files.isRegularFile(binPath.resolve(SUPREME_COMMANDER_EXE))
     );
@@ -299,13 +299,14 @@ public class PreferencesService {
 
   public void detectGamePath() {
     for (Path path : USUAL_GAME_PATHS) {
-      if (isGamePathValid(path)) {
+      if (isGamePathValid(path.resolve("bin"))) {
         onGameDirectoryChosenEvent(new GameDirectoryChosenEvent(path));
         return;
       }
     }
 
     logger.info("Game path could not be detected");
+    // TODO the handler for this event (MissingGamePathNotifier) is not registered on startup at this point
     eventBus.post(MissingGamePathEvent.INSTANCE);
   }
 }

--- a/src/main/java/com/faforever/client/preferences/PreferencesService.java
+++ b/src/main/java/com/faforever/client/preferences/PreferencesService.java
@@ -138,8 +138,6 @@ public class PreferencesService {
       Files.createDirectories(gamePrefs.getParent());
       Files.copy(getClass().getResourceAsStream("/game.prefs"), gamePrefs);
     }
-
-    // no need to try to detect the game path here, the corresponding handlers are not initialized yet
   }
 
   public static void configureLogging() {
@@ -302,6 +300,6 @@ public class PreferencesService {
     }
 
     logger.info("Game path could not be detected");
-    eventBus.post(MissingGamePathEvent.INSTANCE);
+    eventBus.post(new MissingGamePathEvent());
   }
 }

--- a/src/main/java/com/faforever/client/preferences/PreferencesService.java
+++ b/src/main/java/com/faforever/client/preferences/PreferencesService.java
@@ -139,11 +139,7 @@ public class PreferencesService {
       Files.copy(getClass().getResourceAsStream("/game.prefs"), gamePrefs);
     }
 
-    Path path = preferences.getForgedAlliance().getPath();
-    if (path == null || Files.notExists(path)) {
-      logger.info("Game path is not specified or non-existent, trying to detect");
-      detectGamePath();
-    }
+    // no need to try to detect the game path here, the corresponding handlers are not initialized yet
   }
 
   public static void configureLogging() {
@@ -306,7 +302,6 @@ public class PreferencesService {
     }
 
     logger.info("Game path could not be detected");
-    // TODO the handler for this event (MissingGamePathNotifier) is not registered on startup at this point
     eventBus.post(MissingGamePathEvent.INSTANCE);
   }
 }

--- a/src/main/java/com/faforever/client/preferences/event/MissingGamePathEvent.java
+++ b/src/main/java/com/faforever/client/preferences/event/MissingGamePathEvent.java
@@ -1,5 +1,14 @@
 package com.faforever.client.preferences.event;
 
-public enum MissingGamePathEvent {
-  INSTANCE
+import lombok.AllArgsConstructor;
+import lombok.Value;
+
+@Value
+@AllArgsConstructor
+public class MissingGamePathEvent {
+  private boolean immediateUserActionRequired;
+
+  public MissingGamePathEvent() {
+    this(false);
+  }
 }

--- a/src/main/java/com/faforever/client/rankedmatch/Ladder1v1Controller.java
+++ b/src/main/java/com/faforever/client/rankedmatch/Ladder1v1Controller.java
@@ -10,8 +10,10 @@ import com.faforever.client.leaderboard.RatingStat;
 import com.faforever.client.player.Player;
 import com.faforever.client.player.PlayerService;
 import com.faforever.client.preferences.PreferencesService;
+import com.faforever.client.preferences.event.MissingGamePathEvent;
 import com.faforever.client.util.RatingUtil;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.eventbus.EventBus;
 import javafx.application.Platform;
 import javafx.beans.InvalidationListener;
 import javafx.beans.WeakInvalidationListener;
@@ -63,6 +65,7 @@ public class Ladder1v1Controller extends AbstractViewController<Node> {
   private final LeaderboardService leaderboardService;
   private final I18n i18n;
   private final ClientProperties clientProperties;
+  private EventBus eventBus;
 
   public CategoryAxis ratingDistributionXAxis;
   public NumberAxis ratingDistributionYAxis;
@@ -97,13 +100,15 @@ public class Ladder1v1Controller extends AbstractViewController<Node> {
                              PreferencesService preferencesService,
                              PlayerService playerService,
                              LeaderboardService leaderboardService,
-                             I18n i18n, ClientProperties clientProperties) {
+                             I18n i18n, ClientProperties clientProperties,
+                             EventBus eventBus) {
     this.gameService = gameService;
     this.preferencesService = preferencesService;
     this.playerService = playerService;
     this.leaderboardService = leaderboardService;
     this.i18n = i18n;
     this.clientProperties = clientProperties;
+    this.eventBus = eventBus;
 
     random = new Random();
 
@@ -169,7 +174,7 @@ public class Ladder1v1Controller extends AbstractViewController<Node> {
 
   public void onPlayButtonClicked() {
     if (preferencesService.getPreferences().getForgedAlliance().getPath() == null) {
-      // FIXME implement user notification
+      eventBus.post(new MissingGamePathEvent(true));
       return;
     }
 

--- a/src/test/java/com/faforever/client/game/MissingGamePathNotifierTest.java
+++ b/src/test/java/com/faforever/client/game/MissingGamePathNotifierTest.java
@@ -1,0 +1,48 @@
+package com.faforever.client.game;
+
+import com.faforever.client.i18n.I18n;
+import com.faforever.client.notification.ImmediateNotification;
+import com.faforever.client.notification.NotificationService;
+import com.faforever.client.notification.PersistentNotification;
+import com.faforever.client.preferences.event.MissingGamePathEvent;
+import com.google.common.eventbus.EventBus;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class MissingGamePathNotifierTest {
+  @Mock
+  private I18n i18n;
+  @Mock
+  private NotificationService notificationService;
+
+  private MissingGamePathNotifier instance;
+  private EventBus eventBus;
+
+  @Before
+  public void setUp() {
+    eventBus = new EventBus();
+    instance = new MissingGamePathNotifier(eventBus, i18n, notificationService);
+    instance.postConstruct();
+  }
+
+  @Test
+  public void testImmediateNotificationOnUrgentEvent() {
+    eventBus.post(new MissingGamePathEvent(true));
+
+    verify(notificationService).addNotification(any(ImmediateNotification.class));
+  }
+
+  @Test
+  public void testPersistentNotificationOnDefaultEvent() {
+    eventBus.post(new MissingGamePathEvent());
+
+    verify(notificationService).addNotification(any(PersistentNotification.class));
+  }
+}


### PR DESCRIPTION
This fixes the file resolving issue of #599 (missing '/bin' in the path) and also brings up a warning pop-up with a file chooser action on an undetected game path. 
Additionally any events that are posted to the guava eventbus but not being handled are logged at WARN level now. 