### PR TITLE
Reduce unnecessary unit test log spam

### DIFF
--- a/src/main/java/com/faforever/client/chat/AbstractChatTabController.java
+++ b/src/main/java/com/faforever/client/chat/AbstractChatTabController.java
@@ -63,7 +63,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.CompletionException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 

--- a/src/main/java/com/faforever/client/chat/AbstractChatTabController.java
+++ b/src/main/java/com/faforever/client/chat/AbstractChatTabController.java
@@ -18,6 +18,7 @@ import com.faforever.client.theme.UiService;
 import com.faforever.client.ui.StageHolder;
 import com.faforever.client.uploader.ImageUploadService;
 import com.faforever.client.user.UserService;
+import com.faforever.client.util.ConcurrentUtil;
 import com.faforever.client.util.IdenticonUtil;
 import com.faforever.client.util.TimeService;
 import com.google.common.annotations.VisibleForTesting;
@@ -421,7 +422,7 @@ public abstract class AbstractChatTabController implements Controller<Tab> {
       messageTextField.setDisable(false);
       messageTextField.requestFocus();
     }).exceptionally(throwable -> {
-      throwable = throwable instanceof CompletionException ? throwable.getCause() : throwable;
+      throwable = ConcurrentUtil.unwrapIfCompletionException(throwable);
       logger.warn("Message could not be sent: {}", text, throwable);
       notificationService.addNotification(new ImmediateErrorNotification(
           i18n.get("errorTitle"), i18n.get("chat.sendFailed"), throwable, i18n, reportingService)
@@ -443,7 +444,7 @@ public abstract class AbstractChatTabController implements Controller<Tab> {
           messageTextField.requestFocus();
         })
         .exceptionally(throwable -> {
-          throwable = throwable instanceof CompletionException ? throwable.getCause() : throwable;
+          throwable = ConcurrentUtil.unwrapIfCompletionException(throwable);
           // TODO onDisplay error to user somehow
           logger.warn("Message could not be sent: {}", text, throwable);
           messageTextField.setDisable(false);

--- a/src/main/java/com/faforever/client/chat/AbstractChatTabController.java
+++ b/src/main/java/com/faforever/client/chat/AbstractChatTabController.java
@@ -62,6 +62,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CompletionException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -420,6 +421,7 @@ public abstract class AbstractChatTabController implements Controller<Tab> {
       messageTextField.setDisable(false);
       messageTextField.requestFocus();
     }).exceptionally(throwable -> {
+      throwable = throwable instanceof CompletionException ? throwable.getCause() : throwable;
       logger.warn("Message could not be sent: {}", text, throwable);
       notificationService.addNotification(new ImmediateErrorNotification(
           i18n.get("errorTitle"), i18n.get("chat.sendFailed"), throwable, i18n, reportingService)
@@ -441,6 +443,7 @@ public abstract class AbstractChatTabController implements Controller<Tab> {
           messageTextField.requestFocus();
         })
         .exceptionally(throwable -> {
+          throwable = throwable instanceof CompletionException ? throwable.getCause() : throwable;
           // TODO onDisplay error to user somehow
           logger.warn("Message could not be sent: {}", text, throwable);
           messageTextField.setDisable(false);

--- a/src/main/java/com/faforever/client/chat/UserInfoWindowController.java
+++ b/src/main/java/com/faforever/client/chat/UserInfoWindowController.java
@@ -10,7 +10,6 @@ import com.faforever.client.api.dto.PlayerEvent;
 import com.faforever.client.domain.RatingHistoryDataPoint;
 import com.faforever.client.events.EventService;
 import com.faforever.client.fx.Controller;
-import com.faforever.client.fx.JavaFxUtil;
 import com.faforever.client.fx.OffsetDateTimeCell;
 import com.faforever.client.game.KnownFeaturedMod;
 import com.faforever.client.i18n.I18n;
@@ -278,7 +277,6 @@ public class UserInfoWindowController implements Controller<Node> {
         });
   }
 
-  @SuppressWarnings("unchecked")
   private void plotFactionsChart(Map<String, PlayerEvent> playerEvents) {
     int aeonPlays = playerEvents.containsKey(EVENT_AEON_PLAYS) ? playerEvents.get(EVENT_AEON_PLAYS).getCurrentCount() : 0;
     int cybranPlays = playerEvents.containsKey(EVENT_CYBRAN_PLAYS) ? playerEvents.get(EVENT_CYBRAN_PLAYS).getCurrentCount() : 0;
@@ -307,7 +305,6 @@ public class UserInfoWindowController implements Controller<Node> {
     Platform.runLater(() -> factionsChart.getData().addAll(winsSeries, lossSeries));
   }
 
-  @SuppressWarnings("unchecked")
   private void plotUnitsByCategoriesChart(Map<String, PlayerEvent> playerEvents) {
     int airBuilt = playerEvents.containsKey(EVENT_BUILT_AIR_UNITS) ? playerEvents.get(EVENT_BUILT_AIR_UNITS).getCurrentCount() : 0;
     int landBuilt = playerEvents.containsKey(EVENT_BUILT_LAND_UNITS) ? playerEvents.get(EVENT_BUILT_LAND_UNITS).getCurrentCount() : 0;
@@ -320,7 +317,6 @@ public class UserInfoWindowController implements Controller<Node> {
     )));
   }
 
-  @SuppressWarnings("unchecked")
   private void plotTechBuiltChart(Map<String, PlayerEvent> playerEvents) {
     int tech1Built = playerEvents.containsKey(EVENT_BUILT_TECH_1_UNITS) ? playerEvents.get(EVENT_BUILT_TECH_1_UNITS).getCurrentCount() : 0;
     int tech2Built = playerEvents.containsKey(EVENT_BUILT_TECH_2_UNITS) ? playerEvents.get(EVENT_BUILT_TECH_2_UNITS).getCurrentCount() : 0;
@@ -333,18 +329,16 @@ public class UserInfoWindowController implements Controller<Node> {
     )));
   }
 
-  @SuppressWarnings("unchecked")
   private void plotGamesPlayedChart() {
-    Player currentPlayer = playerService.getCurrentPlayer().orElseThrow(() -> new IllegalStateException("Player must be set"));
-    leaderboardService.getEntryForPlayer(currentPlayer.getId()).thenAccept(leaderboardEntryBean -> Platform.runLater(() -> {
+    leaderboardService.getEntryForPlayer(player.getId()).thenAccept(leaderboardEntryBean -> Platform.runLater(() -> {
       int ladderGamesCount = leaderboardEntryBean.getGamesPlayed();
-      int custonGamesCount = currentPlayer.getNumberOfGames();
+      int custonGamesCount = player.getNumberOfGames();
       Platform.runLater(() -> gamesPlayedChart.setData(FXCollections.observableArrayList(
           new PieChart.Data(i18n.get("stats.custom"), custonGamesCount),
           new PieChart.Data(i18n.get("stats.ranked1v1"), ladderGamesCount)
       )));
     })).exceptionally(throwable -> {
-      log.warn("Leaderboard entry could not be read for current player: " + currentPlayer.getUsername(), throwable);
+      log.warn("Leaderboard entry could not be read for player: " + player.getUsername(), throwable);
       return null;
     });
   }

--- a/src/main/java/com/faforever/client/config/AsyncConfig.java
+++ b/src/main/java/com/faforever/client/config/AsyncConfig.java
@@ -51,11 +51,11 @@ public class AsyncConfig implements AsyncConfigurer, SchedulingConfigurer {
   @Bean
   public DestructionAwareBeanPostProcessor threadPoolShutdownProcessor() {
     return (Object bean, String beanName) -> {
-      if (beanName.equals("taskExecutor")) {
+      if ("taskExecutor".equals(beanName)) {
         ExecutorService executor = (ExecutorService) bean;
         executor.shutdownNow();
       }
-      if (beanName.equals("taskScheduler")) {
+      if ("taskScheduler".equals(beanName)) {
         ExecutorService executor = ((ThreadPoolTaskScheduler) bean).getScheduledThreadPoolExecutor();
         executor.shutdownNow();
       }

--- a/src/main/java/com/faforever/client/config/AsyncConfig.java
+++ b/src/main/java/com/faforever/client/config/AsyncConfig.java
@@ -12,6 +12,8 @@ import org.springframework.scheduling.annotation.SchedulingConfigurer;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.scheduling.config.ScheduledTaskRegistrar;
 
+import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.beans.factory.config.DestructionAwareBeanPostProcessor;
 
 import java.util.concurrent.Executor;
@@ -21,6 +23,7 @@ import java.util.concurrent.Executors;
 @EnableAsync
 @EnableScheduling
 @Configuration
+@Slf4j
 public class AsyncConfig implements AsyncConfigurer, SchedulingConfigurer {
 
   @Override
@@ -52,11 +55,8 @@ public class AsyncConfig implements AsyncConfigurer, SchedulingConfigurer {
   public DestructionAwareBeanPostProcessor threadPoolShutdownProcessor() {
     return (Object bean, String beanName) -> {
       if ("taskExecutor".equals(beanName)) {
+        log.info("Shutting down ExecutorService '" + beanName + "'");
         ExecutorService executor = (ExecutorService) bean;
-        executor.shutdownNow();
-      }
-      if ("taskScheduler".equals(beanName)) {
-        ExecutorService executor = ((ThreadPoolTaskScheduler) bean).getScheduledThreadPoolExecutor();
         executor.shutdownNow();
       }
     };

--- a/src/main/java/com/faforever/client/map/MapService.java
+++ b/src/main/java/com/faforever/client/map/MapService.java
@@ -210,7 +210,7 @@ public class MapService implements InitializingBean, DisposableBean {
           List<Path> mapPaths = new ArrayList<>();
           customMapsDirectoryStream.collect(toCollection(() -> mapPaths));
           officialMaps.stream()
-              .map(mapName -> officialMapsPath.resolve(mapName))
+              .map(officialMapsPath::resolve)
               .collect(toCollection(() -> mapPaths));
 
           long totalMaps = mapPaths.size();

--- a/src/main/java/com/faforever/client/map/MapService.java
+++ b/src/main/java/com/faforever/client/map/MapService.java
@@ -98,6 +98,15 @@ public class MapService implements InitializingBean, DisposableBean {
   private Map<String, MapBean> mapsByFolderName;
   private Thread directoryWatcherThread;
   private Path customMapsDirectory;
+  
+  @VisibleForTesting
+  Set<String> officialMaps = ImmutableSet.of(
+      "SCMP_001", "SCMP_002", "SCMP_003", "SCMP_004", "SCMP_005", "SCMP_006", "SCMP_007", "SCMP_008", "SCMP_009", "SCMP_010", "SCMP_011",
+      "SCMP_012", "SCMP_013", "SCMP_014", "SCMP_015", "SCMP_016", "SCMP_017", "SCMP_018", "SCMP_019", "SCMP_020", "SCMP_021", "SCMP_022",
+      "SCMP_023", "SCMP_024", "SCMP_025", "SCMP_026", "SCMP_027", "SCMP_028", "SCMP_029", "SCMP_030", "SCMP_031", "SCMP_032", "SCMP_033",
+      "SCMP_034", "SCMP_035", "SCMP_036", "SCMP_037", "SCMP_038", "SCMP_039", "SCMP_040", "X1MP_001", "X1MP_002", "X1MP_003", "X1MP_004",
+      "X1MP_005", "X1MP_006", "X1MP_007", "X1MP_008", "X1MP_009", "X1MP_010", "X1MP_011", "X1MP_012", "X1MP_014", "X1MP_017"
+      );
 
   @Inject
   public MapService(PreferencesService preferencesService, TaskService taskService,
@@ -495,15 +504,6 @@ public class MapService implements InitializingBean, DisposableBean {
   public void destroy() {
     Optional.ofNullable(directoryWatcherThread).ifPresent(Thread::interrupt);
   }
-
-  @VisibleForTesting
-  Set<String> officialMaps = ImmutableSet.of(
-      "SCMP_001", "SCMP_002", "SCMP_003", "SCMP_004", "SCMP_005", "SCMP_006", "SCMP_007", "SCMP_008", "SCMP_009", "SCMP_010", "SCMP_011",
-      "SCMP_012", "SCMP_013", "SCMP_014", "SCMP_015", "SCMP_016", "SCMP_017", "SCMP_018", "SCMP_019", "SCMP_020", "SCMP_021", "SCMP_022",
-      "SCMP_023", "SCMP_024", "SCMP_025", "SCMP_026", "SCMP_027", "SCMP_028", "SCMP_029", "SCMP_030", "SCMP_031", "SCMP_032", "SCMP_033",
-      "SCMP_034", "SCMP_035", "SCMP_036", "SCMP_037", "SCMP_038", "SCMP_039", "SCMP_040", "X1MP_001", "X1MP_002", "X1MP_003", "X1MP_004",
-      "X1MP_005", "X1MP_006", "X1MP_007", "X1MP_008", "X1MP_009", "X1MP_010", "X1MP_011", "X1MP_012", "X1MP_014", "X1MP_017"
-      );
 
   public enum PreviewSize {
     // These must match the preview URLs

--- a/src/main/java/com/faforever/client/map/MapService.java
+++ b/src/main/java/com/faforever/client/map/MapService.java
@@ -19,6 +19,8 @@ import com.faforever.client.task.TaskService;
 import com.faforever.client.theme.UiService;
 import com.faforever.client.util.ProgrammingError;
 import com.faforever.client.vault.search.SearchController.SearchConfig;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
 import javafx.beans.property.DoubleProperty;
@@ -53,12 +55,12 @@ import java.nio.file.Paths;
 import java.nio.file.WatchKey;
 import java.nio.file.WatchService;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
 
@@ -198,8 +200,8 @@ public class MapService implements InitializingBean, DisposableBean {
         try (Stream<Path> customMapsDirectoryStream = list(customMapsDirectory)) {
           List<Path> mapPaths = new ArrayList<>();
           customMapsDirectoryStream.collect(toCollection(() -> mapPaths));
-          Arrays.stream(OfficialMap.values())
-              .map(map -> officialMapsPath.resolve(map.name()))
+          officialMaps.stream()
+              .map(mapName -> officialMapsPath.resolve(mapName))
               .collect(toCollection(() -> mapPaths));
 
           long totalMaps = mapPaths.size();
@@ -306,7 +308,7 @@ public class MapService implements InitializingBean, DisposableBean {
 
 
   public boolean isOfficialMap(String mapName) {
-    return OfficialMap.fromMapName(mapName) != null;
+    return officialMaps.contains(mapName);
   }
 
 
@@ -494,26 +496,14 @@ public class MapService implements InitializingBean, DisposableBean {
     Optional.ofNullable(directoryWatcherThread).ifPresent(Thread::interrupt);
   }
 
-  public enum OfficialMap {
-    SCMP_001, SCMP_002, SCMP_003, SCMP_004, SCMP_005, SCMP_006, SCMP_007, SCMP_008, SCMP_009, SCMP_010, SCMP_011,
-    SCMP_012, SCMP_013, SCMP_014, SCMP_015, SCMP_016, SCMP_017, SCMP_018, SCMP_019, SCMP_020, SCMP_021, SCMP_022,
-    SCMP_023, SCMP_024, SCMP_025, SCMP_026, SCMP_027, SCMP_028, SCMP_029, SCMP_030, SCMP_031, SCMP_032, SCMP_033,
-    SCMP_034, SCMP_035, SCMP_036, SCMP_037, SCMP_038, SCMP_039, SCMP_040, X1MP_001, X1MP_002, X1MP_003, X1MP_004,
-    X1MP_005, X1MP_006, X1MP_007, X1MP_008, X1MP_009, X1MP_010, X1MP_011, X1MP_012, X1MP_014, X1MP_017;
-
-    private static final Map<String, OfficialMap> fromString;
-
-    static {
-      fromString = new HashMap<>();
-      for (OfficialMap officialMap : values()) {
-        fromString.put(officialMap.name(), officialMap);
-      }
-    }
-
-    public static OfficialMap fromMapName(String mapName) {
-      return fromString.get(mapName.toUpperCase());
-    }
-  }
+  @VisibleForTesting
+  Set<String> officialMaps = ImmutableSet.of(
+      "SCMP_001", "SCMP_002", "SCMP_003", "SCMP_004", "SCMP_005", "SCMP_006", "SCMP_007", "SCMP_008", "SCMP_009", "SCMP_010", "SCMP_011",
+      "SCMP_012", "SCMP_013", "SCMP_014", "SCMP_015", "SCMP_016", "SCMP_017", "SCMP_018", "SCMP_019", "SCMP_020", "SCMP_021", "SCMP_022",
+      "SCMP_023", "SCMP_024", "SCMP_025", "SCMP_026", "SCMP_027", "SCMP_028", "SCMP_029", "SCMP_030", "SCMP_031", "SCMP_032", "SCMP_033",
+      "SCMP_034", "SCMP_035", "SCMP_036", "SCMP_037", "SCMP_038", "SCMP_039", "SCMP_040", "X1MP_001", "X1MP_002", "X1MP_003", "X1MP_004",
+      "X1MP_005", "X1MP_006", "X1MP_007", "X1MP_008", "X1MP_009", "X1MP_010", "X1MP_011", "X1MP_012", "X1MP_014", "X1MP_017"
+      );
 
   public enum PreviewSize {
     // These must match the preview URLs

--- a/src/main/java/com/faforever/client/update/ClientUpdateServiceImpl.java
+++ b/src/main/java/com/faforever/client/update/ClientUpdateServiceImpl.java
@@ -34,12 +34,6 @@ import static org.apache.commons.lang3.StringUtils.defaultString;
 @Profile("!" + FafClientApplication.PROFILE_OFFLINE)
 public class ClientUpdateServiceImpl implements ClientUpdateService {
 
-  public static class InstallerExecutionException extends UncheckedIOException {
-    public InstallerExecutionException(String message, IOException cause) {
-      super(message, cause);
-    }
-  }
-
   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
   private static final String DEVELOPMENT_VERSION_STRING = "dev";
 
@@ -51,6 +45,12 @@ public class ClientUpdateServiceImpl implements ClientUpdateService {
 
   @VisibleForTesting
   ComparableVersion currentVersion;
+  
+  public static class InstallerExecutionException extends UncheckedIOException {
+    public InstallerExecutionException(String message, IOException cause) {
+      super(message, cause);
+    }
+  }
 
   public ClientUpdateServiceImpl(
       TaskService taskService,

--- a/src/main/java/com/faforever/client/util/ConcurrentUtil.java
+++ b/src/main/java/com/faforever/client/util/ConcurrentUtil.java
@@ -7,6 +7,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.invoke.MethodHandles;
+import java.util.concurrent.CompletionException;
 
 public final class ConcurrentUtil {
 
@@ -35,5 +36,9 @@ public final class ConcurrentUtil {
     service.start();
 
     return service;
+  }
+
+  public static Throwable unwrapIfCompletionException(Throwable throwable) {
+    return throwable instanceof CompletionException ? throwable.getCause() : throwable;
   }
 }

--- a/src/test/java/com/faforever/client/chat/AbstractChatTabControllerTest.java
+++ b/src/test/java/com/faforever/client/chat/AbstractChatTabControllerTest.java
@@ -12,6 +12,7 @@ import com.faforever.client.preferences.Preferences;
 import com.faforever.client.preferences.PreferencesService;
 import com.faforever.client.reporting.ReportingService;
 import com.faforever.client.test.AbstractPlainJavaFxTest;
+import com.faforever.client.test.FakeTestException;
 import com.faforever.client.theme.UiService;
 import com.faforever.client.uploader.ImageUploadService;
 import com.faforever.client.user.UserService;
@@ -167,7 +168,7 @@ public class AbstractChatTabControllerTest extends AbstractPlainJavaFxTest {
     instance.setReceiver(receiver);
 
     CompletableFuture<String> future = new CompletableFuture<>();
-    future.completeExceptionally(new Exception("junit fake exception"));
+    future.completeExceptionally(new FakeTestException());
     when(chatService.sendMessageInBackground(eq(receiver), any())).thenReturn(future);
 
     instance.onSendMessage();
@@ -200,7 +201,7 @@ public class AbstractChatTabControllerTest extends AbstractPlainJavaFxTest {
     instance.setReceiver(receiver);
 
     CompletableFuture<String> future = new CompletableFuture<>();
-    future.completeExceptionally(new Exception("junit fake exception"));
+    future.completeExceptionally(new FakeTestException());
     when(chatService.sendActionInBackground(eq(receiver), any())).thenReturn(future);
 
     instance.onSendMessage();

--- a/src/test/java/com/faforever/client/chat/ChatChannelUserItemControllerTest.java
+++ b/src/test/java/com/faforever/client/chat/ChatChannelUserItemControllerTest.java
@@ -93,6 +93,7 @@ public class ChatChannelUserItemControllerTest extends AbstractPlainJavaFxTest {
     when(clanService.getClanByTag(anyString())).thenReturn(CompletableFuture.completedFuture(Optional.of(testClan)));
     when(countryFlagService.loadCountryFlag("US")).thenReturn(Optional.of(mock(Image.class)));
     when(playerService.isOnline(eq(2))).thenReturn(true);
+    when(playerService.getCurrentPlayer()).thenReturn(Optional.of(new Player("junit")));
     clanTooltipControllerMock = mock(ClanTooltipController.class);
     when(uiService.loadFxml("theme/chat/clan_tooltip.fxml")).thenReturn(clanTooltipControllerMock);
     when(clanTooltipControllerMock.getRoot()).thenReturn(new Pane());

--- a/src/test/java/com/faforever/client/chat/ChatControllerTest.java
+++ b/src/test/java/com/faforever/client/chat/ChatControllerTest.java
@@ -117,7 +117,12 @@ public class ChatControllerTest extends AbstractPlainJavaFxTest {
 
   @Test
   public void testOpenPrivateMessageTabForUser() throws Exception {
-    when(privateChatTabController.getRoot()).thenReturn(new Tab());
+    Tab tab = new Tab();
+    doAnswer(invocation -> {
+      tab.setId(invocation.getArgument(0));
+      return null;
+    }).when(privateChatTabController).setReceiver(anyString());
+    when(privateChatTabController.getRoot()).thenReturn(tab);
     WaitForAsyncUtils.waitForAsyncFx(TIMEOUT, () ->
         instance.onInitiatePrivateChatEvent(new InitiatePrivateChatEvent("user")));
   }
@@ -135,14 +140,12 @@ public class ChatControllerTest extends AbstractPlainJavaFxTest {
     connectionState.set(ConnectionState.DISCONNECTED);
   }
 
-  @SuppressWarnings("unchecked")
   private void channelJoined(String channel) {
     MapChangeListener.Change<? extends String, ? extends Channel> testChannelChange = mock(MapChangeListener.Change.class);
     channelsListener.getValue().onChanged(testChannelChange);
   }
 
   @Test
-  @SuppressWarnings("unchecked")
   public void testOnJoinChannelButtonClicked() throws Exception {
     assertThat(instance.tabPane.getTabs(), is(empty()));
 

--- a/src/test/java/com/faforever/client/chat/PrivateChatTabControllerTest.java
+++ b/src/test/java/com/faforever/client/chat/PrivateChatTabControllerTest.java
@@ -130,7 +130,7 @@ public class PrivateChatTabControllerTest extends AbstractPlainJavaFxTest {
   }
 
   @Test
-  public void testOnChatMessageUnfocusedTriggersNotification2() throws InterruptedException, ExecutionException, IOException {
+  public void testOnChatMessageUnfocusedTriggersNotification() {
     // TODO this test throws exceptions if another test runs before it or after it, but not if run alone
     // In that case AbstractChatTabController.hasFocus throws NPE because tabPane.getScene().getWindow() is null
     WaitForAsyncUtils.waitForAsyncFx(5000, () -> getRoot().getScene().getWindow().hide());

--- a/src/test/java/com/faforever/client/chat/PrivateChatTabControllerTest.java
+++ b/src/test/java/com/faforever/client/chat/PrivateChatTabControllerTest.java
@@ -19,6 +19,9 @@ import com.faforever.client.user.UserService;
 import com.faforever.client.util.TimeService;
 import com.faforever.client.vault.replay.WatchButtonController;
 import com.google.common.eventbus.EventBus;
+
+import javafx.collections.ObservableList;
+import javafx.scene.Node;
 import javafx.scene.control.TabPane;
 import javafx.scene.control.skin.TabPaneSkin;
 import org.junit.Before;
@@ -34,7 +37,6 @@ import java.time.Instant;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 
-import static com.faforever.client.theme.UiService.CHAT_CONTAINER;
 import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
@@ -98,7 +100,9 @@ public class PrivateChatTabControllerTest extends AbstractPlainJavaFxTest {
 
     when(playerService.getPlayerForUsername(playerName)).thenReturn(Optional.of(player));
     when(userService.getUsername()).thenReturn(playerName);
-    when(uiService.getThemeFileUrl(CHAT_CONTAINER)).then(invocation -> getThemeFileUrl(invocation.getArgument(0)));
+    when(timeService.asShortTime(any())).thenReturn("");
+    when(i18n.get(any(), any())).then(invocation -> invocation.getArgument(0));
+    when(uiService.getThemeFileUrl(any())).then(invocation -> getThemeFileUrl(invocation.getArgument(0)));
 
     TabPane tabPane = new TabPane();
     tabPane.setSkin(new TabPaneSkin(tabPane));
@@ -126,7 +130,9 @@ public class PrivateChatTabControllerTest extends AbstractPlainJavaFxTest {
   }
 
   @Test
-  public void testOnChatMessageUnfocusedTriggersNotification() {
+  public void testOnChatMessageUnfocusedTriggersNotification2() throws InterruptedException, ExecutionException, IOException {
+    // TODO this test throws exceptions if another test runs before it or after it, but not if run alone
+    // In that case AbstractChatTabController.hasFocus throws NPE because tabPane.getScene().getWindow() is null
     WaitForAsyncUtils.waitForAsyncFx(5000, () -> getRoot().getScene().getWindow().hide());
     instance.onChatMessage(new ChatMessage(playerName, Instant.now(), playerName, "Test message"));
     verify(notificationService).addNotification(any(TransientNotification.class));

--- a/src/test/java/com/faforever/client/chat/PrivateChatTabControllerTest.java
+++ b/src/test/java/com/faforever/client/chat/PrivateChatTabControllerTest.java
@@ -20,8 +20,6 @@ import com.faforever.client.util.TimeService;
 import com.faforever.client.vault.replay.WatchButtonController;
 import com.google.common.eventbus.EventBus;
 
-import javafx.collections.ObservableList;
-import javafx.scene.Node;
 import javafx.scene.control.TabPane;
 import javafx.scene.control.skin.TabPaneSkin;
 import org.junit.Before;

--- a/src/test/java/com/faforever/client/chat/UserInfoWindowControllerTest.java
+++ b/src/test/java/com/faforever/client/chat/UserInfoWindowControllerTest.java
@@ -9,6 +9,7 @@ import com.faforever.client.domain.RatingHistoryDataPoint;
 import com.faforever.client.events.EventService;
 import com.faforever.client.game.KnownFeaturedMod;
 import com.faforever.client.i18n.I18n;
+import com.faforever.client.leaderboard.LeaderboardEntry;
 import com.faforever.client.leaderboard.LeaderboardService;
 import com.faforever.client.notification.NotificationService;
 import com.faforever.client.player.PlayerBuilder;
@@ -80,6 +81,7 @@ public class UserInfoWindowControllerTest extends AbstractPlainJavaFxTest {
     when(achievementItemController.getRoot()).thenReturn(new HBox());
     when(playerService.getPlayersByIds(any())).thenReturn(CompletableFuture.completedFuture(Collections.emptyList()));
 
+    when(leaderboardService.getEntryForPlayer(eq(PLAYER_ID))).thenReturn(CompletableFuture.completedFuture(new LeaderboardEntry()));
     when(statisticsService.getRatingHistory(any(), eq(PLAYER_ID))).thenReturn(CompletableFuture.completedFuture(Arrays.asList(
         new RatingHistoryDataPoint(OffsetDateTime.now(), 1500f, 50f),
         new RatingHistoryDataPoint(OffsetDateTime.now().plus(1, ChronoUnit.DAYS), 1500f, 50f)

--- a/src/test/java/com/faforever/client/config/FafClientApplicationTest.java
+++ b/src/test/java/com/faforever/client/config/FafClientApplicationTest.java
@@ -19,7 +19,7 @@ import java.lang.invoke.MethodHandles;
 import static org.mockito.Mockito.mock;
 
 @RunWith(MockitoJUnitRunner.class)
-public class FeaturedModUpdaterConfigTest extends AbstractPlainJavaFxTest {
+public class FafClientApplicationTest extends AbstractPlainJavaFxTest {
   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   @Test

--- a/src/test/java/com/faforever/client/game/CreateGameControllerTest.java
+++ b/src/test/java/com/faforever/client/game/CreateGameControllerTest.java
@@ -40,6 +40,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -93,6 +94,8 @@ public class CreateGameControllerTest extends AbstractPlainJavaFxTest {
     when(modService.getFeaturedMods()).thenReturn(CompletableFuture.completedFuture(emptyList()));
     when(modService.getInstalledModVersions()).thenReturn(FXCollections.observableList(emptyList()));
     when(mapService.loadPreview(anyString(), any())).thenReturn(new Image("/theme/images/close.png"));
+    when(i18n.get(any(), any())).then(invocation -> invocation.getArgument(0));
+    when(i18n.number(anyInt())).then(invocation -> invocation.getArgument(0).toString());
     when(fafService.connectionStateProperty()).thenReturn(new SimpleObjectProperty<>(ConnectionState.CONNECTED));
 
     loadFxml("theme/play/create_game.fxml", clazz -> instance);

--- a/src/test/java/com/faforever/client/game/GameLaunchMessageBuilder.java
+++ b/src/test/java/com/faforever/client/game/GameLaunchMessageBuilder.java
@@ -2,6 +2,8 @@ package com.faforever.client.game;
 
 import com.faforever.client.remote.domain.GameLaunchMessage;
 
+import static java.util.Collections.emptyList;
+
 import java.util.Arrays;
 
 public class GameLaunchMessageBuilder {
@@ -19,11 +21,31 @@ public class GameLaunchMessageBuilder {
   public GameLaunchMessageBuilder defaultValues() {
     gameLaunchMessage.setUid(1);
     gameLaunchMessage.setMod(KnownFeaturedMod.DEFAULT.getTechnicalName());
-    gameLaunchMessage.setArgs(Arrays.asList("/ratingcolor red", "/clan foo"));
+    gameLaunchMessage.setArgs(emptyList());
     return this;
   }
 
   public GameLaunchMessage get() {
     return gameLaunchMessage;
+  }
+
+  public GameLaunchMessageBuilder uid(int uid) {
+    gameLaunchMessage.setUid(uid);
+    return this;
+  }
+
+  public GameLaunchMessageBuilder mod(String mod) {
+    gameLaunchMessage.setMod(mod);
+    return this;
+  }
+
+  public GameLaunchMessageBuilder mapname(String mapname) {
+    gameLaunchMessage.setMapname(mapname);
+    return this;
+  }
+
+  public GameLaunchMessageBuilder args(String... args) {
+    gameLaunchMessage.setArgs(Arrays.asList(args));
+    return this;
   }
 }

--- a/src/test/java/com/faforever/client/game/GameServiceTest.java
+++ b/src/test/java/com/faforever/client/game/GameServiceTest.java
@@ -61,7 +61,6 @@ import static com.faforever.client.remote.domain.GameStatus.OPEN;
 import static com.faforever.client.remote.domain.GameStatus.PLAYING;
 import static com.natpryce.hamcrest.reflection.HasAnnotationMatcher.hasAnnotation;
 import static java.util.Arrays.asList;
-import static java.util.Collections.emptyList;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -79,7 +78,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -149,7 +147,7 @@ public class GameServiceTest extends AbstractPlainJavaFxTest {
     when(preferencesService.getPreferences()).thenReturn(preferences);
     when(fafService.connectionStateProperty()).thenReturn(new SimpleObjectProperty<>());
     when(replayService.startReplayServer(anyInt())).thenReturn(completedFuture(LOCAL_REPLAY_PORT));
-    when(iceAdapter.start()).thenReturn(CompletableFuture.completedFuture(GPG_PORT));
+    when(iceAdapter.start()).thenReturn(completedFuture(GPG_PORT));
     when(playerService.getCurrentPlayer()).thenReturn(Optional.of(junitPlayer));
 
     doAnswer(invocation -> {
@@ -198,7 +196,7 @@ public class GameServiceTest extends AbstractPlainJavaFxTest {
     when(mapService.isInstalled("map")).thenReturn(true);
     when(fafService.requestJoinGame(game.getId(), null)).thenReturn(completedFuture(gameLaunchMessage));
     when(gameUpdater.update(any(), any(), any(), any())).thenReturn(completedFuture(null));
-    when(modService.getFeaturedMod(game.getFeaturedMod())).thenReturn(CompletableFuture.completedFuture(FeaturedModBeanBuilder.create().defaultValues().get()));
+    when(modService.getFeaturedMod(game.getFeaturedMod())).thenReturn(completedFuture(FeaturedModBeanBuilder.create().defaultValues().get()));
 
     CompletableFuture<Void> future = instance.joinGame(game, null).toCompletableFuture();
 
@@ -227,7 +225,7 @@ public class GameServiceTest extends AbstractPlainJavaFxTest {
     when(mapService.isInstalled("map")).thenReturn(true);
     when(fafService.requestJoinGame(game.getId(), null)).thenReturn(completedFuture(gameLaunchMessage));
     when(gameUpdater.update(any(), any(), any(), any())).thenReturn(completedFuture(null));
-    when(modService.getFeaturedMod(game.getFeaturedMod())).thenReturn(CompletableFuture.completedFuture(FeaturedModBeanBuilder.create().defaultValues().get()));
+    when(modService.getFeaturedMod(game.getFeaturedMod())).thenReturn(completedFuture(FeaturedModBeanBuilder.create().defaultValues().get()));
 
     instance.joinGame(game, null).toCompletableFuture().get();
     verify(modService).enableSimMods(simModsCaptor.capture());
@@ -242,7 +240,7 @@ public class GameServiceTest extends AbstractPlainJavaFxTest {
     mockGlobalStartGameProcess(gameLaunchMessage.getUid(), "/foo", "bar", "/bar", "foo");
     when(gameUpdater.update(any(), any(), any(), any())).thenReturn(completedFuture(null));
     when(fafService.requestHostGame(newGameInfo)).thenReturn(completedFuture(gameLaunchMessage));
-    when(mapService.download(newGameInfo.getMap())).thenReturn(CompletableFuture.completedFuture(null));
+    when(mapService.download(newGameInfo.getMap())).thenReturn(completedFuture(null));
 
     CountDownLatch gameStartedLatch = new CountDownLatch(1);
     CountDownLatch gameTerminatedLatch = new CountDownLatch(1);
@@ -411,10 +409,10 @@ public class GameServiceTest extends AbstractPlainJavaFxTest {
     String[] additionalArgs = { "/team", "1", "/players", "2" };
     mockStartGameProcess(uid, RatingMode.LADDER_1V1, CYBRAN, false, additionalArgs);
     when(fafService.startSearchLadder1v1(CYBRAN)).thenReturn(completedFuture(gameLaunchMessage));
-    when(gameUpdater.update(featuredMod, null, Collections.emptyMap(), Collections.emptySet())).thenReturn(CompletableFuture.completedFuture(null));
+    when(gameUpdater.update(featuredMod, null, Collections.emptyMap(), Collections.emptySet())).thenReturn(completedFuture(null));
     when(mapService.isInstalled(map)).thenReturn(false);
-    when(mapService.download(map)).thenReturn(CompletableFuture.completedFuture(null));
-    when(modService.getFeaturedMod(LADDER_1V1.getTechnicalName())).thenReturn(CompletableFuture.completedFuture(featuredMod));
+    when(mapService.download(map)).thenReturn(completedFuture(null));
+    when(modService.getFeaturedMod(LADDER_1V1.getTechnicalName())).thenReturn(completedFuture(featuredMod));
 
     instance.startSearchLadder1v1(CYBRAN).toCompletableFuture();
 
@@ -436,7 +434,7 @@ public class GameServiceTest extends AbstractPlainJavaFxTest {
     when(forgedAllianceService.startGame(anyInt(), any(), any(), any(), anyInt(), eq(LOCAL_REPLAY_PORT), eq(false), eq(junitPlayer))).thenReturn(process);
     when(gameUpdater.update(any(), any(), any(), any())).thenReturn(completedFuture(null));
     when(fafService.requestHostGame(newGameInfo)).thenReturn(completedFuture(gameLaunchMessage));
-    when(mapService.download(newGameInfo.getMap())).thenReturn(CompletableFuture.completedFuture(null));
+    when(mapService.download(newGameInfo.getMap())).thenReturn(completedFuture(null));
 
     CountDownLatch gameRunningLatch = new CountDownLatch(1);
     instance.gameRunningProperty().addListener((observable, oldValue, newValue) -> {
@@ -484,11 +482,11 @@ public class GameServiceTest extends AbstractPlainJavaFxTest {
     instance.currentGame.set(game);
 
     mockStartGameProcess(game.getId(), GLOBAL, null, true);
-    when(modService.getFeaturedMod(game.getFeaturedMod())).thenReturn(CompletableFuture.completedFuture(FeaturedModBeanBuilder.create().defaultValues().get()));
+    when(modService.getFeaturedMod(game.getFeaturedMod())).thenReturn(completedFuture(FeaturedModBeanBuilder.create().defaultValues().get()));
     when(gameUpdater.update(any(), any(), any(), any())).thenReturn(completedFuture(null));
     when(fafService.requestHostGame(any())).thenReturn(completedFuture(GameLaunchMessageBuilder.create().defaultValues().get()));
-    when(modService.getFeaturedMod(game.getFeaturedMod())).thenReturn(CompletableFuture.completedFuture(FeaturedModBeanBuilder.create().defaultValues().get()));
-    when(mapService.download(game.getMapFolderName())).thenReturn(CompletableFuture.completedFuture(null));
+    when(modService.getFeaturedMod(game.getFeaturedMod())).thenReturn(completedFuture(FeaturedModBeanBuilder.create().defaultValues().get()));
+    when(mapService.download(game.getMapFolderName())).thenReturn(completedFuture(null));
 
     instance.onRehostRequest(new RehostRequestEvent());
 

--- a/src/test/java/com/faforever/client/map/DownloadMapBeanTaskTest.java
+++ b/src/test/java/com/faforever/client/map/DownloadMapBeanTaskTest.java
@@ -4,6 +4,8 @@ import com.faforever.client.i18n.I18n;
 import com.faforever.client.preferences.ForgedAlliancePrefs;
 import com.faforever.client.preferences.Preferences;
 import com.faforever.client.preferences.PreferencesService;
+import com.faforever.client.test.AbstractPlainJavaFxTest;
+
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -20,7 +22,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
-public class DownloadMapBeanTaskTest {
+public class DownloadMapBeanTaskTest extends AbstractPlainJavaFxTest {
 
   @Rule
   public ExpectedException expectedException = ExpectedException.none();

--- a/src/test/java/com/faforever/client/map/MapServiceTest.java
+++ b/src/test/java/com/faforever/client/map/MapServiceTest.java
@@ -14,6 +14,7 @@ import com.faforever.client.task.TaskService;
 import com.faforever.client.test.AbstractPlainJavaFxTest;
 import com.faforever.client.theme.UiService;
 import com.faforever.client.update.ClientConfiguration;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.eventbus.EventBus;
 import javafx.beans.property.ObjectProperty;
@@ -110,7 +111,6 @@ public class MapServiceTest extends AbstractPlainJavaFxTest {
     instance = new MapService(preferencesService, taskService, applicationContext,
         fafService, assetService, i18n, uiService, clientProperties, mapGeneratorService, eventBus);
 
-
     doAnswer(invocation -> {
       @SuppressWarnings("unchecked")
       CompletableTask<Void> task = invocation.getArgument(0);
@@ -119,6 +119,7 @@ public class MapServiceTest extends AbstractPlainJavaFxTest {
       return task;
     }).when(taskService).submitTask(any());
 
+    instance.officialMaps = ImmutableSet.of();
     instance.afterPropertiesSet();
   }
 
@@ -129,6 +130,8 @@ public class MapServiceTest extends AbstractPlainJavaFxTest {
 
   @Test
   public void testGetLocalMapsOfficialMap() throws Exception {
+    instance.officialMaps = ImmutableSet.of("SCMP_001");
+    
     Path scmp001 = Files.createDirectory(mapsDirectory.resolve("SCMP_001"));
     Files.copy(getClass().getResourceAsStream("/maps/SCMP_001/SCMP_001_scenario.lua"), scmp001.resolve("SCMP_001_scenario.lua"));
 
@@ -177,6 +180,8 @@ public class MapServiceTest extends AbstractPlainJavaFxTest {
 
   @Test
   public void testInstalledOfficialMapIgnoreCase() throws Exception {
+    instance.officialMaps = ImmutableSet.of("SCMP_001");
+    
     Path scmp001 = Files.createDirectory(mapsDirectory.resolve("SCMP_001"));
     Files.copy(getClass().getResourceAsStream("/maps/SCMP_001/SCMP_001_scenario.lua"), scmp001.resolve("SCMP_001_scenario.lua"));
 

--- a/src/test/java/com/faforever/client/mod/ModDetailControllerTest.java
+++ b/src/test/java/com/faforever/client/mod/ModDetailControllerTest.java
@@ -7,6 +7,7 @@ import com.faforever.client.player.Player;
 import com.faforever.client.player.PlayerService;
 import com.faforever.client.reporting.ReportingService;
 import com.faforever.client.test.AbstractPlainJavaFxTest;
+import com.faforever.client.test.FakeTestException;
 import com.faforever.client.util.TimeService;
 import com.faforever.client.vault.review.ReviewController;
 import com.faforever.client.vault.review.ReviewService;
@@ -136,7 +137,7 @@ public class ModDetailControllerTest extends AbstractPlainJavaFxTest {
   @Test
   public void testOnInstallButtonClickedInstallindModThrowsException() {
     CompletableFuture<Void> future = new CompletableFuture<>();
-    future.completeExceptionally(new Exception("test exception"));
+    future.completeExceptionally(new FakeTestException());
     when(modService.downloadAndInstallMod(any(ModVersion.class), any(), any())).thenReturn(future);
 
     instance.setModVersion(ModInfoBeanBuilder.create().defaultValues().get());
@@ -164,7 +165,7 @@ public class ModDetailControllerTest extends AbstractPlainJavaFxTest {
     instance.setModVersion(modVersion);
 
     CompletableFuture<Void> future = new CompletableFuture<>();
-    future.completeExceptionally(new Exception("test exception"));
+    future.completeExceptionally(new FakeTestException());
     when(modService.uninstallMod(modVersion)).thenReturn(future);
 
     instance.onUninstallButtonClicked();

--- a/src/test/java/com/faforever/client/mod/ModUploadTaskTest.java
+++ b/src/test/java/com/faforever/client/mod/ModUploadTaskTest.java
@@ -3,6 +3,8 @@ package com.faforever.client.mod;
 import com.faforever.client.i18n.I18n;
 import com.faforever.client.preferences.PreferencesService;
 import com.faforever.client.remote.FafService;
+import com.faforever.client.test.AbstractPlainJavaFxTest;
+
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -21,7 +23,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
-public class ModUploadTaskTest {
+public class ModUploadTaskTest extends AbstractPlainJavaFxTest{
 
   @Rule
   public TemporaryFolder tempFolder = new TemporaryFolder();

--- a/src/test/java/com/faforever/client/mod/ModVaultControllerTest.java
+++ b/src/test/java/com/faforever/client/mod/ModVaultControllerTest.java
@@ -81,11 +81,6 @@ public class ModVaultControllerTest extends AbstractPlainJavaFxTest {
       return modDetailController;
     }).when(uiService).loadFxml("theme/vault/mod/mod_detail.fxml");
 
-    ModVersion modVersion = ModInfoBeanBuilder.create().defaultValues().get();
-    when(modService.getHighestRatedMods(100, 1)).thenReturn(CompletableFuture.completedFuture(Collections.singletonList(modVersion)));
-
-    when(modService.getNewestMods(100, 1)).thenReturn(CompletableFuture.completedFuture(Collections.singletonList(modVersion)));
-
     loadFxml("theme/vault/mod/mod_vault.fxml", clazz -> {
       if (clazz == LogicalNodeController.class) {
         return logicalNodeController;
@@ -122,10 +117,12 @@ public class ModVaultControllerTest extends AbstractPlainJavaFxTest {
 
     when(modService.getNewestMods(anyInt(), anyInt())).thenReturn(CompletableFuture.completedFuture(modVersions));
     when(modService.getHighestRatedMods(anyInt(), anyInt())).thenReturn(CompletableFuture.completedFuture(modVersions));
-
-    CountDownLatch latch = new CountDownLatch(2);
+    when(modService.getHighestRatedUiMods(anyInt(), anyInt())).thenReturn(CompletableFuture.completedFuture(modVersions));
+    
+    CountDownLatch latch = new CountDownLatch(3);
     waitUntilInitialized(instance.newestPane, latch);
     waitUntilInitialized(instance.highestRatedPane, latch);
+    waitUntilInitialized(instance.highestRatedUiPane, latch);
 
     instance.display(new OpenModVaultEvent());
 
@@ -174,11 +171,13 @@ public class ModVaultControllerTest extends AbstractPlainJavaFxTest {
   }
 
   @Test
-  public void showMoreMostLikedMods() {
-    instance.showMoreHighestRatedMods();
+  public void showMoreHighestRatedUiMods() {
+    when(modService.getHighestRatedUiMods(100, 1)).thenReturn(CompletableFuture.completedFuture(Collections.emptyList()));
+    instance.showMoreHighestRatedUiMods();
 
     WaitForAsyncUtils.waitForFxEvents();
 
+    verify(modService).getHighestRatedUiMods(100, 1);
     assertFalse(instance.showroomGroup.isVisible());
     assertTrue(instance.searchResultGroup.isVisible());
   }

--- a/src/test/java/com/faforever/client/remote/ServerAccessorImplTest.java
+++ b/src/test/java/com/faforever/client/remote/ServerAccessorImplTest.java
@@ -32,6 +32,7 @@ import com.faforever.client.remote.gson.ServerMessageTypeTypeAdapter;
 import com.faforever.client.remote.io.QDataInputStream;
 import com.faforever.client.reporting.ReportingService;
 import com.faforever.client.test.AbstractPlainJavaFxTest;
+import com.faforever.client.test.FakeTestException;
 import com.google.common.hash.Hashing;
 import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
@@ -312,7 +313,7 @@ public class ServerAccessorImplTest extends AbstractPlainJavaFxTest {
 
   @Test
   public void onUIDNotFound() throws Exception {
-    instance.onUIDNotExecuted(new Exception("UID not found"));
+    instance.onUIDNotExecuted(new FakeTestException("UID not found"));
     verify(notificationService).addNotification(any(ImmediateNotification.class));
   }
 }

--- a/src/test/java/com/faforever/client/replay/ReplayServiceTest.java
+++ b/src/test/java/com/faforever/client/replay/ReplayServiceTest.java
@@ -18,7 +18,6 @@ import com.faforever.client.task.TaskService;
 import com.faforever.client.test.FakeTestException;
 import com.faforever.commons.replay.ReplayData;
 
-import org.hamcrest.Matcher;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;

--- a/src/test/java/com/faforever/client/replay/ReplayServiceTest.java
+++ b/src/test/java/com/faforever/client/replay/ReplayServiceTest.java
@@ -15,7 +15,10 @@ import com.faforever.client.preferences.PreferencesService;
 import com.faforever.client.remote.FafService;
 import com.faforever.client.reporting.ReportingService;
 import com.faforever.client.task.TaskService;
+import com.faforever.client.test.FakeTestException;
 import com.faforever.commons.replay.ReplayData;
+
+import org.hamcrest.Matcher;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -176,8 +179,8 @@ public class ReplayServiceTest {
     Path file1 = replayDirectory.newFile("replay.fafreplay").toPath();
     Path file2 = replayDirectory.newFile("replay2.fafreplay").toPath();
 
-    doThrow(new RuntimeException("Junit test exception")).when(replayFileReader).parseMetaData(file1);
-    doThrow(new RuntimeException("Junit test exception")).when(replayFileReader).parseMetaData(file2);
+    doThrow(new FakeTestException()).when(replayFileReader).parseMetaData(file1);
+    doThrow(new FakeTestException()).when(replayFileReader).parseMetaData(file2);
 
     Collection<Replay> localReplays = instance.getLocalReplays();
 
@@ -252,14 +255,12 @@ public class ReplayServiceTest {
   public void testRunReplayFileExceptionTriggersNotification() throws Exception {
     Path replayFile = replayDirectory.newFile("replay.scfareplay").toPath();
 
-    doThrow(new RuntimeException("Junit test exception")).when(replayFileReader).readRawReplayData(replayFile);
+    doThrow(new FakeTestException()).when(replayFileReader).readRawReplayData(replayFile);
 
     Replay replay = new Replay();
     replay.setReplayFile(replayFile);
 
-    expectedException.expect(RuntimeException.class);
-    expectedException.expectMessage("Junit test exception");
-
+    expectedException.expect(FakeTestException.class);
     instance.runReplay(replay);
   }
 
@@ -267,13 +268,13 @@ public class ReplayServiceTest {
   public void testRunFafReplayFileExceptionPropagates() throws Exception {
     Path replayFile = replayDirectory.newFile("replay.fafreplay").toPath();
 
-    doThrow(new RuntimeException("Junit test exception")).when(replayFileReader).parseMetaData(replayFile);
+    doThrow(new FakeTestException()).when(replayFileReader).parseMetaData(replayFile);
     when(replayFileReader.readRawReplayData(replayFile)).thenReturn(REPLAY_FIRST_BYTES);
 
     Replay replay = new Replay();
     replay.setReplayFile(replayFile);
 
-    expectedException.expectMessage("Junit test exception");
+    expectedException.expect(FakeTestException.class);
     instance.runReplay(replay);
   }
 
@@ -325,7 +326,7 @@ public class ReplayServiceTest {
   @Test
   public void testRunScFaOnlineReplayExceptionTriggersNotification() throws Exception {
     Path replayFile = replayDirectory.newFile("replay.scfareplay").toPath();
-    doThrow(new RuntimeException("Junit test exception")).when(replayFileReader).parseMetaData(replayFile);
+    doThrow(new FakeTestException()).when(replayFileReader).parseMetaData(replayFile);
 
     ReplayDownloadTask replayDownloadTask = mock(ReplayDownloadTask.class);
     when(replayDownloadTask.getFuture()).thenReturn(CompletableFuture.completedFuture(replayFile));

--- a/src/test/java/com/faforever/client/test/FakeTestException.java
+++ b/src/test/java/com/faforever/client/test/FakeTestException.java
@@ -1,0 +1,26 @@
+package com.faforever.client.test;
+
+public class FakeTestException extends Exception {
+  private static final long serialVersionUID = -2887429654623895910L;
+
+  public FakeTestException() {
+    this("Test Exception");
+  }
+
+  public FakeTestException(Throwable cause) {
+    super("Test Exception", cause);
+  }
+
+  public FakeTestException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public FakeTestException(String message) {
+    super(message);
+  }
+
+  @Override
+  public synchronized Throwable fillInStackTrace() {
+    return this; // this exception will not print stack trace
+  }
+}

--- a/src/test/java/com/faforever/client/test/FakeTestException.java
+++ b/src/test/java/com/faforever/client/test/FakeTestException.java
@@ -1,6 +1,6 @@
 package com.faforever.client.test;
 
-public class FakeTestException extends Exception {
+public class FakeTestException extends RuntimeException {
   private static final long serialVersionUID = -2887429654623895910L;
 
   public FakeTestException() {

--- a/src/test/java/com/faforever/client/update/ClientUpdateServiceImplTest.java
+++ b/src/test/java/com/faforever/client/update/ClientUpdateServiceImplTest.java
@@ -5,6 +5,7 @@ import com.faforever.client.i18n.I18n;
 import com.faforever.client.notification.NotificationService;
 import com.faforever.client.notification.PersistentNotification;
 import com.faforever.client.task.TaskService;
+import com.faforever.client.update.ClientUpdateServiceImpl.InstallerExecutionException;
 import com.faforever.commons.io.Bytes;
 import org.apache.maven.artifact.versioning.ComparableVersion;
 import org.junit.Before;
@@ -14,7 +15,6 @@ import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.context.ApplicationContext;
 
@@ -60,7 +60,6 @@ public class ClientUpdateServiceImplTest {
    * Never version is available on server.
    */
   @Test
-  @SuppressWarnings("unchecked")
   public void testCheckForUpdateInBackgroundUpdateAvailable() throws Exception {
     instance.currentVersion = new ComparableVersion("v0.4.8.0-alpha");
 
@@ -87,7 +86,9 @@ public class ClientUpdateServiceImplTest {
   @Test
   public void testUnixExecutableBitIsSet() throws Exception {
     Path faExePath = fafBinDirectory.newFile("ForgedAlliance.exe").toPath();
-    instance.install(faExePath);
-    Mockito.verify(platformService).setUnixExecutableAndWritableBits(faExePath);
+    try {
+      instance.install(faExePath);
+    } catch(InstallerExecutionException e) {}
+    verify(platformService).setUnixExecutableAndWritableBits(faExePath);
   }
 }

--- a/src/test/java/com/faforever/client/update/ClientUpdateServiceImplTest.java
+++ b/src/test/java/com/faforever/client/update/ClientUpdateServiceImplTest.java
@@ -88,7 +88,7 @@ public class ClientUpdateServiceImplTest {
     Path faExePath = fafBinDirectory.newFile("ForgedAlliance.exe").toPath();
     try {
       instance.install(faExePath);
-    } catch(InstallerExecutionException e) {}
+    } catch (InstallerExecutionException e) {}
     verify(platformService).setUnixExecutableAndWritableBits(faExePath);
   }
 }

--- a/src/test/java/com/faforever/client/util/ConcurrentUtilTest.java
+++ b/src/test/java/com/faforever/client/util/ConcurrentUtilTest.java
@@ -1,0 +1,31 @@
+package com.faforever.client.util;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.function.Function;
+
+import org.junit.Test;
+
+import com.faforever.client.test.FakeTestException;
+
+public class ConcurrentUtilTest {
+  
+  @Test
+  public void testUnwrapIfCompletionException() throws InterruptedException, ExecutionException {
+    RuntimeException exception = new FakeTestException();
+    Function<Throwable, Void> handler = throwable -> {
+      throwable = ConcurrentUtil.unwrapIfCompletionException(throwable);
+      assertEquals(exception, throwable);
+      return null;
+    };
+    CompletableFuture.failedFuture(exception).exceptionally(handler).get();
+    CompletableFuture.completedFuture(null)
+        .thenRun(() -> {
+          throw exception;
+        })
+        .exceptionally(handler)
+        .get();
+  }
+}


### PR DESCRIPTION
### MapService
I simply made the list of official maps mockable. I see no reason for them to be an enum, in fact being an immutable list seems to make the code simpler (it removes the need for the weird string-to-enum-map).

However i would like for that list to be final. To make that happen, the maps would need to be stored in a dependency of `MapService` (a good place is probably `ForgedAlliancePrefs`), so that they can be properly Mocked. But not sure about this, opinions wanted. I have not done that for now.
(see #1377)

### Deliberate Exceptions
Added new class `FakeTestException` that works like a normal exception but doesn't print a stacktrace to replace the `new Exception("fake test exception")` lines.

### Chat tests
There is something really interesting/fishy going on in test `testOnChatMessageUnfocusedTriggersNotification` in class `PrivateChatTabControllerTest` (see `TODO`). The test only throws exceptions when other tests of that class run as well. Help wanted.

### Threadpool cleanup
The `AsyncConfig` class tried to shutdown one of the two threadpool singletons with a `destroy` method which failed (only visible during `FeaturedModUpdaterConfigTest`, silent during normal execution) before shutdown (see #1385). This now fixed and the test class was renamed.

---
Fixes #1377 
Fixes #1379 (this bug increased log spam, and fix was easy)
Fixes #1385
Fixes #1386