### PR TITLE
Fix LaunchCommandBuilderTest for paths with space

### DIFF
--- a/src/main/java/com/faforever/client/fa/LaunchCommandBuilder.java
+++ b/src/main/java/com/faforever/client/fa/LaunchCommandBuilder.java
@@ -15,7 +15,7 @@ import java.util.regex.Pattern;
 
 public class LaunchCommandBuilder {
 
-  private static final Pattern QUOTED_STRING_PATTERN = Pattern.compile("([^\"]\\S*|\".+?\")\\s*");
+  private static final Pattern QUOTED_STRING_PATTERN = Pattern.compile("([^\"]\\S*|\"+.+?\"+)\\s*");
 
   private Float mean;
   private Float deviation;
@@ -144,7 +144,7 @@ public class LaunchCommandBuilder {
 
 
     List<String> command = new ArrayList<>();
-    command.addAll(split(String.format(executableDecorator, executable.toAbsolutePath().toString())));
+    command.addAll(split(String.format(executableDecorator, "\"" + executable.toAbsolutePath().toString() + "\"")));
     command.addAll(Arrays.asList(
         "/init", ForgedAlliancePrefs.INIT_FILE_NAME,
         "/nobugreport"

--- a/src/test/java/com/faforever/client/fa/LaunchCommandBuilderTest.java
+++ b/src/test/java/com/faforever/client/fa/LaunchCommandBuilderTest.java
@@ -16,7 +16,7 @@ public class LaunchCommandBuilderTest {
   private static LaunchCommandBuilder defaultBuilder() {
     return LaunchCommandBuilder.create()
         .executable(Paths.get("test.exe"))
-        .executableDecorator("\"%s\"")
+        .executableDecorator("%s")
         .logFile(Paths.get("preferences.log"))
         .username("junit");
   }
@@ -98,10 +98,26 @@ public class LaunchCommandBuilderTest {
   }
 
   @Test
-  public void testCommandFormat() throws Exception {
+  public void testCommandFormatWithSpaces() throws Exception {
+    String pathWithSpaces = "mypath/with space/test.exe";
     assertThat(
         defaultBuilder()
+            .executable(Paths.get(pathWithSpaces))
             .executableDecorator("/path/to/my/wineprefix primusrun wine %s")
+            .build(),
+        contains(
+            "/path/to/my/wineprefix", "primusrun", "wine", Paths.get(pathWithSpaces).toAbsolutePath().toString(),
+            "/init", "init.lua",
+            "/nobugreport",
+            "/log", Paths.get("preferences.log").toAbsolutePath().toString()
+        ));
+  }
+
+  @Test
+  public void testCommandFormatWithRedundantQuotionMarks() throws Exception {
+    assertThat(
+        defaultBuilder()
+            .executableDecorator("/path/to/my/wineprefix primusrun wine \"\"%s\"\"")
             .build(),
         contains(
             "/path/to/my/wineprefix", "primusrun", "wine", Paths.get("test.exe").toAbsolutePath().toString(),


### PR DESCRIPTION
- Changes executableDecorator argument string to not need to wrap executable placeholder with quotation marks
- Changed regex so that redundant quotation marks are not a problem for that placeholder or any other part of the string

Fixes #1323