### PR TITLE
Fix bugs in chat refactoring

### DIFF
--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -2,6 +2,7 @@
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/downlords-faf-client.iml" filepath="$PROJECT_DIR$/.idea/modules/downlords-faf-client.iml" />
       <module fileurl="file://$PROJECT_DIR$/downlords-faf-client.iml" filepath="$PROJECT_DIR$/downlords-faf-client.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/webview-patch/downlords-faf-client-webview-patch.iml" filepath="$PROJECT_DIR$/.idea/modules/webview-patch/downlords-faf-client-webview-patch.iml" group="webview-patch" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/webview-patch/downlords-faf-client-webview-patch_main.iml" filepath="$PROJECT_DIR$/.idea/modules/webview-patch/downlords-faf-client-webview-patch_main.iml" group="webview-patch" />

--- a/src/main/java/com/faforever/client/chat/ChannelTabController.java
+++ b/src/main/java/com/faforever/client/chat/ChannelTabController.java
@@ -375,7 +375,7 @@ public class ChannelTabController extends AbstractChatTabController {
 
       ChatChannelUser user = listItem.getUser();
 
-      return user != null && user.getUsername().toLowerCase(US).contains(searchString.toLowerCase(US));
+      return listItem.getCategory() != null || user.getUsername().toLowerCase(US).contains(searchString.toLowerCase(US));
     });
   }
 
