### PR TITLE
[fixes #1092] AutoComplete only usernames that are in the channel

### DIFF
--- a/src/main/java/com/faforever/client/chat/AbstractChatTabController.java
+++ b/src/main/java/com/faforever/client/chat/AbstractChatTabController.java
@@ -113,8 +113,8 @@ public abstract class AbstractChatTabController implements Controller<Tab> {
   protected final UiService uiService;
   protected final EventBus eventBus;
   protected final WebViewConfigurer webViewConfigurer;
+  protected final AutoCompletionHelper autoCompletionHelper;
   private final ImageUploadService imageUploadService;
-  private final AutoCompletionHelper autoCompletionHelper;
   private final CountryFlagService countryFlagService;
 
   /**

--- a/src/main/java/com/faforever/client/chat/AbstractChatTabController.java
+++ b/src/main/java/com/faforever/client/chat/AbstractChatTabController.java
@@ -113,7 +113,6 @@ public abstract class AbstractChatTabController implements Controller<Tab> {
   protected final UiService uiService;
   protected final EventBus eventBus;
   protected final WebViewConfigurer webViewConfigurer;
-  protected final AutoCompletionHelper autoCompletionHelper;
   private final ImageUploadService imageUploadService;
   private final CountryFlagService countryFlagService;
 
@@ -145,7 +144,7 @@ public abstract class AbstractChatTabController implements Controller<Tab> {
                                    TimeService timeService, I18n i18n,
                                    ImageUploadService imageUploadService,
                                    NotificationService notificationService, ReportingService reportingService, UiService uiService,
-                                   AutoCompletionHelper autoCompletionHelper, EventBus eventBus, CountryFlagService countryFlagService) {
+                                   EventBus eventBus, CountryFlagService countryFlagService) {
 
     this.webViewConfigurer = webViewConfigurer;
     this.uiService = uiService;
@@ -159,7 +158,6 @@ public abstract class AbstractChatTabController implements Controller<Tab> {
     this.imageUploadService = imageUploadService;
     this.notificationService = notificationService;
     this.reportingService = reportingService;
-    this.autoCompletionHelper = autoCompletionHelper;
     this.eventBus = eventBus;
     this.countryFlagService = countryFlagService;
 
@@ -255,8 +253,6 @@ public abstract class AbstractChatTabController implements Controller<Tab> {
     unreadMessagesCount.addListener((observable, oldValue, newValue) -> chatService.incrementUnreadMessagesCount(newValue.intValue() - oldValue.intValue()));
     JavaFxUtil.addListener(StageHolder.getStage().focusedProperty(), new WeakChangeListener<>(resetUnreadMessagesListener));
     JavaFxUtil.addListener(getRoot().selectedProperty(), new WeakChangeListener<>(resetUnreadMessagesListener));
-
-    autoCompletionHelper.bindTo(messageTextField());
 
     getRoot().setOnClosed(this::onClosed);
   }

--- a/src/main/java/com/faforever/client/chat/AutoCompletionHelper.java
+++ b/src/main/java/com/faforever/client/chat/AutoCompletionHelper.java
@@ -6,6 +6,7 @@ import javafx.event.EventHandler;
 import javafx.scene.control.TextInputControl;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyEvent;
+import lombok.Setter;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
@@ -13,6 +14,7 @@ import org.springframework.stereotype.Component;
 import javax.inject.Inject;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static java.util.Locale.US;
@@ -24,6 +26,8 @@ public class AutoCompletionHelper {
   private final PlayerService playerService;
 
   private List<String> possibleAutoCompletions;
+  @Setter
+  private Set<String> channelUserNames;
   private int nextAutoCompleteIndex;
   private String autoCompletePartialName;
 
@@ -99,8 +103,14 @@ public class AutoCompletionHelper {
 
     nextAutoCompleteIndex = 0;
 
+    Set<String> playerNames = playerService.getPlayerNames();
+
+    if (channelUserNames != null) {
+      playerNames.addAll(channelUserNames);
+    }
+
     possibleAutoCompletions.addAll(
-        playerService.getPlayerNames().stream()
+        playerNames.stream()
             .filter(playerName -> playerName.toLowerCase(US).startsWith(autoCompletePartialName.toLowerCase()))
             .sorted()
             .collect(Collectors.toList())

--- a/src/main/java/com/faforever/client/chat/ChannelTabController.java
+++ b/src/main/java/com/faforever/client/chat/ChannelTabController.java
@@ -56,6 +56,7 @@ import org.springframework.util.Assert;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
@@ -162,6 +163,7 @@ public class ChannelTabController extends AbstractChatTabController {
     userNamesToListItems = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
     chatUserListItems = FXCollections.observableArrayList();
     filteredChatUserList = new FilteredList<>(chatUserListItems);
+    autoCompletionHelper.setChannelUserNames(Collections.unmodifiableSet(userNamesToListItems.keySet()));
 
     chatColorModeChangeListener = (observable, oldValue, newValue) -> {
       if (newValue != DEFAULT) {

--- a/src/main/java/com/faforever/client/chat/PrivateChatTabController.java
+++ b/src/main/java/com/faforever/client/chat/PrivateChatTabController.java
@@ -55,14 +55,13 @@ public class PrivateChatTabController extends AbstractChatTabController {
                                   NotificationService notificationService,
                                   ReportingService reportingService,
                                   UiService uiService,
-                                  AutoCompletionHelper autoCompletionHelper,
                                   EventBus eventBus,
                                   AudioService audioService,
                                   ChatService chatService,
                                   WebViewConfigurer webViewConfigurer,
                                   CountryFlagService countryFlagService) {
     super(webViewConfigurer, userService, chatService, preferencesService, playerService, audioService,
-        timeService, i18n, imageUploadService, notificationService, reportingService, uiService, autoCompletionHelper,
+        timeService, i18n, imageUploadService, notificationService, reportingService, uiService, 
         eventBus, countryFlagService);
   }
 

--- a/src/test/java/com/faforever/client/chat/AbstractChatTabControllerTest.java
+++ b/src/test/java/com/faforever/client/chat/AbstractChatTabControllerTest.java
@@ -82,8 +82,6 @@ public class AbstractChatTabControllerTest extends AbstractPlainJavaFxTest {
   @Mock
   private NotificationService notificationService;
   @Mock
-  private AutoCompletionHelper autoCompletionHelper;
-  @Mock
   private UiService uiService;
   @Mock
   private WebViewConfigurer webViewConfigurer;
@@ -111,8 +109,8 @@ public class AbstractChatTabControllerTest extends AbstractPlainJavaFxTest {
     when(preferencesService.getPreferences()).thenReturn(preferences);
 
     instance = new AbstractChatTabController(webViewConfigurer, userService, chatService, preferencesService,
-        playerService, audioService, timeService, i18n, imageUploadService, notificationService, reportingService, uiService,
-        autoCompletionHelper, eventBus, countryFlagService) {
+        playerService, audioService, timeService, i18n, imageUploadService, notificationService, reportingService,
+        uiService, eventBus, countryFlagService) {
       private final Tab root = new Tab();
       private final WebView webView = new WebView();
       private final TextInputControl messageTextField = new TextField();

--- a/src/test/java/com/faforever/client/chat/ChannelTabControllerTest.java
+++ b/src/test/java/com/faforever/client/chat/ChannelTabControllerTest.java
@@ -78,8 +78,6 @@ public class ChannelTabControllerTest extends AbstractPlainJavaFxTest {
   @Mock
   private NotificationService notificationService;
   @Mock
-  private AutoCompletionHelper autoCompletionHelper;
-  @Mock
   private UiService uiService;
   @Mock
   private UserFilterController userFilterController;
@@ -106,8 +104,7 @@ public class ChannelTabControllerTest extends AbstractPlainJavaFxTest {
         preferencesService, playerService,
         audioService, timeService, i18n, imageUploadService,
         notificationService, reportingService,
-        uiService, autoCompletionHelper,
-        eventBus, webViewConfigurer, countryFlagService
+        uiService, eventBus, webViewConfigurer, countryFlagService
     );
 
     defaultChannel = new Channel(CHANNEL_NAME);

--- a/src/test/java/com/faforever/client/chat/PrivateChatTabControllerTest.java
+++ b/src/test/java/com/faforever/client/chat/PrivateChatTabControllerTest.java
@@ -62,8 +62,6 @@ public class PrivateChatTabControllerTest extends AbstractPlainJavaFxTest {
   @Mock
   private NotificationService notificationService;
   @Mock
-  private AutoCompletionHelper autoCompletionHelper;
-  @Mock
   private UiService uiService;
   @Mock
   private WebViewConfigurer webViewConfigurer;
@@ -90,7 +88,7 @@ public class PrivateChatTabControllerTest extends AbstractPlainJavaFxTest {
     preferencesService.getPreferences().getMainWindow().setLastView(NavigationItem.CHAT.name());
 
     instance = new PrivateChatTabController(userService, preferencesService, playerService, timeService,
-        i18n, imageUploadService, notificationService, reportingService, uiService, autoCompletionHelper, eventBus,
+        i18n, imageUploadService, notificationService, reportingService, uiService, eventBus,
         audioService, chatService, webViewConfigurer, countryFlagService);
 
 


### PR DESCRIPTION
The first commit added the functionality to *also* add chat-only users. But that is not what the users want according to feedback I collected.
Thus I added the second commit, which reduces the autocomplete function to ChannelTabControllers and works for all chat users there.