### PR TITLE
Allow using JDKs without bundled JavaFX

### DIFF
--- a/.idea/runConfigurations/FafClientApplication.xml
+++ b/.idea/runConfigurations/FafClientApplication.xml
@@ -3,7 +3,7 @@
     <envs>
       <env name="spring.profiles.active" value="prod" />
     </envs>
-    <option name="MAIN_CLASS_NAME" value="com.faforever.client.FafClientApplication" />
+    <option name="MAIN_CLASS_NAME" value="com.faforever.client.Main" />
     <module name="downlords-faf-client.main" />
     <option name="VM_PARAMETERS" value="-DnativeDir=build/resources/native -Dprism.dirtyopts=false -Xms128m -Xmx512m -XX:MinHeapFreeRatio=15 -XX:MaxHeapFreeRatio=33 -XX:+HeapDumpOnOutOfMemoryError -XX:+UseStringDeduplication -javaagent:webview-patch/build/libs/webview-patch.jar" />
     <method v="2">

--- a/build.gradle
+++ b/build.gradle
@@ -132,9 +132,14 @@ configurations {
   codacy
 }
 
+
+bootRun {
+    main = "com.faforever.client.Main"
+}
+
 jar {
   manifest {
-    attributes "Main-Class": "com.faforever.client.FafClientApplication",
+    attributes "Main-Class": "com.faforever.client.Main",
         "Implementation-Title": "Downlord's FAF Client",
         "Implementation-Version": version,
         "Implementation-Vendor": "Downlord"

--- a/downlords-faf-client.install4j
+++ b/downlords-faf-client.install4j
@@ -42,7 +42,7 @@
           <versionLine x="539" y="378" text="v${compiler:sys.version}" fontSize="10" fontColor="255,255,255" bold="true" />
         </text>
       </splashScreen>
-      <java mainClass="com.faforever.client.FafClientApplication" mainMode="1" vmParameters="-DnativeDir=natives -Dprism.dirtyopts=false -XX:+HeapDumpOnOutOfMemoryError -javaagent:lib/webview-patch.jar" arguments="" allowVMPassthroughParameters="true" preferredVM="client" bundleRuntime="true">
+      <java mainClass="com.faforever.client.Main" mainMode="1" vmParameters="-DnativeDir=natives -Dprism.dirtyopts=false -XX:+HeapDumpOnOutOfMemoryError -javaagent:lib/webview-patch.jar" arguments="" allowVMPassthroughParameters="true" preferredVM="client" bundleRuntime="true">
         <classPath>
           <scanDirectory location="lib" failOnError="true" />
         </classPath>

--- a/src/main/java/com/faforever/client/FafClientApplication.java
+++ b/src/main/java/com/faforever/client/FafClientApplication.java
@@ -51,7 +51,7 @@ public class FafClientApplication extends Application {
 
   private ConfigurableApplicationContext applicationContext;
 
-  public static void main(String[] args) {
+  public static void applicationMain(String[] args) {
     PreferencesService.configureLogging();
     launch(args);
   }

--- a/src/main/java/com/faforever/client/FafClientApplication.java
+++ b/src/main/java/com/faforever/client/FafClientApplication.java
@@ -26,6 +26,8 @@ import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -34,10 +36,8 @@ import java.util.concurrent.CountDownLatch;
 
 import static com.github.nocatch.NoCatch.noCatch;
 
-@SpringBootApplication(exclude = {
-    JmxAutoConfiguration.class,
-    SecurityAutoConfiguration.class,
-})
+@Configuration
+@ComponentScan
 @EnableConfigurationProperties({ClientProperties.class})
 public class FafClientApplication extends Application {
   public static final String PROFILE_PROD = "prod";

--- a/src/main/java/com/faforever/client/Main.java
+++ b/src/main/java/com/faforever/client/Main.java
@@ -1,0 +1,7 @@
+package com.faforever.client;
+
+public class Main {
+	public static void main(String[] args) {
+		FafClientApplication.applicationMain(args);
+	}
+}

--- a/src/main/java/com/faforever/client/Main.java
+++ b/src/main/java/com/faforever/client/Main.java
@@ -1,5 +1,13 @@
 package com.faforever.client;
 
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.jmx.JmxAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+
+@SpringBootApplication(exclude = {
+    JmxAutoConfiguration.class,
+    SecurityAutoConfiguration.class,
+})
 public class Main {
 	public static void main(String[] args) {
 		FafClientApplication.applicationMain(args);

--- a/src/main/java/com/faforever/client/util/WindowsUtil.java
+++ b/src/main/java/com/faforever/client/util/WindowsUtil.java
@@ -5,10 +5,6 @@ import java.io.PrintStream;
 import java.util.Scanner;
 
 public class WindowsUtil {
-  public static void main(String[] args) {
-    System.out.println(isAdmin());
-  }
-
   public static boolean isAdmin() {
     try {
       ProcessBuilder processBuilder = new ProcessBuilder("cmd.exe");


### PR DESCRIPTION
**I need somebody with intelliJ Ultimate to test the run configurations.**

Changes the main class (entrypoint) so that it no longer is the same class that extends Application.
- New main method inside com.faforever.client.Main, updated all references
- Explicitly sets entry point for bootRun in build.gradle
- Removes additional ambigous main method from WindowsUtil (strictly this only needed if entry point for boot run is not set, but i guess i remove this just in case)
- Renames original main method to avoid confusion

Workaround for #1298