### PR TITLE
rework custom games tab/card tiles, allow sidePane to be hidden

### DIFF
--- a/src/main/java/com/faforever/client/game/GameDetailController.java
+++ b/src/main/java/com/faforever/client/game/GameDetailController.java
@@ -13,8 +13,8 @@ import com.faforever.client.vault.replay.WatchButtonController;
 import javafx.application.Platform;
 import javafx.beans.InvalidationListener;
 import javafx.beans.WeakInvalidationListener;
-import javafx.beans.property.ObjectProperty;
-import javafx.beans.property.SimpleObjectProperty;
+import javafx.beans.property.ReadOnlyObjectProperty;
+import javafx.beans.property.ReadOnlyObjectWrapper;
 import javafx.collections.ObservableMap;
 import javafx.event.ActionEvent;
 import javafx.scene.Node;
@@ -56,7 +56,7 @@ public class GameDetailController implements Controller<Pane> {
   public Label gameTitleLabel;
   public Node joinButton;
   public WatchButtonController watchButtonController;
-  private ObjectProperty<Game> game;
+  private ReadOnlyObjectWrapper<Game> game;
   @SuppressWarnings("FieldCanBeLocal")
   private InvalidationListener teamsInvalidationListener;
   @SuppressWarnings("FieldCanBeLocal")
@@ -77,7 +77,7 @@ public class GameDetailController implements Controller<Pane> {
     this.uiService = uiService;
     this.joinGameHelper = joinGameHelper;
 
-    game = new SimpleObjectProperty<>();
+    game = new ReadOnlyObjectWrapper<>();
 
     gameStatusInvalidationListener = observable -> onGameStatusChanged();
     teamsInvalidationListener = observable -> createTeams();
@@ -167,6 +167,14 @@ public class GameDetailController implements Controller<Pane> {
 
     JavaFxUtil.addListener(game.statusProperty(), weakGameStatusListener);
     gameStatusInvalidationListener.invalidated(game.statusProperty());
+  }
+
+  public Game getGame() {
+    return game.get();
+  }
+
+  public ReadOnlyObjectProperty<Game> gameProperty() {
+    return game.getReadOnlyProperty();
   }
 
   private void createTeams() {

--- a/src/main/java/com/faforever/client/preferences/Preferences.java
+++ b/src/main/java/com/faforever/client/preferences/Preferences.java
@@ -58,6 +58,7 @@ public class Preferences {
   private final MapProperty<URI, ArrayList<HttpCookie>> storedCookies;
   private final BooleanProperty lastGameOnlyFriends;
   private final BooleanProperty disallowJoinsViaDiscord;
+  private final BooleanProperty showGameDetailsSidePane;
 
   public Preferences() {
     gameTileSortingOrder = new SimpleObjectProperty<>(TilesSortingOrder.PLAYER_DES);
@@ -88,6 +89,7 @@ public class Preferences {
     showModdedGames = new SimpleBooleanProperty(true);
     lastGameOnlyFriends = new SimpleBooleanProperty();
     disallowJoinsViaDiscord = new SimpleBooleanProperty();
+    showGameDetailsSidePane = new SimpleBooleanProperty(false);
   }
 
   public VaultPrefs getVaultPrefs() {
@@ -301,6 +303,18 @@ public class Preferences {
 
   public BooleanProperty disallowJoinsViaDiscordProperty() {
     return disallowJoinsViaDiscord;
+  }
+
+  public boolean isShowGameDetailsSidePane() {
+    return showGameDetailsSidePane.get();
+  }
+
+  public void setShowGameDetailsSidePane(boolean showGameDetailsSidePane) {
+    this.showGameDetailsSidePane.set(showGameDetailsSidePane);
+  }
+
+  public BooleanProperty showGameDetailsSidePaneProperty() {
+    return showGameDetailsSidePane;
   }
 
   public enum UnitDataBaseType {

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -22,6 +22,8 @@ dateWithTime={0} at {1}
 
 view.tiles=Tiles
 view.table=Table
+view.showSidePane=Show details
+view.hideSidePane=Hide details
 
 userMenu.logOut=Log out
 userMenu.showProfile=Show profile
@@ -166,8 +168,8 @@ chat.privateMessage.achievements.unlockedFormat={0,number,#}/{1,number,#}
 games.create=Create game
 games.create.minRating=Min.
 games.create.maxRating=Max.
-games.showPasswordProtectedGames=Show password protected games
-games.showModdedGames=Show games with mods
+games.showPasswordProtectedGames=Show private games
+games.showModdedGames=Show modded games
 games.noGamesAvailable=There are no open games. Why don't you create one?
 games.couldNotJoin=Game could not be joined. See error message below.
 game.create.connecting=Waiting for connection
@@ -203,6 +205,7 @@ game.type=Type
 game.mods=Mods
 game.players.format={0,number,#}/{1,number,#}
 game.detail.players.format={0,number,#}/{1,number,#} players
+game.avgRating.format={0,number,#}
 game.join=Join
 game.cancel=Cancel
 game.host=Host

--- a/src/main/resources/theme/play/custom_games.fxml
+++ b/src/main/resources/theme/play/custom_games.fxml
@@ -4,6 +4,7 @@
 <?import com.jfoenix.controls.JFXCheckBox?>
 <?import com.jfoenix.controls.JFXComboBox?>
 <?import javafx.geometry.Insets?>
+<?import javafx.scene.control.Button?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.control.ScrollPane?>
 <?import javafx.scene.control.ToggleButton?>
@@ -17,60 +18,76 @@
 <?import javafx.scene.layout.RowConstraints?>
 <?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
-
-<StackPane fx:id="gamesRoot" alignment="TOP_CENTER" xmlns="http://javafx.com/javafx/10.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.faforever.client.game.CustomGamesController">
-   <children>
-      <GridPane>
-         <columnConstraints>
-            <ColumnConstraints hgrow="ALWAYS" minWidth="10.0" />
-            <ColumnConstraints hgrow="SOMETIMES" minWidth="300.0" prefWidth="300.0" />
-         </columnConstraints>
-         <rowConstraints>
-             <RowConstraints vgrow="NEVER" />
-            <RowConstraints minHeight="10.0" vgrow="ALWAYS" />
-         </rowConstraints>
-         <children>
-             <VBox maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" spacing="10.0">
-              <children>
-                  <HBox>
-                     <children>
-                        <FlowPane hgap="10.0" maxWidth="1.7976931348623157E308" vgap="10.0" HBox.hgrow="ALWAYS">
-                           <children>
-                            <JFXButton fx:id="createGameButton" defaultButton="true" minWidth="-Infinity" mnemonicParsing="false" onAction="#onCreateGameButtonClicked" styleClass="create-game-button" text="%games.create" />
-                            <JFXCheckBox fx:id="showPasswordProtectedGamesCheckBox" mnemonicParsing="false" text="%games.showPasswordProtectedGames" />
-                            <JFXCheckBox fx:id="showModdedGamesCheckBox" mnemonicParsing="false" text="%games.showModdedGames" />
-                            <JFXComboBox fx:id="chooseSortingTypeChoiceBox" />
-                            <Pane />
-                          <HBox alignment="BASELINE_LEFT" />
-                           </children>
-                        </FlowPane>
-                    <ToggleButton fx:id="tableButton" minWidth="-Infinity" mnemonicParsing="false" onAction="#onTableButtonClicked" text="%view.table">
-                    <toggleGroup>
-                        <ToggleGroup fx:id="viewToggleGroup" />
-                    </toggleGroup>
-                           <graphic>
-                               <Label styleClass="icon" text="" />
-                           </graphic>
-                  </ToggleButton>
-                    <ToggleButton fx:id="tilesButton" minWidth="-Infinity" mnemonicParsing="false" onAction="#onTilesButtonClicked" selected="true" text="%view.tiles" toggleGroup="$viewToggleGroup">
-                           <graphic>
-                              <Label styleClass="icon" text="" />
-                           </graphic>
-                        </ToggleButton>
-                     </children>
-                  </HBox>
-              </children>
-              <padding>
-                  <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
-              </padding>
-            </VBox>
-        <ScrollPane fx:id="gameDetailPane" maxWidth="1.7976931348623157E308" GridPane.columnIndex="1" GridPane.rowSpan="2147483647">
-          <content>
-              <fx:include fx:id="gameDetail" source="game_detail.fxml" />
-          </content>
-        </ScrollPane>
-        <AnchorPane fx:id="gameViewContainer" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" GridPane.rowIndex="1" />
-         </children>
-      </GridPane>
-   </children>
+<StackPane xmlns:fx="http://javafx.com/fxml/1" fx:id="gamesRoot" alignment="TOP_CENTER"
+           xmlns="http://javafx.com/javafx/10.0.1" fx:controller="com.faforever.client.game.CustomGamesController">
+    <children>
+        <GridPane fx:id="gamesGridPane">
+            <columnConstraints>
+                <ColumnConstraints hgrow="ALWAYS" minWidth="10.0"/>
+                <ColumnConstraints hgrow="SOMETIMES" minWidth="300.0"
+                                   prefWidth="300.0" fx:id="sidePaneColumn"/>
+            </columnConstraints>
+            <rowConstraints>
+                <RowConstraints vgrow="NEVER"/>
+                <RowConstraints minHeight="10.0" vgrow="ALWAYS"/>
+            </rowConstraints>
+            <children>
+                <VBox maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" spacing="10.0">
+                    <children>
+                        <HBox>
+                            <children>
+                                <FlowPane hgap="10.0" maxWidth="1.7976931348623157E308" vgap="10.0" HBox.hgrow="ALWAYS">
+                                    <children>
+                                        <JFXButton fx:id="createGameButton" defaultButton="true" minWidth="-Infinity"
+                                                   mnemonicParsing="false" onAction="#onCreateGameButtonClicked"
+                                                   styleClass="create-game-button" text="%games.create"/>
+                                        <JFXCheckBox fx:id="showPasswordProtectedGamesCheckBox" mnemonicParsing="false"
+                                                     text="%games.showPasswordProtectedGames"/>
+                                        <JFXCheckBox fx:id="showModdedGamesCheckBox" mnemonicParsing="false"
+                                                     text="%games.showModdedGames"/>
+                                        <JFXComboBox fx:id="chooseSortingTypeChoiceBox"/>
+                                        <Pane/>
+                                        <HBox alignment="BASELINE_LEFT"/>
+                                    </children>
+                                </FlowPane>
+                                <Button fx:id="toggleSidePaneButton" minWidth="-Infinity" mnemonicParsing="false"
+                                        onAction="#toggleSidePane" text="%view.hideSidePane">
+                                    <padding>
+                                        <Insets right="50"/>
+                                    </padding>
+                                </Button>
+                                <ToggleButton fx:id="tableButton" minWidth="-Infinity" mnemonicParsing="false"
+                                              onAction="#onTableButtonClicked" text="%view.table">
+                                    <toggleGroup>
+                                        <ToggleGroup fx:id="viewToggleGroup"/>
+                                    </toggleGroup>
+                                    <graphic>
+                                        <Label styleClass="icon" text=""/>
+                                    </graphic>
+                                </ToggleButton>
+                                <ToggleButton fx:id="tilesButton" minWidth="-Infinity" mnemonicParsing="false"
+                                              onAction="#onTilesButtonClicked" selected="true" text="%view.tiles"
+                                              toggleGroup="$viewToggleGroup">
+                                    <graphic>
+                                        <Label styleClass="icon" text=""/>
+                                    </graphic>
+                                </ToggleButton>
+                            </children>
+                        </HBox>
+                    </children>
+                    <padding>
+                        <Insets bottom="10.0" left="10.0" right="10.0" top="10.0"/>
+                    </padding>
+                </VBox>
+                <ScrollPane fx:id="gameDetailPane" maxWidth="1.7976931348623157E308" GridPane.columnIndex="1"
+                            GridPane.rowSpan="2147483647">
+                    <content>
+                        <fx:include fx:id="gameDetail" source="game_detail.fxml"/>
+                    </content>
+                </ScrollPane>
+                <AnchorPane fx:id="gameViewContainer" maxHeight="1.7976931348623157E308"
+                            maxWidth="1.7976931348623157E308" GridPane.rowIndex="1" prefWidth="10000"/>
+            </children>
+        </GridPane>
+    </children>
 </StackPane>

--- a/src/main/resources/theme/play/game_card.fxml
+++ b/src/main/resources/theme/play/game_card.fxml
@@ -6,14 +6,15 @@
 <?import javafx.scene.layout.AnchorPane?>
 <?import javafx.scene.layout.ColumnConstraints?>
 <?import javafx.scene.layout.GridPane?>
+<?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.RowConstraints?>
 <?import javafx.scene.layout.VBox?>
 <GridPane xmlns:fx="http://javafx.com/fxml/1" fx:id="gameCardRoot" onMouseClicked="#onClick"
           onMouseEntered="#onMouseEntered" onMouseExited="#onMouseExited" styleClass="game-card,card,hoverable"
           xmlns="http://javafx.com/javafx/8.0.141" fx:controller="com.faforever.client.game.GameTileController">
     <columnConstraints>
-        <ColumnConstraints hgrow="NEVER" prefWidth="160.0"/>
-        <ColumnConstraints hgrow="ALWAYS" maxWidth="224.0" minWidth="224.0" prefWidth="224.0"/>
+        <ColumnConstraints hgrow="NEVER" prefWidth="140.0"/>
+        <ColumnConstraints hgrow="ALWAYS" maxWidth="220.0" minWidth="220.0" prefWidth="220.0"/>
     </columnConstraints>
     <rowConstraints>
         <RowConstraints fillHeight="false" minHeight="10.0" vgrow="SOMETIMES"/>
@@ -29,51 +30,66 @@
     <children>
         <AnchorPane GridPane.rowSpan="2147483647" GridPane.valignment="TOP">
             <children>
-                <ImageView fx:id="mapImageView" fitHeight="160.0" fitWidth="160.0" preserveRatio="true"/>
+                <ImageView fx:id="mapImageView" fitHeight="140.0" fitWidth="140.0" preserveRatio="true"/>
                 <Label fx:id="lockIconLabel" layoutX="10.0" layoutY="10.0" styleClass="lock-icon,icon" text="🔒"
                        AnchorPane.leftAnchor="10.0" AnchorPane.topAnchor="10.0"/>
                 <VBox alignment="BOTTOM_LEFT" styleClass="card-dimmer" AnchorPane.bottomAnchor="0.0"
                       AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0">
                     <children>
-                        <Label fx:id="gameTitleLabel" maxWidth="1.7976931348623157E308" minWidth="0.0"
-                               styleClass="card-title" text="&lt;Very long game title to see if wrapping works&gt;"
-                               wrapText="true"/>
                         <Label fx:id="gameMapLabel" maxWidth="1.7976931348623157E308" minWidth="0.0"
                                styleClass="card-subtitle" text="&lt;Game Map&gt;"/>
                     </children>
                 </VBox>
             </children>
         </AnchorPane>
-        <Label fx:id="gameTypeLabel" minWidth="0.0" text="&lt;Game Type&gt;" GridPane.columnIndex="1">
+        <Label fx:id="gameTitleLabel" maxWidth="1.7976931348623157E308" minWidth="0.0" GridPane.columnIndex="1"
+               GridPane.rowIndex="0"
+               styleClass="card-title" text="&lt;Very long game title to see if wrapping works&gt;"
+               wrapText="true">
             <GridPane.margin>
-                <Insets bottom="5.0" left="10.0" right="10.0" top="10.0"/>
+                <Insets bottom="0.0" left="10.0" right="10.0" top="10.0"/>
             </GridPane.margin>
         </Label>
-        <Label fx:id="numberOfPlayersLabel" minWidth="0.0" text="&lt;Number of Players&gt;" GridPane.columnIndex="1"
-               GridPane.rowIndex="1">
-            <graphic>
-                <Label styleClass="icon" text=""/>
-            </graphic>
+        <Label fx:id="gameTypeLabel" minWidth="0.0" text="&lt;Game Type&gt;" GridPane.columnIndex="1"
+               GridPane.rowIndex="1" styleClass="card-featured-mod">
             <GridPane.margin>
-                <Insets bottom="5.0" left="10.0" right="10.0" top="5.0"/>
+                <Insets bottom="10.0" left="10.0" right="10.0" top="0.0"/>
             </GridPane.margin>
         </Label>
-        <Label fx:id="modsLabel" maxHeight="1.7976931348623157E308" minWidth="0.0" text="&lt;Mods&gt;" wrapText="true"
-               GridPane.columnIndex="1" GridPane.rowIndex="6">
-            <graphic>
-                <Label styleClass="icon" text=""/>
-            </graphic>
+        <HBox GridPane.columnIndex="1" GridPane.rowIndex="2" spacing="70">
             <GridPane.margin>
-                <Insets bottom="5.0" left="10.0" right="10.0" top="5.0"/>
+                <Insets bottom="0" left="10.0" right="10.0" top="0"/>
             </GridPane.margin>
-        </Label>
+            <children>
+                <Label fx:id="numberOfPlayersLabel" minWidth="0.0" text="&lt;Number of Players&gt;"
+                       styleClass="card-info">
+                    <graphic>
+                        <Label styleClass="icon" text=""/>
+                    </graphic>
+                </Label>
+                <Label fx:id="avgRatingLabel" minWidth="0.0" text="&lt;Avg&gt;" styleClass="card-info">
+                    <graphic>
+                        <Label styleClass="icon" text=""/>
+                    </graphic>
+                </Label>
+            </children>
+        </HBox>
         <Label fx:id="hostLabel" maxHeight="1.7976931348623157E308" minWidth="0.0" text="&lt;Host&gt;"
-               GridPane.columnIndex="1" GridPane.rowIndex="3">
+               GridPane.columnIndex="1" GridPane.rowIndex="3" styleClass="card-info">
             <graphic>
                 <Label styleClass="icon" text=""/>
             </graphic>
             <GridPane.margin>
-                <Insets bottom="5.0" left="10.0" right="10.0" top="5.0"/>
+                <Insets bottom="0" left="10.0" right="10.0" top="0"/>
+            </GridPane.margin>
+        </Label>
+        <Label fx:id="modsLabel" maxHeight="1.7976931348623157E308" minWidth="0.0" text="&lt;Mods&gt;" wrapText="true"
+               GridPane.columnIndex="1" GridPane.rowIndex="6" styleClass="card-mod-list">
+            <graphic>
+                <Label styleClass="icon" text=""/>
+            </graphic>
+            <GridPane.margin>
+                <Insets bottom="0.0" left="10.0" right="10.0" top="5.0"/>
             </GridPane.margin>
         </Label>
     </children>

--- a/src/main/resources/theme/play/play.fxml
+++ b/src/main/resources/theme/play/play.fxml
@@ -9,8 +9,8 @@
       xmlns="http://javafx.com/javafx/8.0.60" fx:controller="com.faforever.client.play.PlayController">
     <children>
         <TabPane fx:id="playRootTabPane" rotateGraphic="true" side="LEFT" tabClosingPolicy="UNAVAILABLE"
-                 tabMaxHeight="200.0"
-                 tabMinHeight="200.0" VBox.vgrow="ALWAYS">
+                 tabMaxHeight="170.0"
+                 tabMinHeight="170.0" VBox.vgrow="ALWAYS">
             <tabs>
                 <Tab fx:id="customGamesTab">
                     <content>
@@ -19,7 +19,7 @@
                     <graphic>
                         <Group>
                             <children>
-                                <VBox prefWidth="200.0" rotate="90.0">
+                                <VBox prefWidth="170.0" rotate="90.0">
                                     <children>
                                         <Label text="%play.custom" styleClass="tab-label"/>
                                     </children>
@@ -35,7 +35,7 @@
                <graphic>
                   <Group>
                      <children>
-                        <VBox prefWidth="200.0" rotate="90.0">
+                         <VBox prefWidth="170.0" rotate="90.0">
                            <children>
                                <Label text="%play.ranked1v1" styleClass="tab-label"/>
                            </children>
@@ -51,7 +51,7 @@
                     <graphic>
                         <Group>
                             <children>
-                                <VBox prefWidth="200.0" rotate="90.0">
+                                <VBox prefWidth="170.0" rotate="90.0">
                                     <children>
                                         <Label text="%play.coop" styleClass="tab-label"/>
                                     </children>

--- a/src/main/resources/theme/style.css
+++ b/src/main/resources/theme/style.css
@@ -93,6 +93,7 @@
   -card-color-hover: #61616199;
   /* -grey-900 plus transparency */
   -dimmer-color: #21212199;
+  -card-map-subtitle-color: #c7c7c7
 }
 
 /***************** Remove ugly borders and default background introduced by modena *****************/
@@ -1068,12 +1069,25 @@
 
 .card-title {
   -fx-font-size: 16px;
+  -fx-font-weight: bold;
+}
+
+.card-featured-mod {
+  -fx-font-size: 11px;
   -fx-text-fill: -fx-light-text-color;
+}
+
+.card-info {
+  -fx-font-size: 14px;
+}
+
+.card-mod-list {
+  -fx-font-size: 14px;
 }
 
 .card-subtitle {
   -fx-font-size: 12px;
-  -fx-text-fill: -fx-mid-text-color;
+  -fx-text-fill: -card-map-subtitle-color;
 }
 
 .control-label {

--- a/src/test/java/com/faforever/client/game/GameTileControllerTest.java
+++ b/src/test/java/com/faforever/client/game/GameTileControllerTest.java
@@ -4,6 +4,7 @@ import com.faforever.client.fx.MouseEvents;
 import com.faforever.client.i18n.I18n;
 import com.faforever.client.map.MapService;
 import com.faforever.client.mod.ModService;
+import com.faforever.client.player.PlayerService;
 import com.faforever.client.test.AbstractPlainJavaFxTest;
 import com.faforever.client.theme.UiService;
 import javafx.scene.input.MouseButton;
@@ -33,6 +34,8 @@ public class GameTileControllerTest extends AbstractPlainJavaFxTest {
   private I18n i18n;
   @Mock
   private MapService mapService;
+  @Mock
+  private PlayerService playerService;
 
   private Game game;
 
@@ -41,7 +44,7 @@ public class GameTileControllerTest extends AbstractPlainJavaFxTest {
 
   @Before
   public void setUp() throws Exception {
-    instance = new GameTileController(mapService, i18n, joinGameHelper, modService, uiService);
+    instance = new GameTileController(mapService, i18n, joinGameHelper, modService, uiService, playerService);
 
     game = GameBuilder.create().defaultValues().get();
 


### PR DESCRIPTION
closes #1228

A lot of users combined about the tiles mode in the custom games play tab. This reworks them to be more readable, smaller to support small screen resolutions, allows hiding the side pane (saved to the client.prefs) and adds an average rating indicator to the cards.