### PR TITLE
Write to an advanced log (LOGBACK)

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,2 @@
+# Default ignored files
+/shelf/

--- a/src/main/java/com/faforever/client/fa/relay/ice/IceAdapterImpl.java
+++ b/src/main/java/com/faforever/client/fa/relay/ice/IceAdapterImpl.java
@@ -37,7 +37,6 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.SocketUtils;
 
 import javax.inject.Inject;
-import java.io.PrintWriter;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.net.ConnectException;
@@ -60,7 +59,6 @@ public class IceAdapterImpl implements IceAdapter, InitializingBean, DisposableB
 
   private static final int CONNECTION_ATTEMPTS = 50;
   private static final int CONNECTION_ATTEMPT_DELAY_MILLIS = 100;
-//  public static final String ADVANCED_ICE_ADAPTER_LOG_FORMAT = "Advanced Ice Adapter Log_%s.log";
 
   private static final Logger log = LoggerFactory.getLogger("faf-ice-adapter");
   private static final Logger advancedLogger = LoggerFactory.getLogger("faf-ice-adapter-advanced");
@@ -77,7 +75,6 @@ public class IceAdapterImpl implements IceAdapter, InitializingBean, DisposableB
   private Process process;
   private LobbyMode lobbyInitMode;
   private JJsonPeer peer;
-  private PrintWriter advancedIceLogPrinter;
 
   @Inject
   public IceAdapterImpl(ApplicationContext applicationContext, ClientProperties clientProperties, PlayerService playerService,
@@ -312,10 +309,5 @@ public class IceAdapterImpl implements IceAdapter, InitializingBean, DisposableB
   public void stop() {
     Optional.ofNullable(iceAdapterProxy).ifPresent(IceAdapterApi::quit);
     peer = null;
-    if (advancedIceLogPrinter != null) {
-      advancedIceLogPrinter.flush();
-      advancedIceLogPrinter.close();
-      advancedIceLogPrinter = null;
-    }
   }
 }

--- a/src/main/java/com/faforever/client/fa/relay/ice/IceAdapterImpl.java
+++ b/src/main/java/com/faforever/client/fa/relay/ice/IceAdapterImpl.java
@@ -28,7 +28,6 @@ import com.nbarraille.jjsonrpc.JJsonPeer;
 import com.nbarraille.jjsonrpc.TcpClient;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.DisposableBean;
@@ -204,10 +203,21 @@ public class IceAdapterImpl implements IceAdapter, InitializingBean, DisposableB
         processBuilder.environment().put("LOG_DIR", preferencesService.getIceAdapterLogDirectory().toAbsolutePath().toString());
 
         log.info("Starting ICE adapter with command: {}", cmd);
-        advancedLogger.debug("\n\n");
+        boolean advancedIceLogEnabled = preferencesService.getPreferences().isAdvancedIceLogEnabled();
+        if (advancedIceLogEnabled) {
+          advancedLogger.info("\n\n");
+        }
         process = processBuilder.start();
-        OsUtils.gobbleLines(process.getInputStream(), s -> advancedLogger.debug(s));
-        OsUtils.gobbleLines(process.getErrorStream(), s -> advancedLogger.debug(s));
+        OsUtils.gobbleLines(process.getInputStream(), msg -> {
+          if (advancedIceLogEnabled) {
+            advancedLogger.info(msg);
+          }
+        });
+        OsUtils.gobbleLines(process.getErrorStream(), msg -> {
+          if (advancedIceLogEnabled) {
+            advancedLogger.error(msg);
+          }
+        });
 
         IceAdapterCallbacks iceAdapterCallbacks = applicationContext.getBean(IceAdapterCallbacks.class);
 

--- a/src/main/java/com/faforever/client/fa/relay/ice/IceAdapterImpl.java
+++ b/src/main/java/com/faforever/client/fa/relay/ice/IceAdapterImpl.java
@@ -213,13 +213,13 @@ public class IceAdapterImpl implements IceAdapter, InitializingBean, DisposableB
         processBuilder.command(cmd);
         processBuilder.environment().put("LOG_DIR", preferencesService.getIceAdapterLogDirectory().toAbsolutePath().toString());
 