@@ -429,7 +429,9 @@ public class ChannelTabController extends AbstractChatTabController {
     Arrays.stream(ChatUserCategory.values())
         .filter(chatUserCategory -> !chatUserCategories.contains(chatUserCategory))
         .map(categoriesToUserListItems::get)
-        .forEach(chatUserListItems::removeAll);
+        .flatMap(Collection::stream)
+        .filter(categoryOrChatUserListItem -> categoryOrChatUserListItem.getUser() != null && categoryOrChatUserListItem.getUser().equals(chatUser))
+        .forEach(chatUserListItems::remove);
 
     CategoryOrChatUserListItem listItem = new CategoryOrChatUserListItem(null, chatUser);
     chatUserCategories.stream()
@@ -439,6 +441,7 @@ public class ChannelTabController extends AbstractChatTabController {
 
   private void addToTreeItemSorted(CategoryOrChatUserListItem parent, CategoryOrChatUserListItem child) {
     Platform.runLater(() -> {
+      categoriesToUserListItems.get(parent.getCategory()).add(child);
       for (int index = chatUserListItems.indexOf(parent) + 1; index < chatUserListItems.size(); index++) {
         CategoryOrChatUserListItem otherItem = chatUserListItems.get(index);
 
@@ -483,6 +486,7 @@ public class ChannelTabController extends AbstractChatTabController {
       } else {
         updateUserMessageDisplay(chatUser, "");
       }
+      updateChatUserListItemsForCategories(chatUser);
     };
     socialStatusMessagesListeners.computeIfAbsent(player.getUsername(), i -> new ArrayList<>()).add(listener);
     return new WeakChangeListener<>(listener);

--- a/src/main/java/com/faforever/client/chat/ChatUserContextMenuController.java
+++ b/src/main/java/com/faforever/client/chat/ChatUserContextMenuController.java
@@ -48,7 +48,6 @@ import org.springframework.stereotype.Component;
 import java.lang.invoke.MethodHandles;
 import java.net.URL;
 import java.util.Objects;
-import java.util.Optional;
 
 import static com.faforever.client.chat.ChatColorMode.CUSTOM;
 import static com.faforever.client.fx.WindowController.WindowButtonType.CLOSE;
@@ -95,7 +94,6 @@ public class ChatUserContextMenuController implements Controller<ContextMenu> {
 
   @SuppressWarnings("FieldCanBeLocal")
   private ChangeListener<Player> playerChangeListener;
-  private Optional<Runnable> onSocialStatusChangedListener;
 
   public ChatUserContextMenuController(PreferencesService preferencesService,
                                        PlayerService playerService, ReplayService replayService,
@@ -110,7 +108,6 @@ public class ChatUserContextMenuController implements Controller<ContextMenu> {
     this.joinGameHelper = joinGameHelper;
     this.avatarService = avatarService;
     this.uiService = uiService;
-    onSocialStatusChangedListener = Optional.empty();
   }
 
   public void initialize() {
@@ -258,13 +255,11 @@ public class ChatUserContextMenuController implements Controller<ContextMenu> {
       playerService.removeFoe(player);
     }
     playerService.addFriend(player);
-    onSocialStatusChangedListener.ifPresent(Runnable::run);
   }
 
   public void onRemoveFriendSelected() {
     Player player = getPlayer();
     playerService.removeFriend(player);
-    onSocialStatusChangedListener.ifPresent(Runnable::run);
   }
 
   public void onAddFoeSelected() {
@@ -273,13 +268,11 @@ public class ChatUserContextMenuController implements Controller<ContextMenu> {
       playerService.removeFriend(player);
     }
     playerService.addFoe(player);
-    onSocialStatusChangedListener.ifPresent(Runnable::run);
   }
 
   public void onRemoveFoeSelected() {
     Player player = getPlayer();
     playerService.removeFoe(player);
-    onSocialStatusChangedListener.ifPresent(Runnable::run);
   }
 
   public void onWatchGameSelected() {
@@ -327,9 +320,5 @@ public class ChatUserContextMenuController implements Controller<ContextMenu> {
   @Override
   public ContextMenu getRoot() {
     return chatUserContextMenuRoot;
-  }
-
-  void setOnSocialStatusChangedListener(Optional<Runnable> onSocialStatusChangedListener) {
-    this.onSocialStatusChangedListener = onSocialStatusChangedListener;
   }
 }

--- a/src/main/java/com/faforever/client/chat/ChatUserItemController.java
+++ b/src/main/java/com/faforever/client/chat/ChatUserItemController.java
@@ -108,7 +108,6 @@ public class ChatUserItemController implements Controller<Node> {
   private Tooltip clanTooltip;
   private Tooltip avatarTooltip;
   private Tooltip userTooltip;
-  private Optional<Runnable> onSocialStatusUpdatedListener;
 
   // TODO reduce dependencies, rely on eventBus instead
   public ChatUserItemController(PreferencesService preferencesService, AvatarService avatarService,
@@ -216,7 +215,6 @@ public class ChatUserItemController implements Controller<Node> {
   public void onContextMenuRequested(ContextMenuEvent event) {
     ChatUserContextMenuController contextMenuController = uiService.loadFxml("theme/chat/chat_user_context_menu.fxml");
     contextMenuController.setChatUser(chatUser);
-    contextMenuController.setOnSocialStatusChangedListener(onSocialStatusUpdatedListener);
     contextMenuController.getContextMenu().show(chatUserItemRoot, event.getScreenX(), event.getScreenY());
   }
 
@@ -502,9 +500,5 @@ public class ChatUserItemController implements Controller<Node> {
   public void onMouseExitedAvatarImageView() {
     Tooltip.uninstall(avatarImageView, avatarTooltip);
     avatarTooltip = null;
-  }
-
-  public void setOnSocialStatusUpdatedListener(Optional<Runnable> onSocialStatusUpdatedListener) {
-    this.onSocialStatusUpdatedListener = onSocialStatusUpdatedListener;
   }
 }

--- a/src/main/java/com/faforever/client/chat/ChatUserListCell.java
+++ b/src/main/java/com/faforever/client/chat/ChatUserListCell.java
@@ -4,13 +4,11 @@ import com.faforever.client.theme.UiService;
 import javafx.scene.control.ListCell;
 
 import java.util.Objects;
-import java.util.Optional;
 
 public class ChatUserListCell extends ListCell<CategoryOrChatUserListItem> {
 
   private final ChatUserItemController chatUserItemController;
   private final ChatUserItemCategoryController chatUserCategoryController;
-  private Optional<Runnable> onSocialStatusUpdatedListener;
   private Object oldItem;
 
   public ChatUserListCell(UiService uiService) {
@@ -18,11 +16,6 @@ public class ChatUserListCell extends ListCell<CategoryOrChatUserListItem> {
     chatUserCategoryController = uiService.loadFxml("theme/chat/chat_user_category.fxml");
 
     setText(null);
-  }
-
-  // TODO check whether or not this is meant to be used. Fix accordingly.
-  public void setOnSocialStatusUpdatedListener(Runnable onSocialStatusUpdatedListener) {
-    this.onSocialStatusUpdatedListener = Optional.ofNullable(onSocialStatusUpdatedListener);
   }
 
   @Override
@@ -44,7 +37,6 @@ public class ChatUserListCell extends ListCell<CategoryOrChatUserListItem> {
     if (item.getUser() != null) {
       chatUserCategoryController.setChatUserCategory(null);
       chatUserItemController.setChatUser(item.getUser());
-      chatUserItemController.setOnSocialStatusUpdatedListener(onSocialStatusUpdatedListener);
       setGraphic(chatUserItemController.getRoot());
     } else {
       chatUserItemController.setChatUser(null);

--- a/src/main/java/com/faforever/client/query/LogicalNodeController.java
+++ b/src/main/java/com/faforever/client/query/LogicalNodeController.java
@@ -43,6 +43,9 @@ public class LogicalNodeController implements Controller<Node> {
     logicalOperatorField.setConverter(new StringConverter<>() {
       @Override
       public String toString(LogicalOperator object) {
+        if (object == null) {
+          return "";
+        }
         return i18n.get(object.i18nKey);
       }
 

--- a/src/main/java/com/faforever/client/query/SpecificationController.java
+++ b/src/main/java/com/faforever/client/query/SpecificationController.java
@@ -114,9 +114,12 @@ public class SpecificationController implements Controller<Node> {
     valueField.editableProperty().bind(valueField.visibleProperty());
 
     operationField.setItems(comparisonOperators);
-    operationField.setConverter(new StringConverter<ComparisonOperator>() {
+    operationField.setConverter(new StringConverter<>() {
       @Override
       public String toString(ComparisonOperator object) {
+        if (object == null) {
+          return "";
+        }
         return i18n.get(operatorToI18nKey.get(object));
       }
 

--- a/src/test/java/com/faforever/client/chat/PircBotXChatServiceTest.java
+++ b/src/test/java/com/faforever/client/chat/PircBotXChatServiceTest.java
@@ -840,7 +840,6 @@ public class PircBotXChatServiceTest extends AbstractPlainJavaFxTest {
     when(user.getNick()).thenReturn(chatUser1.getUsername());
 
     connect();
-    firePircBotXEvent(createPrivateMessageEvent(user, message));
 
     CountDownLatch latch = new CountDownLatch(1);
     doAnswer(invocation -> {
@@ -848,7 +847,8 @@ public class PircBotXChatServiceTest extends AbstractPlainJavaFxTest {
       return null;
     }).when(eventBus).post(any(ChatMessageEvent.class));
 
-    latch.await(500, TimeUnit.SECONDS);
+    firePircBotXEvent(createPrivateMessageEvent(user, message));
+    latch.await(100, TimeUnit.SECONDS);
     verify(eventBus).post(any(ChatMessageEvent.class));
   }
 }


### PR DESCRIPTION
Some bugs fixed in Downlord's chat rewrite. The categoriesToUserList map was never updated and no changes were made when the social status changed. Also all users were removed from one category in line 429 of ChannelTabController instead of only the items if the user that is updated. Further with new java version or javafx version the StringConverter of Combo boxes seems to be feed with null values as well(for empty display), so I returned "" in that case.

Fixes #976
Fixes #971