### PR TITLE
u00200 instead of Whitespace in Leaderboard Co-Op

### DIFF
--- a/ci/test.sh
+++ b/ci/test.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-./gradlew --stacktrace -PjavafxPlatform=linux check
+./gradlew --stacktrace --debug -PjavafxPlatform=linux check

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-./gradlew --stacktrace --debug -PjavafxPlatform=linux check
+./gradlew --stacktrace -PjavafxPlatform=linux check

--- a/src/main/resources/i18n/messages_cs.properties
+++ b/src/main/resources/i18n/messages_cs.properties
@@ -396,7 +396,7 @@ duration.hourMinutes = {0,number,\#}h {1,number,\#}min
 # suppress inspection "TrailingSpacesInProperty"
 vsSeparator = \ vs 
 # suppress inspection "TrailingSpacesInProperty"
-textSeparator = , 
+textSeparator=,\u0020
 secondsAgo = před {0,number,\#} sekundami
 minuteAgo = před {0,number,\#} minutou
 minutesAgo = před {0,number,\#} minuty

--- a/src/main/resources/i18n/messages_de.properties
+++ b/src/main/resources/i18n/messages_de.properties
@@ -399,7 +399,7 @@ duration.hourMinutes = {0,number,\#}h {0,number,\#}min
 # suppress inspection "TrailingSpacesInProperty"
 vsSeparator = u0020vsu0020
 # suppress inspection "TrailingSpacesInProperty"
-textSeparator = ,u0020
+textSeparator=,\u0020
 secondsAgo = Vor {0,number,\#} Sekunden
 minuteAgo = Vor {0,number,\#} Minute
 minutesAgo = Vor {0,number,\#} Minuten

--- a/src/main/resources/i18n/messages_fr.properties
+++ b/src/main/resources/i18n/messages_fr.properties
@@ -414,7 +414,7 @@ duration.hourMinutes = {0,number,\#}h {1,number,\#}min
 # suppress inspection "TrailingSpacesInProperty"
 vsSeparator = u0020contreu0020
 # suppress inspection "TrailingSpacesInProperty"
-textSeparator = ,u0020
+textSeparator=,\u0020
 secondsAgo = Il y a {0,number,\#} secondes
 minuteAgo = Il y a {0,number,\#} minute
 minutesAgo = Il y a {0,number,\#} minutes

--- a/src/main/resources/i18n/messages_ru.properties
+++ b/src/main/resources/i18n/messages_ru.properties
@@ -402,7 +402,7 @@ duration.hourMinutes = {0,number,\#}ч {1,number,\#}мин
 # suppress inspection "TrailingSpacesInProperty"
 vsSeparator = \ против 
 # suppress inspection "TrailingSpacesInProperty"
-textSeparator = , 
+textSeparator=,\u0020
 secondsAgo = {0,number,\#} секунд назад
 minuteAgo = {0,number,\#} минуту назад
 minutesAgo = {0,number,\#} минут назад

--- a/src/main/resources/i18n/messages_zh.properties
+++ b/src/main/resources/i18n/messages_zh.properties
@@ -345,7 +345,7 @@ duration.hourMinutes = {0,number,\#}小时{1,number,\#}分钟
 # suppress inspection "TrailingSpacesInProperty"
 vsSeparator = 对
 # suppress inspection "TrailingSpacesInProperty"
-textSeparator = ，
+textSeparator=,\u0020
 secondsAgo = {0,number,\#}秒前
 minuteAgo = {0,number,\#}分钟前
 minutesAgo = {0,number,\#}分钟前


### PR DESCRIPTION
Fixes Text Seperator in languages other than english.
It was missing the Backslash before the unicode definition or was without it (just a space instad of \u0020)

Fixes #1116