-        advancedLogger.info(String.format("\n\n\nStarting ICE adapter with command: %s", cmd));
+        advancedLogger.info("\n\n\nStarting ICE adapter with command: {}", cmd);
         log.debug("Starting ICE adapter with command: {}", cmd);
         process = processBuilder.start();
         // Why does this logger even exist in addition to normal logger and advanced logger?
         Logger logger = LoggerFactory.getLogger("faf-ice-adapter");
-        OsUtils.gobbleLines(process.getInputStream(), s -> advancedLogger.debug(s));
-        OsUtils.gobbleLines(process.getErrorStream(), s -> advancedLogger.warn(s));
+        OsUtils.gobbleLines(process.getInputStream(), s -> advancedLogger.debug("STDOUT: " + s));
+        OsUtils.gobbleLines(process.getErrorStream(), s -> advancedLogger.debug("STDERR: " + s));
 
         IceAdapterCallbacks iceAdapterCallbacks = applicationContext.getBean(IceAdapterCallbacks.class);
 
@@ -248,8 +248,11 @@ public class IceAdapterImpl implements IceAdapter, InitializingBean, DisposableB
         int exitCode = process.waitFor();
         if (exitCode == 0) {
           logger.debug("ICE adapter terminated normally");
+          advancedLogger.info("ICE adapter terminated normally");
         } else {
           logger.warn("ICE adapter terminated with exit code: {}", exitCode);
+          advancedLogger.warn("ICE adapter terminated normally");
+          // we could remove this duplication everywhere by having the normal logger of this class log to advanced ice log as well
         }
       } catch (Exception e) {
         iceAdapterClientFuture.completeExceptionally(e);

--- a/src/main/java/com/faforever/client/fa/relay/ice/IceAdapterImpl.java
+++ b/src/main/java/com/faforever/client/fa/relay/ice/IceAdapterImpl.java
@@ -27,6 +27,8 @@ import com.google.common.eventbus.Subscribe;
 import com.nbarraille.jjsonrpc.JJsonPeer;
 import com.nbarraille.jjsonrpc.TcpClient;
 import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.DisposableBean;
@@ -55,12 +57,12 @@ import static java.util.Arrays.asList;
 
 @Component
 @Lazy
+@Slf4j
 public class IceAdapterImpl implements IceAdapter, InitializingBean, DisposableBean {
 
   private static final int CONNECTION_ATTEMPTS = 50;
   private static final int CONNECTION_ATTEMPT_DELAY_MILLIS = 100;
 
-  private static final Logger log = LoggerFactory.getLogger("faf-ice-adapter");
   private static final Logger advancedLogger = LoggerFactory.getLogger("faf-ice-adapter-advanced");
 
   private final ApplicationContext applicationContext;
@@ -202,9 +204,10 @@ public class IceAdapterImpl implements IceAdapter, InitializingBean, DisposableB
         processBuilder.environment().put("LOG_DIR", preferencesService.getIceAdapterLogDirectory().toAbsolutePath().toString());
 
         log.info("Starting ICE adapter with command: {}", cmd);
+        advancedLogger.debug("\n\n");
         process = processBuilder.start();
-        OsUtils.gobbleLines(process.getInputStream(), s -> advancedLogger.debug("  STDOUT <- " + s));
-        OsUtils.gobbleLines(process.getErrorStream(), s -> advancedLogger.debug("  STDERR <- " + s));
+        OsUtils.gobbleLines(process.getInputStream(), s -> advancedLogger.debug(s));
+        OsUtils.gobbleLines(process.getErrorStream(), s -> advancedLogger.debug(s));
 
         IceAdapterCallbacks iceAdapterCallbacks = applicationContext.getBean(IceAdapterCallbacks.class);
 

--- a/src/main/java/com/faforever/client/preferences/Preferences.java
+++ b/src/main/java/com/faforever/client/preferences/Preferences.java
@@ -59,6 +59,7 @@ public class Preferences {
   private final BooleanProperty lastGameOnlyFriends;
   private final BooleanProperty disallowJoinsViaDiscord;
   private final BooleanProperty showGameDetailsSidePane;
+  private final BooleanProperty advancedIceLogEnabled;
 
   public Preferences() {
     gameTileSortingOrder = new SimpleObjectProperty<>(TilesSortingOrder.PLAYER_DES);
@@ -90,6 +91,7 @@ public class Preferences {
     lastGameOnlyFriends = new SimpleBooleanProperty();
     disallowJoinsViaDiscord = new SimpleBooleanProperty();
     showGameDetailsSidePane = new SimpleBooleanProperty(false);
+    advancedIceLogEnabled = new SimpleBooleanProperty(false);
   }
 
   public VaultPrefs getVaultPrefs() {
@@ -311,6 +313,18 @@ public class Preferences {
 
   public void setShowGameDetailsSidePane(boolean showGameDetailsSidePane) {
     this.showGameDetailsSidePane.set(showGameDetailsSidePane);
+  }
+
+  public boolean isAdvancedIceLogEnabled() {
+    return advancedIceLogEnabled.get();
+  }
+
+  public void setAdvancedIceLogEnabled(boolean advancedIceLogEnabled) {
+    this.advancedIceLogEnabled.set(advancedIceLogEnabled);
+  }
+
+  public BooleanProperty advancedIceLogEnabledProperty() {
+    return advancedIceLogEnabled;
   }
 
   public BooleanProperty showGameDetailsSidePaneProperty() {

--- a/src/main/java/com/faforever/client/preferences/PreferencesService.java
+++ b/src/main/java/com/faforever/client/preferences/PreferencesService.java
@@ -87,6 +87,13 @@ public class PreferencesService implements InitializingBean {
         .resolve("logs")
         .resolve("downlords-faf-client.log")
         .toString());
+    // duplicated, see getFafLogDirectory; make getFafLogDirectory or log dir static?
+    
+    System.setProperty("ICE_ADVANCED_LOG", PreferencesService.FAF_DATA_DIRECTORY
+        .resolve("logs/iceAdapterLogs")
+        .resolve("advanced-ice-adapter.log")
+        .toString());
+    // duplicated, see getIceAdapterLogDirectory; make getIceAdapterLogDirectory or ice log dir static?
 
     SLF4JBridgeHandler.removeHandlersForRootLogger();
     SLF4JBridgeHandler.install();

--- a/src/main/java/com/faforever/client/preferences/PreferencesService.java
+++ b/src/main/java/com/faforever/client/preferences/PreferencesService.java
@@ -180,6 +180,10 @@ public class PreferencesService implements InitializingBean {
     return FAF_DATA_DIRECTORY;
   }
 
+  public Path getIceAdapterLogDirectory() {
+    return getFafLogDirectory().resolve("iceAdapterLogs");
+  }
+
   /**
    * This is the fall back location for the vault, it is set when for some reasons the game can not find the files in
    * the "My Documents" folder.

--- a/src/main/java/com/faforever/client/preferences/ui/SettingsController.java
+++ b/src/main/java/com/faforever/client/preferences/ui/SettingsController.java
@@ -27,8 +27,6 @@ import com.faforever.client.ui.preferences.event.GameDirectoryChooseEvent;
 import com.faforever.client.user.UserService;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.eventbus.EventBus;
-import com.jfoenix.controls.JFXTextField;
-import com.jfoenix.controls.JFXToggleButton;
 import javafx.application.Platform;
 import javafx.beans.InvalidationListener;
 import javafx.beans.WeakInvalidationListener;
@@ -38,7 +36,6 @@ import javafx.beans.value.WeakChangeListener;
 import javafx.collections.FXCollections;
 import javafx.event.ActionEvent;
 import javafx.geometry.Bounds;
-import javafx.event.ActionEvent;
 import javafx.scene.Node;
 import javafx.scene.control.Button;
 import javafx.scene.control.CheckBox;
@@ -130,10 +127,11 @@ public class SettingsController implements Controller<Node> {
   public ComboBox<UnitDataBaseType> unitDatabaseComboBox;
   public Toggle notifyOnAtMentionOnlyToggle;
   public Pane languagesContainer;
-  public JFXTextField backgroundImageLocation;
+  public TextField backgroundImageLocation;
   public CheckBox disallowJoinsCheckBox;
-  public JFXToggleButton secondaryVaultLocationToggleButton;
+  public ToggleButton secondaryVaultLocationToggleButton;
   public Button autoJoinChannelsButton;
+  public ToggleButton advancedIceLogToggleButton;
   private Popup autojoinChannelsPopUp;
   private ChangeListener<Theme> selectedThemeChangeListener;
   private ChangeListener<Theme> currentThemeChangeListener;
@@ -291,6 +289,8 @@ public class SettingsController implements Controller<Node> {
       Path vaultBaseDirectory = secondaryVaultLocationToggleButton.isSelected() ? preferencesService.getSecondaryVaultLocation() : preferencesService.getPrimaryVaultLocation();
       preferences.getForgedAlliance().setVaultBaseDirectory(vaultBaseDirectory);
     });
+
+    advancedIceLogToggleButton.selectedProperty().bindBidirectional(preferences.advancedIceLogEnabledProperty());
 
     initUnitDatabaseSelection(preferences);
   }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -68,7 +68,6 @@ logging:
     org.springframework.web.client: info
     org.springframework.security.oauth2: info
     org.springframework.security.oauth2.client.token.grant: off
-    faf-ice-adapter: info
 
     org.ice4j.stack: warn
     com.nbarraille.jjsonrpc: warn

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -700,6 +700,7 @@ mapDir.changed.noneAscii=We detected you have a username with special characters
 mapDir.changed.unix=We detected you have a unix system and moved your vault directory to fallback location.
 mapDir.changed.oneDrive=We detected you use OneDrive for your documents and moved your vault directory to fallback location.
 settings.use.secondaryVaultLocation=Use Fallback vault location. You want to use this if map/mod downloading has issues and the game does not find maps/mods.
+settings.use.advancedIceLog=Write an into an extra file advanced information about the ice adapter.
 help.title=Links Overview
 linksTecHelpDiscord=Technical help on Discord
 linksTecHelpForum=Technical help on forum

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -17,7 +17,7 @@
 		<encoder
 			class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
 			<Pattern>
-				%d{dd-MM-yyyy HH:mm:ss.SSS} %-5level - %msg%n
+				%msg%n
 			</Pattern>
 		</encoder>
 		<file>${ICE_ADVANCED_LOG}</file>
@@ -28,13 +28,8 @@
 			<totalSizeCap>30MB</totalSizeCap>
 		</rollingPolicy>
 	</appender>
-	<!-- This logger only logs to FILE_ICE_ADVANCED -->
 	<logger name="faf-ice-adapter-advanced" additivity="false" level="debug">
 		<appender-ref ref="FILE_ICE_ADVANCED" />
-	</logger>
-	<!-- This logger logs to both FILE_ICE_ADVANCED and normal log -->
-	<logger name="faf-ice-adapter">
-    	<appender-ref ref="FILE_ICE_ADVANCED" />
 	</logger>
 
 </configuration>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+	<!-- Client logs -->
+	<include resource="org/springframework/boot/logging/logback/defaults.xml" />
+	<property name="LOG_FILE" value="${LOG_FILE:-${LOG_PATH:-${LOG_TEMP:-${java.io.tmpdir:-/tmp}}}/spring.log}" />
+	<include resource="org/springframework/boot/logging/logback/console-appender.xml" />
+	<include resource="org/springframework/boot/logging/logback/file-appender.xml" />
+	<root level="info">
+		<appender-ref ref="CONSOLE" />
+		<appender-ref ref="FILE" />
+	</root>
+
+	<!-- Advanced ICE logs -->
+	<appender name="FILE_ICE_ADVANCED"
+		class="ch.qos.logback.core.rolling.RollingFileAppender">
+		<encoder
+			class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+			<Pattern>
+				%d{dd-MM-yyyy HH:mm:ss.SSS} - %msg%n
+			</Pattern>
+		</encoder>
+		<file>${ICE_ADVANCED_LOG}</file>
+		<rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+			<cleanHistoryOnStart>true</cleanHistoryOnStart>
+			<fileNamePattern>${ICE_ADVANCED_LOG}.%d{yyyy-MM-dd}.gz}</fileNamePattern>
+			<maxHistory>7</maxHistory>
+			<totalSizeCap>30MB</totalSizeCap>
+		</rollingPolicy>
+	</appender>
+	<logger name="faf-ice-adapter-advanced" additivity="false" level="info">
+		<appender-ref ref="FILE_ICE_ADVANCED" />
+	</logger>
+
+</configuration>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -17,7 +17,7 @@
 		<encoder
 			class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
 			<Pattern>
-				%d{dd-MM-yyyy HH:mm:ss.SSS} - %msg%n
+				%d{dd-MM-yyyy HH:mm:ss.SSS} %-5level - %msg%n
 			</Pattern>
 		</encoder>
 		<file>${ICE_ADVANCED_LOG}</file>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -28,8 +28,13 @@
 			<totalSizeCap>30MB</totalSizeCap>
 		</rollingPolicy>
 	</appender>
-	<logger name="faf-ice-adapter-advanced" additivity="false" level="info">
+	<!-- This logger only logs to FILE_ICE_ADVANCED -->
+	<logger name="faf-ice-adapter-advanced" additivity="false" level="debug">
 		<appender-ref ref="FILE_ICE_ADVANCED" />
+	</logger>
+	<!-- This logger logs to both FILE_ICE_ADVANCED and normal log -->
+	<logger name="faf-ice-adapter">
+    	<appender-ref ref="FILE_ICE_ADVANCED" />
 	</logger>
 
 </configuration>

--- a/src/main/resources/theme/settings/settings.fxml
+++ b/src/main/resources/theme/settings/settings.fxml
@@ -39,6 +39,7 @@
                                 <RowConstraints minHeight="10.0" prefHeight="50.0" vgrow="SOMETIMES"/>
                                 <RowConstraints minHeight="10.0" prefHeight="50.0" vgrow="SOMETIMES"/>
                                 <RowConstraints minHeight="10.0" prefHeight="50.0" vgrow="SOMETIMES"/>
+                                <RowConstraints minHeight="10.0" prefHeight="50.0" vgrow="SOMETIMES"/>
                                 <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="ALWAYS"/>
                             </rowConstraints>
                             <children>
@@ -60,6 +61,10 @@
                                        GridPane.rowIndex="3"/>
                                 <JFXToggleButton fx:id="secondaryVaultLocationToggleButton" GridPane.columnIndex="1"
                                                  GridPane.rowIndex="3"/>
+                                <Label styleClass="h3" text="%settings.use.advancedIceLog" wrapText="true"
+                                       GridPane.rowIndex="4"/>
+                                <JFXToggleButton fx:id="advancedIceLogToggleButton" GridPane.columnIndex="1"
+                                                 GridPane.rowIndex="4"/>
                             </children>
                         </GridPane>
                     </content>


### PR DESCRIPTION
Alternative for #1435 
Fixes #1431 

I have changed bunch of things:
- I reduced number of loggers inside `IceAdapterImpl` from 3 to 2 (a "normal logger" for the class itself called `faf-ice-adapter` and special logger `faf-ice-adapter-advanced`)
- anything that goes into `faf-ice-adapter` also goes into advanced log file (in addition to normal file and console)
- STDOUT and STDERR from ice process only go into `faf-ice-adapter-advanced` and subsequently into advanced log file only

I suggest disabling the advanced log by having a custom filter on the advanced file appender (very easy to implement) which just filters away all lines if advanced log is disabled.


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#1431: Add an option to log stdout and stderr of the adapter](https://issuehunt.io/repos/32919066/issues/1431)
---

IssueHunt has been backed by the following sponsors. [Become a sponsor](https://issuehunt.io/membership/members)
</details>
<!-- /Issuehunt content-->