### PR TITLE
set default chat format to compact

### DIFF
--- a/src/main/java/com/faforever/client/preferences/ChatPrefs.java
+++ b/src/main/java/com/faforever/client/preferences/ChatPrefs.java
@@ -47,7 +47,7 @@ public class ChatPrefs {
     userToColor = new SimpleMapProperty<>(FXCollections.observableHashMap());
     chatColorMode = new SimpleObjectProperty<>(CUSTOM);
     idleThreshold = new SimpleIntegerProperty(10);
-    chatFormat = new SimpleObjectProperty<>(ChatFormat.EXTENDED);
+    chatFormat = new SimpleObjectProperty<>(ChatFormat.COMPACT);
   }
 
   public ChatColorMode getChatColorMode() {


### PR DESCRIPTION
most people prefer the compact chat mode and requested this should be set as the default.