### PR TITLE
Bugfix/#782 apply ircfilter on user login

### DIFF
--- a/src/main/java/com/faforever/client/chat/ChannelTabController.java
+++ b/src/main/java/com/faforever/client/chat/ChannelTabController.java
@@ -37,6 +37,7 @@ import javafx.scene.control.Tab;
 import javafx.scene.control.TextField;
 import javafx.scene.control.TextInputControl;
 import javafx.scene.control.TitledPane;
+import javafx.scene.control.ToggleButton;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.HBox;
@@ -80,7 +81,7 @@ public class ChannelTabController extends AbstractChatTabController {
   private final Map<String, Map<Pane, ChatUserItemController>> userToChatUserControls;
   private final ThreadPoolExecutor threadPoolExecutor;
   private final TaskScheduler taskScheduler;
-  public Button advancedUserFilter;
+  public ToggleButton advancedUserFilter;
   public HBox searchFieldContainer;
   public Button closeSearchFieldButton;
   public TextField searchField;
@@ -315,13 +316,7 @@ public class ChannelTabController extends AbstractChatTabController {
 
     userFilterController = uiService.loadFxml("theme/chat/user_filter.fxml");
     userFilterController.setChannelController(this);
-    userFilterController.getIsFilterAppliedProperty().addListener((observable, oldValue, newValue) -> {
-      if (!oldValue && newValue) {
-        advancedUserFilter.setStyle("-fx-text-fill: -swatch-400");
-      } else if (oldValue && !newValue) {
-        advancedUserFilter.setStyle(null);
-      }
-    });
+    userFilterController.filterAppliedProperty().addListener(((observable, oldValue, newValue) -> advancedUserFilter.setSelected(newValue)));
     filterUserPopup.getContent().setAll(userFilterController.getRoot());
   }
 
@@ -452,7 +447,7 @@ public class ChannelTabController extends AbstractChatTabController {
       if (!userSearchTextField.textProperty().get().isEmpty()) {
         chatUserItemController.setVisible(isUsernameMatch(chatUserItemController));
       }
-      if (userFilterController.getIsFilterAppliedProperty().get()) {
+      if (userFilterController.isFilterApplied()) {
         chatUserItemController.setVisible(userFilterController.filterUser(chatUserItemController));
       }
     }
@@ -586,12 +581,13 @@ public class ChannelTabController extends AbstractChatTabController {
   }
 
   public void onAdvancedUserFilter(ActionEvent actionEvent) {
+    advancedUserFilter.setSelected(userFilterController.isFilterApplied());
     if (filterUserPopup.isShowing()) {
       filterUserPopup.hide();
       return;
     }
 
-    Button button = (Button) actionEvent.getSource();
+    ToggleButton button = (ToggleButton) actionEvent.getSource();
 
     Bounds screenBounds = advancedUserFilter.localToScreen(advancedUserFilter.getBoundsInLocal());
     filterUserPopup.show(button.getScene().getWindow(), screenBounds.getMinX(), screenBounds.getMaxY());

--- a/src/main/java/com/faforever/client/chat/ChannelTabController.java
+++ b/src/main/java/com/faforever/client/chat/ChannelTabController.java
@@ -315,6 +315,13 @@ public class ChannelTabController extends AbstractChatTabController {
 
     userFilterController = uiService.loadFxml("theme/chat/user_filter.fxml");
     userFilterController.setChannelController(this);
+    userFilterController.getIsFilterAppliedProperty().addListener((observable, oldValue, newValue) -> {
+      if (!oldValue && newValue) {
+        advancedUserFilter.setStyle("-fx-text-fill: -swatch-400");
+      } else if (oldValue && !newValue) {
+        advancedUserFilter.setStyle(null);
+      }
+    });
     filterUserPopup.getContent().setAll(userFilterController.getRoot());
   }
 
@@ -445,8 +452,8 @@ public class ChannelTabController extends AbstractChatTabController {
       if (!userSearchTextField.textProperty().get().isEmpty()) {
         chatUserItemController.setVisible(isUsernameMatch(chatUserItemController));
       }
-      if (filterUserPopup.isShowing()) {
-        userFilterController.filterUser(chatUserItemController);
+      if (userFilterController.getIsFilterAppliedProperty().get()) {
+        chatUserItemController.setVisible(userFilterController.filterUser(chatUserItemController));
       }
     }
   }

--- a/src/main/java/com/faforever/client/chat/UserFilterController.java
+++ b/src/main/java/com/faforever/client/chat/UserFilterController.java
@@ -5,6 +5,8 @@ import com.faforever.client.game.PlayerStatus;
 import com.faforever.client.i18n.I18n;
 import com.faforever.client.util.RatingUtil;
 import com.google.common.annotations.VisibleForTesting;
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.SimpleBooleanProperty;
 import javafx.event.ActionEvent;
 import javafx.scene.Node;
 import javafx.scene.control.MenuButton;
@@ -33,6 +35,7 @@ public class UserFilterController implements Controller<Node> {
   public TextField clanFilterField;
   public TextField minRatingFilterField;
   public TextField maxRatingFilterField;
+  private BooleanProperty isFilterApplied = new SimpleBooleanProperty(false);
   @VisibleForTesting
   ChannelTabController channelTabController;
   @VisibleForTesting
@@ -61,6 +64,7 @@ public class UserFilterController implements Controller<Node> {
         chatUserItemController.setVisible(filterUser(chatUserItemController));
       }
     }
+    isFilterApplied.set(!maxRatingFilterField.getText().isEmpty() || !maxRatingFilterField.getText().isEmpty() || !clanFilterField.getText().isEmpty());
   }
 
   boolean filterUser(ChatUserItemController chatUserItemController) {
@@ -68,6 +72,10 @@ public class UserFilterController implements Controller<Node> {
         && isInClan(chatUserItemController)
         && isBoundedByRating(chatUserItemController)
         && isGameStatusMatch(chatUserItemController);
+  }
+
+  public BooleanProperty getIsFilterAppliedProperty() {
+    return isFilterApplied;
   }
 
   @VisibleForTesting

--- a/src/main/resources/theme/chat/channel_tab.fxml
+++ b/src/main/resources/theme/chat/channel_tab.fxml
@@ -7,6 +7,7 @@
 <?import javafx.scene.control.Tab?>
 <?import javafx.scene.control.TextField?>
 <?import javafx.scene.control.TitledPane?>
+<?import javafx.scene.control.ToggleButton?>
 <?import javafx.scene.layout.AnchorPane?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.VBox?>
@@ -33,8 +34,8 @@
               <HBox alignment="CENTER">
                 <children>
                   <TextField fx:id="userSearchTextField" maxWidth="1.7976931348623157E308" minWidth="10.0" prefColumnCount="5" HBox.hgrow="ALWAYS" />
-                    <Button fx:id="advancedUserFilter" mnemonicParsing="false" onAction="#onAdvancedUserFilter"
-                            styleClass="icon-button" text="" HBox.hgrow="NEVER"/>
+                  <ToggleButton fx:id="advancedUserFilter" mnemonicParsing="false" onAction="#onAdvancedUserFilter"
+                                styleClass="icon-button" text="" HBox.hgrow="NEVER"/>
                 </children>
                         <VBox.margin>
                            <Insets left="10.0" />

--- a/src/main/resources/theme/chat/user_filter.fxml
+++ b/src/main/resources/theme/chat/user_filter.fxml
@@ -2,12 +2,12 @@
 
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.control.MenuButton?>
-<?import javafx.scene.control.MenuItem?>
+<?import javafx.scene.control.RadioMenuItem?>
 <?import javafx.scene.control.TextField?>
+<?import javafx.scene.control.ToggleGroup?>
 <?import javafx.scene.layout.ColumnConstraints?>
 <?import javafx.scene.layout.GridPane?>
 <?import javafx.scene.layout.RowConstraints?>
-
 <GridPane fx:id="filterUserRoot" hgap="10.0" styleClass="filter-user-root" vgap="10.0" xmlns="http://javafx.com/javafx/8.0.60" xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.faforever.client.chat.UserFilterController">
   <columnConstraints>
     <ColumnConstraints hgrow="SOMETIMES" />
@@ -24,9 +24,15 @@
     <TextField fx:id="maxRatingFilterField" promptText="%chat.filter.maxRating" GridPane.columnSpan="2147483647" GridPane.rowIndex="1" />
   <MenuButton fx:id="gameStatusMenu" mnemonicParsing="false" text="%game.gameStatus" GridPane.rowIndex="3">
     <items>
-      <MenuItem mnemonicParsing="false" onAction="#onGameStatusNone" text="%game.gameStatus.none" />
-      <MenuItem mnemonicParsing="false" onAction="#onGameStatusPlaying" text="%game.gameStatus.playing" />
-      <MenuItem mnemonicParsing="false" onAction="#onGameStatusLobby" text="%game.gameStatus.lobby" />
+        <RadioMenuItem mnemonicParsing="false" text="%game.gameStatus.none" onAction="#onGameStatusNone">
+            <toggleGroup>
+                <ToggleGroup fx:id="gameStatusToggleGroup"/>
+            </toggleGroup>
+        </RadioMenuItem>
+        <RadioMenuItem mnemonicParsing="false" toggleGroup="$gameStatusToggleGroup" onAction="#onGameStatusPlaying"
+                       text="%game.gameStatus.playing"/>
+        <RadioMenuItem mnemonicParsing="false" toggleGroup="$gameStatusToggleGroup" onAction="#onGameStatusLobby"
+                       text="%game.gameStatus.lobby"/>
     </items>
   </MenuButton>
   </children>

--- a/src/test/java/com/faforever/client/chat/ChannelTabControllerTest.java
+++ b/src/test/java/com/faforever/client/chat/ChannelTabControllerTest.java
@@ -138,7 +138,7 @@ public class ChannelTabControllerTest extends AbstractPlainJavaFxTest {
     when(uiService.loadFxml("theme/chat/user_filter.fxml")).thenReturn(userFilterController);
     when(uiService.loadFxml("theme/chat/chat_user_item.fxml")).thenReturn(chatUserItemController);
     when(userFilterController.getRoot()).thenReturn(new Pane());
-    when(userFilterController.getIsFilterAppliedProperty()).thenReturn(new SimpleBooleanProperty(false));
+    when(userFilterController.filterAppliedProperty()).thenReturn(new SimpleBooleanProperty(false));
     when(chatUserItemController.getRoot()).thenReturn(new Pane());
     when(uiService.getThemeFileUrl(CHAT_CONTAINER)).thenReturn(getClass().getResource("/theme/chat/chat_container.html"));
 

--- a/src/test/java/com/faforever/client/chat/ChannelTabControllerTest.java
+++ b/src/test/java/com/faforever/client/chat/ChannelTabControllerTest.java
@@ -22,6 +22,7 @@ import com.faforever.client.uploader.ImageUploadService;
 import com.faforever.client.user.UserService;
 import com.faforever.client.util.TimeService;
 import com.google.common.eventbus.EventBus;
+import javafx.beans.property.SimpleBooleanProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.MapChangeListener;
 import javafx.collections.MapChangeListener.Change;
@@ -137,6 +138,7 @@ public class ChannelTabControllerTest extends AbstractPlainJavaFxTest {
     when(uiService.loadFxml("theme/chat/user_filter.fxml")).thenReturn(userFilterController);
     when(uiService.loadFxml("theme/chat/chat_user_item.fxml")).thenReturn(chatUserItemController);
     when(userFilterController.getRoot()).thenReturn(new Pane());
+    when(userFilterController.getIsFilterAppliedProperty()).thenReturn(new SimpleBooleanProperty(false));
     when(chatUserItemController.getRoot()).thenReturn(new Pane());
     when(uiService.getThemeFileUrl(CHAT_CONTAINER)).thenReturn(getClass().getResource("/theme/chat/chat_container.html"));
 


### PR DESCRIPTION
1. Applies filter on new chat users logging in.
2. If one applied a PlayerStatus filter (i.e. only show PlayerStatus.PLAYING), it could not be unset. Opted for RadioMenuItems in a togglegroup as more than one status should not be selectable anyway.
3. Filter should apply despite closing the popup, so now shows with standard togglebutton styling whether or not a filter is active/applied. 