### PR TITLE
Fix circular dependency ReplayService <-> GameService

### DIFF
--- a/src/main/java/com/faforever/client/fx/BrowserCallback.java
+++ b/src/main/java/com/faforever/client/fx/BrowserCallback.java
@@ -8,9 +8,7 @@ import com.faforever.client.config.ClientProperties;
 import com.faforever.client.i18n.I18n;
 import com.faforever.client.main.event.JoinChannelEvent;
 import com.faforever.client.main.event.ShowReplayEvent;
-import com.faforever.client.notification.ImmediateNotification;
 import com.faforever.client.notification.NotificationService;
-import com.faforever.client.notification.Severity;
 import com.faforever.client.player.Player;
 import com.faforever.client.player.PlayerService;
 import com.faforever.client.replay.ReplayService;
@@ -89,15 +87,7 @@ public class BrowserCallback {
     }
 
     String replayId = replayUrlMatcher.group(1);
-
-    replayService.findById(Integer.parseInt(replayId))
-        .thenAccept(replay -> Platform.runLater(() -> {
-          if (replay.isPresent()) {
-            eventBus.post(new ShowReplayEvent(replay.get()));
-          } else {
-            notificationService.addNotification(new ImmediateNotification(i18n.get("replay.notFoundTitle"), i18n.get("replay.replayNotFoundText", replayId), Severity.WARN));
-          }
-        }));
+    eventBus.post(new ShowReplayEvent(Integer.parseInt(replayId)));
   }
 
   /**

--- a/src/main/java/com/faforever/client/main/event/JoinChannelEvent.java
+++ b/src/main/java/com/faforever/client/main/event/JoinChannelEvent.java
@@ -1,8 +1,10 @@
 package com.faforever.client.main.event;
 
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 @Data
+@EqualsAndHashCode(callSuper = true)
 public class JoinChannelEvent extends NavigateEvent {
   private final String channel;
 

--- a/src/main/java/com/faforever/client/main/event/ShowReplayEvent.java
+++ b/src/main/java/com/faforever/client/main/event/ShowReplayEvent.java
@@ -1,9 +1,10 @@
 package com.faforever.client.main.event;
 
-import com.faforever.client.replay.Replay;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 @Data
+@EqualsAndHashCode(callSuper = true)
 public class ShowReplayEvent extends OpenOnlineReplayVaultEvent {
-  private final Replay replay;
+  private final int replayId;
 }

--- a/src/main/java/com/faforever/client/replay/LocalReplayInfo.java
+++ b/src/main/java/com/faforever/client/replay/LocalReplayInfo.java
@@ -4,12 +4,15 @@ import com.faforever.client.game.Game;
 import com.faforever.client.remote.domain.GameStatus;
 import com.faforever.client.remote.domain.VictoryCondition;
 
+import lombok.Data;
+
 import java.util.List;
 import java.util.Map;
 
 /**
  * This class is meant to be serialized/deserialized from/to JSON.
  */
