### PR TITLE
Properly encode URLs for all jackson objects

### DIFF
--- a/src/main/java/com/faforever/client/config/JacksonConfig.java
+++ b/src/main/java/com/faforever/client/config/JacksonConfig.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.google.common.annotations.VisibleForTesting;
+
 import org.apache.maven.artifact.versioning.ComparableVersion;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -33,7 +35,8 @@ public class JacksonConfig {
     }
   }
 
-  private static class UrlDeserializer extends JsonDeserializer<URL> {
+  @VisibleForTesting
+  static class UrlDeserializer extends JsonDeserializer<URL> {
 
     @Override
     public URL deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {

--- a/src/main/java/com/faforever/client/config/JacksonConfig.java
+++ b/src/main/java/com/faforever/client/config/JacksonConfig.java
@@ -10,6 +10,9 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
 
 @Configuration
 public class JacksonConfig {
@@ -18,6 +21,7 @@ public class JacksonConfig {
   public Module customDeserializers() {
     SimpleModule fafModule = new SimpleModule();
     fafModule.addDeserializer(ComparableVersion.class, new ComparableVersionDeserializer());
+    fafModule.addDeserializer(URL.class, new UrlDeserializer());
     return fafModule;
   }
 
@@ -26,6 +30,21 @@ public class JacksonConfig {
     @Override
     public ComparableVersion deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
       return new ComparableVersion(p.getValueAsString());
+    }
+  }
+
+  private static class UrlDeserializer extends JsonDeserializer<URL> {
+
+    @Override
+    public URL deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+      // the default URL parsing is bad, see https://stackoverflow.com/questions/10786042/java-url-encoding-of-query-string-parameters
+      URL url = new URL(p.getValueAsString());
+      try {
+        URI uri = new URI(url.getProtocol(), url.getUserInfo(), url.getHost(), url.getPort(), url.getPath(), url.getQuery(), url.getRef());
+        return uri.toURL();
+      } catch (URISyntaxException e) {
+        throw new IOException("Could not parse URL!", e);
+      }
     }
   }
 }

--- a/src/test/java/com/faforever/client/config/JacksonConfigTest.java
+++ b/src/test/java/com/faforever/client/config/JacksonConfigTest.java
@@ -1,0 +1,33 @@
+package com.faforever.client.config;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.net.URL;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.faforever.client.config.JacksonConfig.UrlDeserializer;
+import com.fasterxml.jackson.core.JsonParser;
+
+@RunWith(MockitoJUnitRunner.class)
+public class JacksonConfigTest {
+
+  @Mock
+  JsonParser parser;
+
+  @Test
+  public void testUrlDeserializer() throws IOException {
+    String urlOriginal = "http://www.foo.bar/path with space/test?foo=arg with space&bar=baz";
+    String urlEncoded = "http://www.foo.bar/path%20with%20space/test?foo=arg%20with%20space&bar=baz";
+    
+    UrlDeserializer deserializer = new UrlDeserializer();
+    Mockito.when(parser.getValueAsString()).thenReturn(urlOriginal);
+    URL result = deserializer.deserialize(parser, null);
+    assertEquals(urlEncoded, result.toString());
+  }
+}


### PR DESCRIPTION
Applies some stackoverflow magic to fix all jackson conversion from json string to URL object.

Fixes #1373