### PR TITLE
Fixes Featured Mod not shown

### DIFF
--- a/src/main/java/com/faforever/client/replay/ReplayService.java
+++ b/src/main/java/com/faforever/client/replay/ReplayService.java
@@ -170,7 +170,7 @@ public class ReplayService {
           .forEach(replayFile -> {
             try {
               LocalReplayInfo replayInfo = replayFileReader.parseMetaData(replayFile);
-              FeaturedMod featuredMod = modService.getFeaturedMod(replayInfo.getFeaturedMod()).getNow(FeaturedMod.UNKNOWN);
+              FeaturedMod featuredMod = modService.getFeaturedMod(replayInfo.getFeaturedMod()).get();
 
               mapService.findByMapFolderName(replayInfo.getMapname())
                   .thenAccept(mapBean -> replayInfos.add(new Replay(replayInfo, replayFile, featuredMod, mapBean.orElse(null))));


### PR DESCRIPTION
The load local replay called is made async already so the get() is fine otherwise the get() will be called one step ahead. getNow is problematic if the Future is not ready it simply uses unknow if future is not finishes which is the case in most cases.
Fixes #732