+@Data
 public class LocalReplayInfo {
 
   private String host;
@@ -17,6 +20,7 @@ public class LocalReplayInfo {
   private String title;
   private String mapname;
   private GameStatus state;
+  //TODO what is this? not used by client.
   private Boolean[] options;
   // FAF calls this "game_type" but it's actually the victory condition.
   private VictoryCondition gameType;
@@ -30,7 +34,13 @@ public class LocalReplayInfo {
   private String recorder;
   private Map<String, String> versionInfo;
   private double gameEnd;
+  /**
+   * Backwards compatibility: If 0.0, then {@code launchedAt} should be available instead.
+   */
   private double gameTime;
+  /**
+   * Backwards compatibility: If 0.0, then {@code gameTime} should be available instead.
+   */
   private double launchedAt;
 
   public void updateFromGameInfoBean(Game game) {
@@ -47,163 +57,5 @@ public class LocalReplayInfo {
     // FIXME this (and all others here) should do a deep copy
     teams = game.getTeams();
     featuredModVersions = game.getFeaturedModVersions();
-  }
-
-  public String getHost() {
-    return host;
-  }
-
-  public void setHost(String host) {
-    this.host = host;
-  }
-
-  public Integer getUid() {
-    return uid;
-  }
-
-  public void setUid(Integer uid) {
-    this.uid = uid;
-  }
-
-  public String getTitle() {
-    return title;
-  }
-
-  public void setTitle(String title) {
-    this.title = title;
-  }
-
-  public String getMapname() {
-    return mapname;
-  }
-
-  public void setMapname(String mapname) {
-    this.mapname = mapname;
-  }
-
-  public GameStatus getState() {
-    return state;
-  }
-
-  public void setState(GameStatus state) {
-    this.state = state;
-  }
-
-  public Boolean[] getOptions() {
-    return options;
-  }
-
-  public void setOptions(Boolean[] options) {
-    this.options = options;
-  }
-
-  public VictoryCondition getGameType() {
-    return gameType;
-  }
-
-  public void setGameType(VictoryCondition gameType) {
-    this.gameType = gameType;
-  }
-
-  public String getFeaturedMod() {
-    return featuredMod;
-  }
-
-  public void setFeaturedMod(String featuredMod) {
-    this.featuredMod = featuredMod;
-  }
-
-  public Integer getMaxPlayers() {
-    return maxPlayers;
-  }
-
-  public void setMaxPlayers(Integer maxPlayers) {
-    this.maxPlayers = maxPlayers;
-  }
-
-  public Integer getNumPlayers() {
-    return numPlayers;
-  }
-
-  public void setNumPlayers(Integer numPlayers) {
-    this.numPlayers = numPlayers;
-  }
-
-  public Map<String, String> getSimMods() {
-    return simMods;
-  }
-
-  public void setSimMods(Map<String, String> simMods) {
-    this.simMods = simMods;
-  }
-
-  public Map<String, List<String>> getTeams() {
-    return teams;
-  }
-
-  public void setTeams(Map<String, List<String>> teams) {
-    this.teams = teams;
-  }
-
-  public Map<String, Integer> getFeaturedModVersions() {
-    return featuredModVersions;
-  }
-
-  public void setFeaturedModVersions(Map<String, Integer> featuredModVersions) {
-    this.featuredModVersions = featuredModVersions;
-  }
-
-  public boolean isComplete() {
-    return complete;
-  }
-
-  public void setComplete(boolean complete) {
-    this.complete = complete;
-  }
-
-  public String getRecorder() {
-    return recorder;
-  }
-
-  public void setRecorder(String recorder) {
-    this.recorder = recorder;
-  }
-
-  public Map<String, String> getVersionInfo() {
-    return versionInfo;
-  }
-
-  public void setVersionInfo(Map<String, String> versionInfo) {
-    this.versionInfo = versionInfo;
-  }
-
-  public double getGameEnd() {
-    return gameEnd;
-  }
-
-  public void setGameEnd(double gameEnd) {
-    this.gameEnd = gameEnd;
-  }
-
-  /**
-   * Backwards compatibility: If 0.0, then {@code launchedAt} should be available instead.
-   */
-  public double getGameTime() {
-    return gameTime;
-  }
-
-  public void setGameTime(double gameTime) {
-    this.gameTime = gameTime;
-  }
-
-  /**
-   * Backwards compatibility: If 0.0, then {@code gameTime} should be available instead.
-   */
-  public double getLaunchedAt() {
-    return launchedAt;
-  }
-
-  public void setLaunchedAt(double launchedAt) {
-    this.launchedAt = launchedAt;
   }
 }

--- a/src/main/java/com/faforever/client/replay/OnlineReplayVaultController.java
+++ b/src/main/java/com/faforever/client/replay/OnlineReplayVaultController.java
@@ -7,7 +7,9 @@ import com.faforever.client.i18n.I18n;
 import com.faforever.client.main.event.NavigateEvent;
 import com.faforever.client.main.event.ShowReplayEvent;
 import com.faforever.client.notification.ImmediateErrorNotification;
+import com.faforever.client.notification.ImmediateNotification;
 import com.faforever.client.notification.NotificationService;
+import com.faforever.client.notification.Severity;
 import com.faforever.client.preferences.PreferencesService;
 import com.faforever.client.query.SearchablePropertyMappings;
 import com.faforever.client.reporting.ReportingService;
@@ -159,7 +161,7 @@ public class OnlineReplayVaultController extends AbstractViewController<Node> {
           @Override
           public void changed(ObservableValue<? extends State> observable, State oldValue, State newValue) {
             if (newValue != State.UNINITIALIZED) {
-              Platform.runLater(() -> onShowReplayDetail(((ShowReplayEvent) navigateEvent).getReplay()));
+              onShowReplayEvent((ShowReplayEvent) navigateEvent);
               state.removeListener(this);
             }
           }
@@ -169,8 +171,19 @@ public class OnlineReplayVaultController extends AbstractViewController<Node> {
       return;
     }
     if (navigateEvent instanceof ShowReplayEvent) {
-      onShowReplayDetail(((ShowReplayEvent) navigateEvent).getReplay());
+      onShowReplayEvent((ShowReplayEvent) navigateEvent);
     }
+  }
+
+  private void onShowReplayEvent(ShowReplayEvent event) {
+    int replayId = event.getReplayId();
+    replayService.findById(replayId).thenAccept(replay -> {
+      if (replay.isPresent()) {
+        Platform.runLater(() -> onShowReplayDetail(replay.get()));
+      } else {
+        notificationService.addNotification(new ImmediateNotification(i18n.get("replay.notFoundTitle"), i18n.get("replay.replayNotFoundText", replayId), Severity.WARN));
+      }
+    });
   }
 
   @Override

--- a/src/main/java/com/faforever/client/replay/ReplayServer.java
+++ b/src/main/java/com/faforever/client/replay/ReplayServer.java
@@ -1,10 +1,13 @@
 package com.faforever.client.replay;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
+
+import com.faforever.client.game.Game;
 
 public interface ReplayServer {
 
   void stop();
 
-  CompletableFuture<Integer> start(int gameId);
+  CompletableFuture<Integer> start(int gameId, Supplier<Game> onGameInfoFinished);
 }

--- a/src/main/java/com/faforever/client/replay/ReplayServerImpl.java
+++ b/src/main/java/com/faforever/client/replay/ReplayServerImpl.java
@@ -181,7 +181,6 @@ public class ReplayServerImpl implements ReplayServer {
   }
 
   private void finishReplayInfo(Supplier<Game> onGameInfoFinished) {
-    // game needs to running or finished
     Game game = onGameInfoFinished.get();
 
     replayInfo.updateFromGameInfoBean(game);

--- a/src/main/java/com/faforever/client/replay/ReplayServerImpl.java
+++ b/src/main/java/com/faforever/client/replay/ReplayServerImpl.java
@@ -2,7 +2,6 @@ package com.faforever.client.replay;
 
 import com.faforever.client.config.ClientProperties;
 import com.faforever.client.game.Game;
-import com.faforever.client.game.GameService;
 import com.faforever.client.i18n.I18n;
 import com.faforever.client.notification.Action;
 import com.faforever.client.notification.NotificationService;
@@ -30,6 +29,7 @@ import java.net.SocketException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
 
 import static com.github.nocatch.NoCatch.noCatch;
 
@@ -54,7 +54,6 @@ public class ReplayServerImpl implements ReplayServer {
   private final ClientProperties clientProperties;
   private final NotificationService notificationService;
   private final I18n i18n;
-  private final GameService gameService;
   private final UserService userService;
   private final ReplayFileWriter replayFileWriter;
   private final ClientUpdateService clientUpdateService;
@@ -65,12 +64,10 @@ public class ReplayServerImpl implements ReplayServer {
 
   @Inject
   public ReplayServerImpl(ClientProperties clientProperties, NotificationService notificationService, I18n i18n,
-                          GameService gameService, UserService userService, ReplayFileWriter replayFileWriter,
-                          ClientUpdateService clientUpdateService) {
+                          UserService userService, ReplayFileWriter replayFileWriter, ClientUpdateService clientUpdateService) {
     this.clientProperties = clientProperties;
     this.notificationService = notificationService;
     this.i18n = i18n;
-    this.gameService = gameService;
     this.userService = userService;
     this.replayFileWriter = replayFileWriter;
     this.clientUpdateService = clientUpdateService;
@@ -93,7 +90,7 @@ public class ReplayServerImpl implements ReplayServer {
   }
 
   @Override
-  public CompletableFuture<Integer> start(int gameId) {
+  public CompletableFuture<Integer> start(int gameId, Supplier<Game> onGameInfoFinished) {
     stoppedGracefully = false;
     CompletableFuture<Integer> future = new CompletableFuture<>();
     new Thread(() -> {
@@ -109,11 +106,11 @@ public class ReplayServerImpl implements ReplayServer {
 
         try (Socket remoteReplayServerSocket = new Socket(remoteReplayServerHost, remoteReplayServerPort);
              DataOutputStream fafReplayOutputStream = new DataOutputStream(remoteReplayServerSocket.getOutputStream())) {
-          recordAndRelay(gameId, localSocket, fafReplayOutputStream);
+          recordAndRelay(gameId, localSocket, fafReplayOutputStream, onGameInfoFinished);
         } catch (ConnectException e) {
           log.warn("Could not connect to remote replay server", e);
           notificationService.addNotification(new PersistentNotification(i18n.get("replayServer.unreachable"), Severity.WARN));
-          recordAndRelay(gameId, localSocket, null);
+          recordAndRelay(gameId, localSocket, null, onGameInfoFinished);
         }
       } catch (IOException e) {
         if (stoppedGracefully) {
@@ -123,7 +120,7 @@ public class ReplayServerImpl implements ReplayServer {
         log.warn("Error in replay server", e);
         notificationService.addNotification(new PersistentNotification(
             i18n.get("replayServer.listeningFailed"),
-            Severity.WARN, Collections.singletonList(new Action(i18n.get("replayServer.retry"), event -> start(gameId)))
+            Severity.WARN, Collections.singletonList(new Action(i18n.get("replayServer.retry"), event -> start(gameId, onGameInfoFinished)))
         ));
       }
     }).start();
@@ -143,7 +140,7 @@ public class ReplayServerImpl implements ReplayServer {
   /**
    * @param fafReplayOutputStream if {@code null}, the replay won't be relayed
    */
-  private void recordAndRelay(int uid, ServerSocket serverSocket, @Nullable OutputStream fafReplayOutputStream) throws IOException {
+  private void recordAndRelay(int uid, ServerSocket serverSocket, @Nullable OutputStream fafReplayOutputStream, Supplier<Game> onGameInfoFinished) throws IOException {
     Socket socket = serverSocket.accept();
     log.debug("Accepted connection from {}", socket.getRemoteSocketAddress());
 
@@ -179,12 +176,13 @@ public class ReplayServerImpl implements ReplayServer {
     }
 
     log.debug("FAF has disconnected, writing replay data to file");
-    finishReplayInfo();
+    finishReplayInfo(onGameInfoFinished);
     replayFileWriter.writeReplayDataToFile(replayData, replayInfo);
   }
 
-  private void finishReplayInfo() {
-    Game game = gameService.getByUid(replayInfo.getUid());
+  private void finishReplayInfo(Supplier<Game> onGameInfoFinished) {
+    // game needs to running or finished
+    Game game = onGameInfoFinished.get();
 
     replayInfo.updateFromGameInfoBean(game);
     replayInfo.setGameEnd(pythonTime());

--- a/src/main/java/com/faforever/client/replay/ReplayService.java
+++ b/src/main/java/com/faforever/client/replay/ReplayService.java
@@ -107,7 +107,6 @@ public class ReplayService {
   private final ReportingService reportingService;
   private final ApplicationContext applicationContext;
   private final PlatformService platformService;
-  private final ReplayServer replayServer;
   private final FafService fafService;
   private final ModService modService;
   private final MapService mapService;
@@ -117,7 +116,7 @@ public class ReplayService {
                        ReplayFileReader replayFileReader, NotificationService notificationService,
                        GameService gameService, TaskService taskService, I18n i18n,
                        ReportingService reportingService, ApplicationContext applicationContext,
-                       PlatformService platformService, ReplayServer replayServer, FafService fafService,
+                       PlatformService platformService, FafService fafService,
                        ModService modService, MapService mapService) {
     this.clientProperties = clientProperties;
     this.preferencesService = preferencesService;
@@ -129,7 +128,6 @@ public class ReplayService {
     this.reportingService = reportingService;
     this.applicationContext = applicationContext;
     this.platformService = platformService;
-    this.replayServer = replayServer;
     this.fafService = fafService;
     this.modService = modService;
     this.mapService = mapService;
@@ -287,16 +285,6 @@ public class ReplayService {
   }
 
 
-  public CompletableFuture<Integer> startReplayServer(int gameUid) {
-    return replayServer.start(gameUid);
-  }
-
-
-  public void stopReplayServer() {
-    replayServer.stop();
-  }
-
-
   public void runReplay(Integer replayId) {
     runOnlineReplay(replayId);
   }
@@ -319,7 +307,6 @@ public class ReplayService {
 
   public CompletableFuture<Optional<Replay>> findById(int id) {
     return fafService.findReplayById(id);
-
   }
 
 
@@ -360,7 +347,6 @@ public class ReplayService {
   }
 
   @SneakyThrows
-
   public void runReplayFile(Path path) {
     log.debug("Starting replay file: {}", path.toAbsolutePath());
 

--- a/src/test/java/com/faforever/client/fx/BrowserCallbackTest.java
+++ b/src/test/java/com/faforever/client/fx/BrowserCallbackTest.java
@@ -6,10 +6,8 @@ import com.faforever.client.config.ClientProperties;
 import com.faforever.client.config.ClientProperties.Vault;
 import com.faforever.client.i18n.I18n;
 import com.faforever.client.main.event.ShowReplayEvent;
-import com.faforever.client.notification.ImmediateNotification;
 import com.faforever.client.notification.NotificationService;
 import com.faforever.client.player.PlayerService;
-import com.faforever.client.replay.Replay;
 import com.faforever.client.replay.ReplayService;
 import com.faforever.client.test.AbstractPlainJavaFxTest;
 import com.faforever.client.theme.UiService;
@@ -19,13 +17,8 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.testfx.util.WaitForAsyncUtils;
 
-import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
-
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 public class BrowserCallbackTest extends AbstractPlainJavaFxTest {
   private BrowserCallback instance;
@@ -59,8 +52,6 @@ public class BrowserCallbackTest extends AbstractPlainJavaFxTest {
 
   @Test
   public void testOpenReplayUrl() {
-    Replay replay = new Replay();
-    when(replayService.findById(12)).thenReturn(CompletableFuture.completedFuture(Optional.of(replay)));
     instance.openUrl("replayId=12");
     WaitForAsyncUtils.waitForFxEvents();
     verify(eventBus).post(any(ShowReplayEvent.class));

--- a/src/test/java/com/faforever/client/fx/BrowserCallbackTest.java
+++ b/src/test/java/com/faforever/client/fx/BrowserCallbackTest.java
@@ -58,15 +58,6 @@ public class BrowserCallbackTest extends AbstractPlainJavaFxTest {
   }
 
   @Test
-  public void testOpenReplayUrlForUnknownReplay() {
-    when(i18n.get(anyString())).thenReturn("value for key");
-    when(replayService.findById(12)).thenReturn(CompletableFuture.completedFuture(Optional.empty()));
-    instance.openUrl("replayId=12");
-    WaitForAsyncUtils.waitForFxEvents();
-    verify(notificationService).addNotification(any(ImmediateNotification.class));
-  }
-
-  @Test
   public void testOpenReplayUrl() {
     Replay replay = new Replay();
     when(replayService.findById(12)).thenReturn(CompletableFuture.completedFuture(Optional.of(replay)));

--- a/src/test/java/com/faforever/client/replay/ReplayServiceTest.java
+++ b/src/test/java/com/faforever/client/replay/ReplayServiceTest.java
@@ -119,8 +119,6 @@ public class ReplayServiceTest {
   @Mock
   private PlatformService platformService;
   @Mock
-  private ReplayServer replayServer;
-  @Mock
   private ModService modService;
   @Mock
   private MapService mapService;
@@ -130,7 +128,7 @@ public class ReplayServiceTest {
     MockitoAnnotations.initMocks(this);
 
     instance = new ReplayService(new ClientProperties(), preferencesService, replayFileReader, notificationService, gameService,
-        taskService, i18n, reportingService, applicationContext, platformService, replayServer, fafService, modService, mapService);
+        taskService, i18n, reportingService, applicationContext, platformService, fafService, modService, mapService);
 
     when(preferencesService.getReplaysDirectory()).thenReturn(replayDirectory.getRoot().toPath());
     when(preferencesService.getCorruptedReplaysDirectory()).thenReturn(replayDirectory.getRoot().toPath().resolve("corrupt"));


### PR DESCRIPTION
**Makes installers work again.**
Split ReplayService:
- `ReplayFileService` for the important stuff that has to do with handling replay files and starting replays; maybe this name should be changed back to `ReplayService`
- `ReplayRemoteService`; i really don't know why these 1-line-methods even need to exist if they just wrap `ReplayServer` and `FafService` but ok, the `GameService` just wanted to use these.

Untangle ReplayServer / GameService

Fixes #1396 