### PR TITLE
set faf-uid file permission after download (might fix #1162)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -221,6 +221,11 @@ task downloadUnixUid(type: Download) {
   src "https://github.com/FAForever/uid/releases/download/v${faf_uid_version}/faf-uid"
   dest file("${buildDir}/resources/native/faf-uid")
   onlyIfNewer true
+  doLast {
+    project.exec {
+      commandLine('chmod',  '+x', "${buildDir}/resources/native/faf-uid")
+    }
+  }
 }
 
 task downloadWindowsUid(type: Download) {

--- a/src/main/java/com/faforever/client/legacy/PosixUidService.java
+++ b/src/main/java/com/faforever/client/legacy/PosixUidService.java
@@ -7,7 +7,6 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.attribute.PosixFilePermission;
@@ -22,7 +21,6 @@ public class PosixUidService implements UidService {
   public String generate(String sessionId, Path logFile) throws IOException {
     String uidDir = System.getProperty("nativeDir", "lib");
     Path uidPath = Paths.get(uidDir).resolve("faf-uid");
-    Files.setPosixFilePermissions(uidPath, Sets.immutableEnumSet(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_EXECUTE));
     return OsUtils.execAndGetOutput(String.format("%s %s", uidPath.toAbsolutePath(), sessionId));
   }
 }


### PR DESCRIPTION
try to fix  #1162 
I dont have a proper environment to test this, but the downloaded file `native/faf-uid` seems to get proper permissions on my machine during build.