### PR TITLE
[fixes #1086 #1013] Fix irc color bug and remove broken colorPerUserMapChangeListener 

### DIFF
--- a/src/main/java/com/faforever/client/chat/ChatUserItemController.java
+++ b/src/main/java/com/faforever/client/chat/ChatUserItemController.java
@@ -140,10 +140,12 @@ public class ChatUserItemController implements Controller<Node> {
     JavaFxUtil.addListener(chatPrefs.chatFormatProperty(), weakFormatInvalidationListener);
 
     colorPerUserMapChangeListener = change -> {
-      String lowerUsername = chatUser.getUsername().toLowerCase(US);
-      if (lowerUsername.equalsIgnoreCase(change.getKey())) {
-        Color newColor = chatPrefs.getUserToColor().get(lowerUsername);
-        assignColor(newColor);
+      if (chatUser != null) {
+        String lowerUsername = chatUser.getUsername().toLowerCase(US);
+        if (lowerUsername.equalsIgnoreCase(change.getKey())) {
+          Color newColor = chatPrefs.getUserToColor().get(lowerUsername);
+          assignColor(newColor);
+        }
       }
     };
     userActivityListener = (observable) -> JavaFxUtil.runLater(this::onUserActivity);

--- a/src/main/resources/theme/chat/compact/chat_text.html
+++ b/src/main/resources/theme/chat/compact/chat_text.html
@@ -1,1 +1,1 @@
-<span class="text {css-classes}">{text}</span>
+<span class="text {css-classes}" style="{inline-style}">{text}</span>

--- a/src/main/resources/theme/chat/extended/chat_text.html
+++ b/src/main/resources/theme/chat/extended/chat_text.html
@@ -1,1 +1,1 @@
-<div class="text {css-classes}">{text}</div>
+<div class="text {css-classes}" style="{inline-style}">{text}</div>


### PR DESCRIPTION
~~The listener is bound to a chatUser that is not set when the constructor is called. Thus chatUser is always null. Each user color change is also evaluated in all ChatUserItemControllers causing an exception for each user in chat.~~

~~This PR does not solve the coloring of new messages, it only fixes the NPE problem.~~

NPE issues and coloring of new message are fixed now.