### PR TITLE
Local replay vault watching/reloading

### DIFF
--- a/src/main/java/com/faforever/client/main/event/LocalReplaysChangedEvent.java
+++ b/src/main/java/com/faforever/client/main/event/LocalReplaysChangedEvent.java
@@ -1,11 +1,11 @@
 package com.faforever.client.main.event;
 
 import com.faforever.client.replay.Replay;
-import lombok.Data;
+import lombok.Value;
 
 import java.util.Collection;
 
-@Data
+@Value
 public class LocalReplaysChangedEvent {
   private final Collection<Replay> newReplays;
   private final Collection<Replay> deletedReplays;

--- a/src/main/java/com/faforever/client/main/event/LocalReplaysChangedEvent.java
+++ b/src/main/java/com/faforever/client/main/event/LocalReplaysChangedEvent.java
@@ -2,12 +2,27 @@ package com.faforever.client.main.event;
 
 import com.faforever.client.replay.Replay;
 import lombok.Value;
+import org.springframework.context.ApplicationEvent;
 
 import java.util.Collection;
 
-@Value
-public class LocalReplaysChangedEvent {
+public class LocalReplaysChangedEvent extends ApplicationEvent {
+
   private final Collection<Replay> newReplays;
   private final Collection<Replay> deletedReplays;
+
+  public LocalReplaysChangedEvent(Object source, Collection<Replay> newReplays, Collection<Replay> deletedReplays) {
+    super(source);
+    this.newReplays = newReplays;
+    this.deletedReplays = deletedReplays;
+  }
+
+  public Collection<Replay> getNewReplays() {
+    return newReplays;
+  }
+
+  public Collection<Replay> getDeletedReplays() {
+    return deletedReplays;
+  }
 }
 

--- a/src/main/java/com/faforever/client/main/event/LocalReplaysChangedEvent.java
+++ b/src/main/java/com/faforever/client/main/event/LocalReplaysChangedEvent.java
@@ -1,0 +1,13 @@
+package com.faforever.client.main.event;
+
+import com.faforever.client.replay.Replay;
+import lombok.Data;
+
+import java.util.Collection;
+
+@Data
+public class LocalReplaysChangedEvent {
+  private final Collection<Replay> newReplays;
+  private final Collection<Replay> deletedReplays;
+}
+

--- a/src/main/java/com/faforever/client/main/event/OpenReplayVaultEvent.java
+++ b/src/main/java/com/faforever/client/main/event/OpenReplayVaultEvent.java
@@ -1,0 +1,7 @@
+package com.faforever.client.main.event;
+
+public class OpenReplayVaultEvent extends NavigateEvent {
+  public OpenReplayVaultEvent() {
+    super(NavigationItem.VAULT);
+  }
+}

--- a/src/main/java/com/faforever/client/replay/LoadLocalReplaysTask.java
+++ b/src/main/java/com/faforever/client/replay/LoadLocalReplaysTask.java
@@ -26,7 +26,6 @@ public class LoadLocalReplaysTask extends CompletableTask<Collection<Replay>> {
   @Override
   protected Collection<Replay> call() throws Exception {
     updateTitle(i18n.get("replays.loadingLocalTask.title"));
-    return replayService.getLocalReplays();
+    return replayService.loadLocalReplays().get();
   }
-
 }

--- a/src/main/java/com/faforever/client/replay/ReplayService.java
+++ b/src/main/java/com/faforever/client/replay/ReplayService.java
@@ -30,7 +30,6 @@ import com.faforever.client.vault.search.SearchController.SortConfig;
 import com.faforever.commons.replay.ReplayData;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Splitter;
-import com.google.common.eventbus.EventBus;
 import com.google.common.net.UrlEscapers;
 import com.google.common.primitives.Bytes;
 import lombok.RequiredArgsConstructor;
@@ -40,6 +39,7 @@ import org.eclipse.jgit.util.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
@@ -125,7 +125,7 @@ public class ReplayService {
   private final FafService fafService;
   private final ModService modService;
   private final MapService mapService;
-  private final EventBus eventBus;
+  private final ApplicationEventPublisher publisher;
   private final ExecutorService executorService;
   private Thread directoryWatcherThread;
   private WatchService watchService;
@@ -141,7 +141,7 @@ public class ReplayService {
     taskService.submitTask(loadLocalReplaysTask).getFuture().thenAccept( replays -> {
       localReplays.clear();
       localReplays.addAll(replays);
-      eventBus.post(new LocalReplaysChangedEvent(replays, new ArrayList<Replay>()));
+      publisher.publishEvent(new LocalReplaysChangedEvent(this, replays, new ArrayList<Replay>()));
     });
 
     try {
@@ -199,7 +199,7 @@ public class ReplayService {
     }
 
     localReplays.addAll(newReplays);
-    eventBus.post(new LocalReplaysChangedEvent(newReplays, deletedReplays));
+    publisher.publishEvent(new LocalReplaysChangedEvent(this, newReplays, deletedReplays));
   }
 
   @VisibleForTesting

--- a/src/main/java/com/faforever/client/replay/ReplayService.java
+++ b/src/main/java/com/faforever/client/replay/ReplayService.java
@@ -150,7 +150,7 @@ public class ReplayService {
       Optional.ofNullable(directoryWatcherThread).ifPresent(Thread::interrupt);
       directoryWatcherThread = startDirectoryWatcher(replaysDirectory);
     } catch (IOException e) {
-      logger.debug("Failed to start watching the local replays directory");
+      logger.warn("Failed to start watching the local replays directory");
     }
   }
 

--- a/src/main/java/com/faforever/client/replay/ReplayService.java
+++ b/src/main/java/com/faforever/client/replay/ReplayService.java
@@ -185,7 +185,11 @@ public class ReplayService {
         tryLoadingLocalReplay(fullPathToReplay)
             .thenAccept(newReplay -> newReplays.add(newReplay));
       } else if (watchEvent.kind() == ENTRY_DELETE) {
-        Optional<Replay> existingReplay = localReplays.stream().filter(replay -> replay.getReplayFile().compareTo(fullPathToReplay) == 0).findFirst();
+        Optional<Replay> existingReplay = localReplays
+            .stream()
+            .filter(replay -> replay.getReplayFile().compareTo(fullPathToReplay) == 0)
+            .findFirst();
+        
         if (existingReplay.isPresent()) {
           Replay deletedReplay = existingReplay.get();
           deletedReplays.add(deletedReplay);

--- a/src/main/java/com/faforever/client/replay/ReplayService.java
+++ b/src/main/java/com/faforever/client/replay/ReplayService.java
@@ -262,7 +262,15 @@ public class ReplayService {
     List<CompletableFuture<Replay>> replayFutures = StreamSupport.stream(directoryStream.spliterator(), false)
         .sorted(Comparator.comparing(path -> noCatch(() -> Files.getLastModifiedTime((Path) path))).reversed())
         .limit(MAX_REPLAYS)
-        .map(replayFile -> noCatch(() -> loadLocalReplay(replayFile)))
+        .map( replayFile -> {
+          try {
+            return loadLocalReplay(replayFile);
+          } catch (Exception e) {
+            // do nothing; notification should already be shown to user
+            return null;
+          }
+        })
+        .filter(replay -> replay != null)
         .collect(Collectors.toList());
 
     CompletableFuture[] replayFuturesArray = replayFutures.toArray(new CompletableFuture[replayFutures.size()]);

--- a/src/main/java/com/faforever/client/replay/ReplayService.java
+++ b/src/main/java/com/faforever/client/replay/ReplayService.java
@@ -272,7 +272,7 @@ public class ReplayService {
             return null;
           }
         })
-        .filter(replay -> replay != null)
+        .filter(Objects::nonNull)
         .collect(Collectors.toList());
 
     CompletableFuture[] replayFuturesArray = replayFutures.toArray(new CompletableFuture[replayFutures.size()]);

--- a/src/main/java/com/faforever/client/replay/ReplayService.java
+++ b/src/main/java/com/faforever/client/replay/ReplayService.java
@@ -134,14 +134,11 @@ public class ReplayService {
   private List<Replay> localReplays = new ArrayList<Replay>();
 
   public void startLoadingAndWatchingLocalReplays() {
-    // TODO: Create task?
-    executorService.execute(() -> {
-      LoadLocalReplaysTask loadLocalReplaysTask = new LoadLocalReplaysTask(this, i18n);
-      taskService.submitTask(loadLocalReplaysTask).getFuture().thenAccept( replays -> {
-        localReplays.clear();
-        localReplays.addAll(replays);
-        eventBus.post(new LocalReplaysChangedEvent(replays, new ArrayList<Replay>()));
-      });
+    LoadLocalReplaysTask loadLocalReplaysTask = applicationContext.getBean(LoadLocalReplaysTask.class);
+    taskService.submitTask(loadLocalReplaysTask).getFuture().thenAccept( replays -> {
+      localReplays.clear();
+      localReplays.addAll(replays);
+      eventBus.post(new LocalReplaysChangedEvent(replays, new ArrayList<Replay>()));
     });
 
     try {
@@ -156,7 +153,7 @@ public class ReplayService {
     return localReplays;
   }
 
-  private Thread startDirectoryWatcher(Path replaysDirectory) throws IOException {
+  protected Thread startDirectoryWatcher(Path replaysDirectory) throws IOException {
     Thread thread = new Thread(() -> noCatch(() -> {
       try (WatchService watcher = replaysDirectory.getFileSystem().newWatchService()) {
         replaysDirectory.register(watcher, ENTRY_CREATE, ENTRY_MODIFY, ENTRY_DELETE);

--- a/src/main/java/com/faforever/client/replay/ReplayService.java
+++ b/src/main/java/com/faforever/client/replay/ReplayService.java
@@ -7,6 +7,8 @@ import com.faforever.client.game.Game;
 import com.faforever.client.game.GameService;
 import com.faforever.client.game.KnownFeaturedMod;
 import com.faforever.client.i18n.I18n;
+import com.faforever.client.main.event.LocalReplaysChangedEvent;
+import com.faforever.client.map.MapBean;
 import com.faforever.client.map.MapService;
 import com.faforever.client.mod.FeaturedMod;
 import com.faforever.client.mod.ModService;
@@ -28,6 +30,7 @@ import com.faforever.client.vault.search.SearchController.SortConfig;
 import com.faforever.commons.replay.ReplayData;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Splitter;
+import com.google.common.eventbus.EventBus;
 import com.google.common.net.UrlEscapers;
 import com.google.common.primitives.Bytes;
 import lombok.RequiredArgsConstructor;
@@ -36,22 +39,30 @@ import lombok.extern.slf4j.Slf4j;
 import org.eclipse.jgit.util.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.InitializingBean;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.ByteArrayInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.RandomAccessFile;
 import java.lang.invoke.MethodHandles;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.channels.FileLock;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchKey;
+import java.nio.file.WatchService;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
@@ -60,21 +71,26 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutorService;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import static com.faforever.client.notification.Severity.WARN;
 import static com.github.nocatch.NoCatch.noCatch;
+import static java.lang.Thread.sleep;
 import static java.net.URLDecoder.decode;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.nio.file.Files.createDirectories;
 import static java.nio.file.Files.move;
+import static java.nio.file.StandardWatchEventKinds.ENTRY_CREATE;
+import static java.nio.file.StandardWatchEventKinds.ENTRY_DELETE;
+import static java.nio.file.StandardWatchEventKinds.ENTRY_MODIFY;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
 import static java.util.Collections.singletonList;
-
 
 @Lazy
 @Service
@@ -111,6 +127,82 @@ public class ReplayService {
   private final FafService fafService;
   private final ModService modService;
   private final MapService mapService;
+  private final EventBus eventBus;
+  private final ExecutorService executorService;
+  private Thread directoryWatcherThread;
+  private WatchService watchService;
+  private List<Replay> localReplays = new ArrayList<Replay>();
+
+  public void startLoadingAndWatchingLocalReplays() {
+    // TODO: Create task?
+    executorService.execute(() -> {
+      loadLocalReplays().thenAccept( replays -> {
+        localReplays.clear();
+        localReplays.addAll(replays);
+        eventBus.post(new LocalReplaysChangedEvent(replays, new ArrayList<Replay>()));
+      });
+    });
+
+    try {
+      Optional.ofNullable(directoryWatcherThread).ifPresent(Thread::interrupt);
+      directoryWatcherThread = startDirectoryWatcher(preferencesService.getReplaysDirectory());
+    } catch (IOException e) {
+      logger.debug("Failed to start watching the local replays directory");
+    }
+  }
+
+  public Collection<Replay> getLocalReplays() {
+    return localReplays;
+  }
+
+  private Thread startDirectoryWatcher(Path replaysDirectory) throws IOException {
+    Thread thread = new Thread(() -> noCatch(() -> {
+      try (WatchService watcher = replaysDirectory.getFileSystem().newWatchService()) {
+        replaysDirectory.register(watcher, ENTRY_CREATE, ENTRY_MODIFY, ENTRY_DELETE);
+        while (!Thread.interrupted()) {
+          WatchKey key = watcher.take();
+          onLocalReplaysWatchEvent(key);
+          key.reset();
+        }
+      } catch (InterruptedException e) {
+        logger.debug("Local replay directory watcher terminated ({})", e.getMessage());
+      }
+    }));
+    thread.setDaemon(true);
+    thread.start();
+    return thread;
+  }
+
+  private void onLocalReplaysWatchEvent(WatchKey key) {
+    Collection<Replay> newReplays = new ArrayList<Replay>();
+    Collection<Replay> deletedReplays = new ArrayList<Replay>();
+    for (WatchEvent<?> watchEvent : key.pollEvents()) {
+      Path path = (Path) watchEvent.context();
+      Path fullPathToReplay = preferencesService.getReplaysDirectory().resolve(path);
+
+      if (watchEvent.kind() == ENTRY_CREATE) {
+        try {
+          loadLocalReplay(fullPathToReplay)
+              .thenAccept(newReplay -> {
+                newReplays.add(newReplay);
+              });
+        } catch (Exception e) {
+          logger.warn("Failed to load local replay file '{}'", path, e);
+        }
+
+      } else if (watchEvent.kind() == ENTRY_DELETE) {
+        Optional<Replay> existingReplay = localReplays.stream().filter(replay -> replay.getReplayFile().compareTo(fullPathToReplay) == 0).findFirst();
+        if (existingReplay.isPresent()) {
+          Replay deletedReplay = existingReplay.get();
+          deletedReplays.add(deletedReplay);
+          localReplays.remove(deletedReplay);
+        }
+      }
+    }
+
+    localReplays.addAll(newReplays);
+    eventBus.post(new LocalReplaysChangedEvent(newReplays, deletedReplays));
+  }
 
   @VisibleForTesting
   static Integer parseSupComVersion(byte[] rawReplayBytes) {
@@ -156,9 +248,8 @@ public class ReplayService {
    * Loads some, but not all, local replays. Loading all local replays could result in OOME.
    */
   @SneakyThrows
-  public Collection<Replay> getLocalReplays() {
-    Collection<Replay> replayInfos = new ArrayList<>();
-
+  @Async
+  private CompletableFuture<Collection<Replay>> loadLocalReplays() {
     String replayFileGlob = clientProperties.getReplay().getReplayFileGlob();
 
     Path replaysDirectory = preferencesService.getReplaysDirectory();
@@ -166,25 +257,42 @@ public class ReplayService {
       noCatch(() -> createDirectories(replaysDirectory));
     }
 
-    try (DirectoryStream<Path> directoryStream = Files.newDirectoryStream(replaysDirectory, replayFileGlob)) {
-      StreamSupport.stream(directoryStream.spliterator(), false)
-          .sorted(Comparator.comparing(path -> noCatch(() -> Files.getLastModifiedTime((Path) path))).reversed())
-          .limit(MAX_REPLAYS)
-          .forEach(replayFile -> {
-            try {
-              LocalReplayInfo replayInfo = replayFileReader.parseMetaData(replayFile);
-              FeaturedMod featuredMod = modService.getFeaturedMod(replayInfo.getFeaturedMod()).get();
+    DirectoryStream<Path> directoryStream = Files.newDirectoryStream(replaysDirectory, replayFileGlob);
+    List<CompletableFuture<Replay>> replayFutures = StreamSupport.stream(directoryStream.spliterator(), false)
+        .sorted(Comparator.comparing(path -> noCatch(() -> Files.getLastModifiedTime((Path) path))).reversed())
+        .limit(MAX_REPLAYS)
+        .map(replayFile -> noCatch(() -> loadLocalReplay(replayFile)))
+        .collect(Collectors.toList());
 
-              mapService.findByMapFolderName(replayInfo.getMapname())
-                  .thenAccept(mapBean -> replayInfos.add(new Replay(replayInfo, replayFile, featuredMod, mapBean.orElse(null))));
-            } catch (Exception e) {
-              logger.warn("Could not read replay file '{}'", replayFile, e);
-              moveCorruptedReplayFile(replayFile);
-            }
-          });
+    CompletableFuture[] replayFuturesArray = replayFutures.toArray(new CompletableFuture[replayFutures.size()]);
+    return CompletableFuture.allOf(replayFuturesArray)
+        .thenApply(ignoredVoid ->
+            replayFutures.stream()
+                .map(future -> future.join())
+                .collect(Collectors.toList()));
+
+  }
+
+  @Async
+  private CompletableFuture<Replay> loadLocalReplay(Path replayFile) throws Exception  {
+    try {
+      LocalReplayInfo replayInfo = replayFileReader.parseMetaData(replayFile);
+
+      CompletableFuture<FeaturedMod> featuredModFuture = modService.getFeaturedMod(replayInfo.getFeaturedMod());
+      CompletableFuture<Optional<MapBean>> mapBeanFuture = mapService.findByMapFolderName(replayInfo.getMapname());
+
+      return CompletableFuture.allOf(featuredModFuture, mapBeanFuture).thenApply(ignoredVoid  -> {
+        Optional<MapBean> mapBean = mapBeanFuture.join();
+        if (!mapBean.isPresent()) {
+          throw new CompletionException(new FileNotFoundException());
+        }
+        return new Replay(replayInfo, replayFile, featuredModFuture.join(), mapBean.get());
+      });
+    } catch (Exception e) {
+      logger.warn("Could not read replay file '{}'", replayFile, e);
+      moveCorruptedReplayFile(replayFile);
+      throw e;
     }
-
-    return replayInfos;
   }
 
   private void moveCorruptedReplayFile(Path replayFile) {

--- a/src/main/java/com/faforever/client/replay/ReplayService.java
+++ b/src/main/java/com/faforever/client/replay/ReplayService.java
@@ -134,6 +134,11 @@ public class ReplayService {
   private List<Replay> localReplays = new ArrayList<Replay>();
 
   public void startLoadingAndWatchingLocalReplays() {
+    Path replaysDirectory = preferencesService.getReplaysDirectory();
+    if (Files.notExists(replaysDirectory)) {
+      noCatch(() -> createDirectories(replaysDirectory));
+    }
+
     LoadLocalReplaysTask loadLocalReplaysTask = applicationContext.getBean(LoadLocalReplaysTask.class);
     taskService.submitTask(loadLocalReplaysTask).getFuture().thenAccept( replays -> {
       localReplays.clear();
@@ -143,7 +148,7 @@ public class ReplayService {
 
     try {
       Optional.ofNullable(directoryWatcherThread).ifPresent(Thread::interrupt);
-      directoryWatcherThread = startDirectoryWatcher(preferencesService.getReplaysDirectory());
+      directoryWatcherThread = startDirectoryWatcher(replaysDirectory);
     } catch (IOException e) {
       logger.debug("Failed to start watching the local replays directory");
     }

--- a/src/main/java/com/faforever/client/replay/ReplayService.java
+++ b/src/main/java/com/faforever/client/replay/ReplayService.java
@@ -136,7 +136,8 @@ public class ReplayService {
   public void startLoadingAndWatchingLocalReplays() {
     // TODO: Create task?
     executorService.execute(() -> {
-      loadLocalReplays().thenAccept( replays -> {
+      LoadLocalReplaysTask loadLocalReplaysTask = new LoadLocalReplaysTask(this, i18n);
+      taskService.submitTask(loadLocalReplaysTask).getFuture().thenAccept( replays -> {
         localReplays.clear();
         localReplays.addAll(replays);
         eventBus.post(new LocalReplaysChangedEvent(replays, new ArrayList<Replay>()));
@@ -249,7 +250,7 @@ public class ReplayService {
    */
   @SneakyThrows
   @Async
-  private CompletableFuture<Collection<Replay>> loadLocalReplays() {
+  public CompletableFuture<Collection<Replay>> loadLocalReplays() {
     String replayFileGlob = clientProperties.getReplay().getReplayFileGlob();
 
     Path replaysDirectory = preferencesService.getReplaysDirectory();

--- a/src/main/java/com/faforever/client/vault/VaultController.java
+++ b/src/main/java/com/faforever/client/vault/VaultController.java
@@ -5,9 +5,11 @@ import com.faforever.client.main.event.NavigateEvent;
 import com.faforever.client.main.event.OpenMapVaultEvent;
 import com.faforever.client.main.event.OpenModVaultEvent;
 import com.faforever.client.main.event.OpenOnlineReplayVaultEvent;
+import com.faforever.client.main.event.OpenReplayVaultEvent;
 import com.faforever.client.map.MapVaultController;
 import com.faforever.client.mod.ModVaultController;
 import com.faforever.client.replay.OnlineReplayVaultController;
+import com.faforever.client.vault.replay.ReplayVaultController;
 import com.google.common.eventbus.EventBus;
 import javafx.scene.Node;
 import javafx.scene.control.Tab;
@@ -29,7 +31,9 @@ public class VaultController extends AbstractViewController<Node> {
   public MapVaultController mapVaultController;
   public ModVaultController modVaultController;
   public OnlineReplayVaultController onlineReplayVaultController;
+  public ReplayVaultController localReplayVaultController;
   public Tab onlineReplayVaultTab;
+  public Tab localReplayVaultTab;
   private boolean isHandlingEvent;
 
   public VaultController(EventBus eventBus) {
@@ -54,6 +58,8 @@ public class VaultController extends AbstractViewController<Node> {
         eventBus.post(new OpenModVaultEvent());
       } else if (newValue == onlineReplayVaultTab) {
         eventBus.post(new OpenOnlineReplayVaultEvent());
+      } else if (newValue == localReplayVaultTab) {
+        eventBus.post(new OpenReplayVaultEvent());
       }
       // TODO implement other tabs
     });
@@ -76,6 +82,10 @@ public class VaultController extends AbstractViewController<Node> {
       if (navigateEvent instanceof OpenOnlineReplayVaultEvent) {
         vaultRoot.getSelectionModel().select(onlineReplayVaultTab);
         onlineReplayVaultController.display(navigateEvent);
+      }
+      if (navigateEvent instanceof OpenReplayVaultEvent) {
+        vaultRoot.getSelectionModel().select(localReplayVaultTab);
+        localReplayVaultController.display(navigateEvent);
       }
     } finally {
       isHandlingEvent = false;

--- a/src/main/java/com/faforever/client/vault/replay/ReplayVaultController.java
+++ b/src/main/java/com/faforever/client/vault/replay/ReplayVaultController.java
@@ -262,27 +262,7 @@ public class ReplayVaultController extends AbstractViewController<Node> {
     replayTableView.setVisible(true);
     loadingPane.setVisible(false);
   }
-
-//  public void loadOnlineReplaysInBackground() {
-//    replayService.getOnlineReplays()
-//        .thenAccept(this::addOnlineReplays)
-//        .exceptionally(throwable -> {
-//          logger.warn("Error while loading online replays", throwable);
-//          notificationService.addNotification(new PersistentNotification(
-//              i18n.valueOf("replays.loadingOnlineTask.failed"),
-//              Severity.ERROR,
-//              Collections.singletonList(new Action(i18n.valueOf("report"), event -> reportingService.reportError(throwable)))
-//          ));
-//          return null;
-//        });
-//  }
-
-//  private void addOnlineReplays(Collection<ReplayInfoBean> result) {
-//    Collection<Item<ReplayInfoBean>> items = result.stream()
-//        .map(Item::new).collect(Collectors.toCollection(ArrayList::new));
-//    Platform.runLater(() -> onlineReplaysRoot.getChildren().addAll(items));
-//  }
-
+  
   public Node getRoot() {
     return replayVaultRoot;
   }

--- a/src/main/java/com/faforever/client/vault/replay/ReplayVaultController.java
+++ b/src/main/java/com/faforever/client/vault/replay/ReplayVaultController.java
@@ -118,14 +118,18 @@ public class ReplayVaultController extends AbstractViewController<Node> {
 
   @Override
   protected void onDisplay(NavigateEvent navigateEvent) {
-    // TODO: Display information that view contents are loading
     if (isDisplayingForFirstTime) {
-      eventBus.register(this);
-      replayService.startLoadingAndWatchingLocalReplays();
+      loadLocalReplaysInBackground();
       isDisplayingForFirstTime = false;
     }
 
     super.onDisplay(navigateEvent);
+  }
+
+  protected void loadLocalReplaysInBackground() {
+    // TODO: Display information that view contents are loading
+    eventBus.register(this);
+    replayService.startLoadingAndWatchingLocalReplays();
   }
 
   @NotNull

--- a/src/main/java/com/faforever/client/vault/replay/ReplayVaultController.java
+++ b/src/main/java/com/faforever/client/vault/replay/ReplayVaultController.java
@@ -15,9 +15,9 @@ import com.faforever.client.task.TaskService;
 import com.faforever.client.theme.UiService;
 import com.faforever.client.util.TimeService;
 import com.faforever.client.vault.map.MapPreviewTableCellController;
+import com.faforever.client.vault.review.Review;
 import com.google.common.base.Joiner;
-import com.google.common.eventbus.EventBus;
-import com.google.common.eventbus.Subscribe;
+import javafx.application.Platform;
 import javafx.beans.binding.StringBinding;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.value.ObservableValue;
@@ -39,7 +39,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationListener;
 import org.springframework.context.annotation.Scope;
+import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
 import java.lang.invoke.MethodHandles;
@@ -51,10 +53,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
-import static java.util.Arrays.setAll;
-
 @Component
-@Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
 @RequiredArgsConstructor
 // TODO reduce dependencies
 public class ReplayVaultController extends AbstractViewController<Node> {
@@ -69,7 +68,6 @@ public class ReplayVaultController extends AbstractViewController<Node> {
   private final ReportingService reportingService;
   private final ApplicationContext applicationContext;
   private final UiService uiService;
-  private final EventBus eventBus;
 
   public Pane replayVaultRoot;
   public VBox loadingPane;
@@ -122,7 +120,6 @@ public class ReplayVaultController extends AbstractViewController<Node> {
   }
 
   protected void loadLocalReplaysInBackground() {
-    eventBus.register(this);
     replayService.startLoadingAndWatchingLocalReplays();
   }
 
@@ -252,7 +249,7 @@ public class ReplayVaultController extends AbstractViewController<Node> {
     return new SimpleObjectProperty<>(Duration.between(startTime, endTime));
   }
 
-  @Subscribe
+  @EventListener
   public void onLocalReplaysChanged(LocalReplaysChangedEvent event) {
     Collection<Replay> newReplays = event.getNewReplays();
     Collection<Replay> deletedReplays = event.getDeletedReplays();

--- a/src/main/java/com/faforever/client/vault/replay/ReplayVaultController.java
+++ b/src/main/java/com/faforever/client/vault/replay/ReplayVaultController.java
@@ -1,7 +1,9 @@
 package com.faforever.client.vault.replay;
 
+import com.faforever.client.fx.AbstractViewController;
 import com.faforever.client.fx.Controller;
 import com.faforever.client.i18n.I18n;
+import com.faforever.client.main.event.NavigateEvent;
 import com.faforever.client.map.MapBean;
 import com.faforever.client.map.MapService;
 import com.faforever.client.map.MapService.PreviewSize;
@@ -58,7 +60,7 @@ import static java.util.Arrays.asList;
 @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
 @RequiredArgsConstructor
 // TODO reduce dependencies
-public class ReplayVaultController implements Controller<Node> {
+public class ReplayVaultController extends AbstractViewController<Node> {
 
   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
   private final NotificationService notificationService;
@@ -106,6 +108,11 @@ public class ReplayVaultController implements Controller<Node> {
     durationColumn.setCellFactory(this::durationCellFactory);
 
     loadLocalReplaysInBackground();
+  }
+
+  @Override
+  protected void onDisplay(NavigateEvent navigateEvent) {
+    super.onDisplay(navigateEvent);
   }
 
   @NotNull

--- a/src/main/resources/theme/vault/replay/replay_vault.fxml
+++ b/src/main/resources/theme/vault/replay/replay_vault.fxml
@@ -2,19 +2,36 @@
 
 <?import javafx.scene.control.TableColumn?>
 <?import javafx.scene.control.TableView?>
-<TableView xmlns:fx="http://javafx.com/fxml/1" fx:id="replayVaultRoot" prefHeight="200.0" prefWidth="200.0"
-           xmlns="http://javafx.com/javafx/8.0.40"
+<?import com.jfoenix.controls.JFXSpinner?>
+<?import javafx.scene.layout.StackPane?>
+<?import javafx.scene.layout.VBox?>
+<?import javafx.scene.control.Label?>
+<StackPane xmlns:fx="http://javafx.com/fxml/1" fx:id="replayVaultRoot" xmlns="http://javafx.com/javafx/8.0.111"
            fx:controller="com.faforever.client.vault.replay.ReplayVaultController">
-  <columns>
-      <TableColumn fx:id="mapColumn" prefWidth="75.0" text="%game.map"/>
-      <TableColumn fx:id="titleColumn" prefWidth="75.0" text="%game.title"/>
-      <TableColumn fx:id="playersColumn" prefWidth="75.0" text="%game.players"/>
-      <TableColumn fx:id="timeColumn" prefWidth="75.0" text="%game.time"/>
-      <TableColumn fx:id="durationColumn" prefWidth="75.0" text="%game.duration"/>
-      <TableColumn fx:id="gameTypeColumn" prefWidth="75.0" text="%game.gameType"/>
-      <TableColumn fx:id="idColumn" prefWidth="75.0" text="%game.id"/>
-  </columns>
-  <columnResizePolicy>
-      <TableView fx:constant="CONSTRAINED_RESIZE_POLICY"/>
-  </columnResizePolicy>
-</TableView>
+    <children>
+        <TableView fx:id="replayTableView" prefHeight="200.0" prefWidth="200.0">
+            <columns>
+                <TableColumn fx:id="mapColumn" prefWidth="75.0" text="%game.map"/>
+                <TableColumn fx:id="titleColumn" prefWidth="75.0" text="%game.title"/>
+                <TableColumn fx:id="playersColumn" prefWidth="75.0" text="%game.players"/>
+                <TableColumn fx:id="timeColumn" prefWidth="75.0" text="%game.time"/>
+                <TableColumn fx:id="durationColumn" prefWidth="75.0" text="%game.duration"/>
+                <TableColumn fx:id="gameTypeColumn" prefWidth="75.0" text="%game.gameType"/>
+                <TableColumn fx:id="idColumn" prefWidth="75.0" text="%game.id"/>
+            </columns>
+            <columnResizePolicy>
+                <TableView fx:constant="CONSTRAINED_RESIZE_POLICY"/>
+            </columnResizePolicy>
+        </TableView>
+        <VBox fx:id="loadingPane" alignment="CENTER" maxHeight="1.7976931348623157E308"
+              maxWidth="1.7976931348623157E308" mouseTransparent="true" spacing="10.0">
+            <children>
+                <Label contentDisplay="TOP" text="%vault.replays.loading">
+                    <graphic>
+                        <JFXSpinner/>
+                    </graphic>
+                </Label>
+            </children>
+        </VBox>
+    </children>
+</StackPane>

--- a/src/test/java/com/faforever/client/replay/ReplayServiceTest.java
+++ b/src/test/java/com/faforever/client/replay/ReplayServiceTest.java
@@ -19,7 +19,6 @@ import com.faforever.client.task.TaskService;
 import com.faforever.client.test.FakeTestException;
 import com.faforever.commons.replay.ReplayData;
 
-import com.google.common.eventbus.EventBus;
 import okio.Options;
 import org.junit.Before;
 import org.junit.Rule;
@@ -32,6 +31,7 @@ import org.mockito.MockitoAnnotations;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationEventPublisher;
 
 import java.io.BufferedInputStream;
 import java.io.InputStream;
@@ -140,7 +140,7 @@ public class ReplayServiceTest {
   @Mock
   private MapService mapService;
   @Mock
-  private EventBus eventBus;
+  private ApplicationEventPublisher publisher;
   @Mock
   private ExecutorService executorService;
 
@@ -149,7 +149,7 @@ public class ReplayServiceTest {
     MockitoAnnotations.initMocks(this);
 
     instance = new ReplayService(new ClientProperties(), preferencesService, replayFileReader, notificationService, gameService,
-        taskService, i18n, reportingService, applicationContext, platformService, fafService, modService, mapService, eventBus, executorService);
+        taskService, i18n, reportingService, applicationContext, platformService, fafService, modService, mapService, publisher, executorService);
 
     when(preferencesService.getReplaysDirectory()).thenReturn(replayDirectory.getRoot().toPath());
     when(preferencesService.getCorruptedReplaysDirectory()).thenReturn(replayDirectory.getRoot().toPath().resolve("corrupt"));
@@ -228,7 +228,7 @@ public class ReplayServiceTest {
 
     verify(taskService).submitTask(task);
     assertThat(instance.getLocalReplays(), hasSize(3));
-    verify(eventBus).post(argThat((LocalReplaysChangedEvent event) -> event.getNewReplays().size() == 3));
+    verify(publisher).publishEvent(argThat((LocalReplaysChangedEvent event) -> event.getNewReplays().size() == 3));
     verifyZeroInteractions(notificationService);
   }
 

--- a/src/test/java/com/faforever/client/replay/ReplayServiceTest.java
+++ b/src/test/java/com/faforever/client/replay/ReplayServiceTest.java
@@ -18,6 +18,7 @@ import com.faforever.client.task.TaskService;
 import com.faforever.client.test.FakeTestException;
 import com.faforever.commons.replay.ReplayData;
 
+import com.google.common.eventbus.EventBus;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -25,6 +26,7 @@ import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+
 import org.springframework.context.ApplicationContext;
 
 import java.net.URI;
@@ -35,6 +37,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
@@ -122,13 +125,17 @@ public class ReplayServiceTest {
   private ModService modService;
   @Mock
   private MapService mapService;
+  @Mock
+  private EventBus eventBus;
+  @Mock
+  private ExecutorService executorService;
 
   @Before
   public void setUp() throws Exception {
     MockitoAnnotations.initMocks(this);
 
     instance = new ReplayService(new ClientProperties(), preferencesService, replayFileReader, notificationService, gameService,
-        taskService, i18n, reportingService, applicationContext, platformService, fafService, modService, mapService);
+        taskService, i18n, reportingService, applicationContext, platformService, fafService, modService, mapService, eventBus, executorService);
 
     when(preferencesService.getReplaysDirectory()).thenReturn(replayDirectory.getRoot().toPath());
     when(preferencesService.getCorruptedReplaysDirectory()).thenReturn(replayDirectory.getRoot().toPath().resolve("corrupt"));

--- a/src/test/java/com/faforever/client/vault/replay/ReplayVaultControllerTest.java
+++ b/src/test/java/com/faforever/client/vault/replay/ReplayVaultControllerTest.java
@@ -1,9 +1,10 @@
 package com.faforever.client.vault.replay;
 
 import com.faforever.client.i18n.I18n;
+import com.faforever.client.main.event.LocalReplaysChangedEvent;
 import com.faforever.client.map.MapService;
 import com.faforever.client.notification.NotificationService;
-import com.faforever.client.replay.LoadLocalReplaysTask;
+import com.faforever.client.replay.Replay;
 import com.faforever.client.replay.ReplayInfoBeanBuilder;
 import com.faforever.client.replay.ReplayService;
 import com.faforever.client.reporting.ReportingService;
@@ -19,23 +20,17 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.springframework.context.ApplicationContext;
 
+import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
-import static org.mockito.Mockito.when;
 
 public class ReplayVaultControllerTest extends AbstractPlainJavaFxTest {
 
@@ -60,15 +55,13 @@ public class ReplayVaultControllerTest extends AbstractPlainJavaFxTest {
   private UiService uiService;
   @Mock
   private EventBus eventBus;
+  @Mock
+  private ExecutorService executorService;
 
   @Before
   public void setUp() throws Exception {
     instance = new ReplayVaultController(notificationService, replayService, mapService, taskService, i18n, timeService,
         reportingService, applicationContext, uiService, eventBus);
-
-    doReturn(new LoadLocalReplaysTask(replayService, i18n)).when(applicationContext).getBean(eq(LoadLocalReplaysTask.class));
-
-    doAnswer(invocation -> invocation.getArgument(0)).when(taskService).submitTask(any());
 
     loadFxml("theme/vault/replay/replay_vault.fxml", clazz -> instance);
   }
@@ -81,24 +74,22 @@ public class ReplayVaultControllerTest extends AbstractPlainJavaFxTest {
 
   @Test
   public void testLoadLocalReplaysInBackground() throws Exception {
-    LoadLocalReplaysTask task = mock(LoadLocalReplaysTask.class);
-    when(task.getFuture()).thenReturn(CompletableFuture.completedFuture(Arrays.asList(
+
+    var replays = Arrays.asList(
         ReplayInfoBeanBuilder.create().get(),
         ReplayInfoBeanBuilder.create().get(),
         ReplayInfoBeanBuilder.create().get()
-    )));
-
-    when(applicationContext.getBean(LoadLocalReplaysTask.class)).thenReturn(task);
+    );
 
     CountDownLatch loadedLatch = new CountDownLatch(1);
     ((TableView) instance.getRoot()).getItems().addListener((InvalidationListener) observable -> loadedLatch.countDown());
 
     instance.loadLocalReplaysInBackground();
+    instance.onLocalReplaysChanged(new LocalReplaysChangedEvent(replays, new ArrayList<Replay>()));
 
     assertTrue(loadedLatch.await(5000, TimeUnit.MILLISECONDS));
     assertThat(((TableView) instance.getRoot()).getItems().size(), is(3));
 
-    verify(taskService).submitTask(task);
     verifyZeroInteractions(notificationService);
   }
 }

--- a/src/test/java/com/faforever/client/vault/replay/ReplayVaultControllerTest.java
+++ b/src/test/java/com/faforever/client/vault/replay/ReplayVaultControllerTest.java
@@ -83,13 +83,13 @@ public class ReplayVaultControllerTest extends AbstractPlainJavaFxTest {
     );
 
     CountDownLatch loadedLatch = new CountDownLatch(1);
-    ((TableView) instance.getRoot()).getItems().addListener((InvalidationListener) observable -> loadedLatch.countDown());
+    instance.replayTableView.getItems().addListener((InvalidationListener) observable -> loadedLatch.countDown());
 
     instance.loadLocalReplaysInBackground();
     instance.onLocalReplaysChanged(new LocalReplaysChangedEvent(replays, new ArrayList<Replay>()));
 
     assertTrue(loadedLatch.await(5000, TimeUnit.MILLISECONDS));
-    assertThat(((TableView) instance.getRoot()).getItems().size(), is(3));
+    assertThat(instance.replayTableView.getItems().size(), is(3));
 
     verifyZeroInteractions(notificationService);
   }

--- a/src/test/java/com/faforever/client/vault/replay/ReplayVaultControllerTest.java
+++ b/src/test/java/com/faforever/client/vault/replay/ReplayVaultControllerTest.java
@@ -22,6 +22,7 @@ import org.springframework.context.ApplicationContext;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -75,7 +76,7 @@ public class ReplayVaultControllerTest extends AbstractPlainJavaFxTest {
   @Test
   public void testLoadLocalReplaysInBackground() throws Exception {
 
-    var replays = Arrays.asList(
+    List<Replay> replays = Arrays.asList(
         ReplayInfoBeanBuilder.create().get(),
         ReplayInfoBeanBuilder.create().get(),
         ReplayInfoBeanBuilder.create().get()

--- a/src/test/java/com/faforever/client/vault/replay/ReplayVaultControllerTest.java
+++ b/src/test/java/com/faforever/client/vault/replay/ReplayVaultControllerTest.java
@@ -11,6 +11,7 @@ import com.faforever.client.task.TaskService;
 import com.faforever.client.test.AbstractPlainJavaFxTest;
 import com.faforever.client.theme.UiService;
 import com.faforever.client.util.TimeService;
+import com.google.common.eventbus.EventBus;
 import javafx.beans.InvalidationListener;
 import javafx.scene.control.TableView;
 import org.junit.Before;
@@ -57,11 +58,13 @@ public class ReplayVaultControllerTest extends AbstractPlainJavaFxTest {
   private ReportingService reportingService;
   @Mock
   private UiService uiService;
+  @Mock
+  private EventBus eventBus;
 
   @Before
   public void setUp() throws Exception {
     instance = new ReplayVaultController(notificationService, replayService, mapService, taskService, i18n, timeService,
-        reportingService, applicationContext, uiService);
+        reportingService, applicationContext, uiService, eventBus);
 
     doReturn(new LoadLocalReplaysTask(replayService, i18n)).when(applicationContext).getBean(eq(LoadLocalReplaysTask.class));
 

--- a/src/test/java/com/faforever/client/vault/replay/ReplayVaultControllerTest.java
+++ b/src/test/java/com/faforever/client/vault/replay/ReplayVaultControllerTest.java
@@ -55,14 +55,12 @@ public class ReplayVaultControllerTest extends AbstractPlainJavaFxTest {
   @Mock
   private UiService uiService;
   @Mock
-  private EventBus eventBus;
-  @Mock
   private ExecutorService executorService;
 
   @Before
   public void setUp() throws Exception {
     instance = new ReplayVaultController(notificationService, replayService, mapService, taskService, i18n, timeService,
-        reportingService, applicationContext, uiService, eventBus);
+        reportingService, applicationContext, uiService);
 
     loadFxml("theme/vault/replay/replay_vault.fxml", clazz -> instance);
   }
@@ -86,7 +84,7 @@ public class ReplayVaultControllerTest extends AbstractPlainJavaFxTest {
     instance.replayTableView.getItems().addListener((InvalidationListener) observable -> loadedLatch.countDown());
 
     instance.loadLocalReplaysInBackground();
-    instance.onLocalReplaysChanged(new LocalReplaysChangedEvent(replays, new ArrayList<Replay>()));
+    instance.onLocalReplaysChanged(new LocalReplaysChangedEvent(this, replays, new ArrayList<Replay>()));
 
     assertTrue(loadedLatch.await(5000, TimeUnit.MILLISECONDS));
     assertThat(instance.replayTableView.getItems().size(), is(3));


### PR DESCRIPTION
Fixes #1141.

This patch implements lazy loading of the local replay vault and automatic updates when replays have been added to or removed from the local replay directory.

- Uses WatchEvents to detect changes in the local replay directory
- Works for both played games and manually added/removed replay files
- Updates the list accordingly and respects previous sorting
- Replays from played games are now written to the cache directory first and then moved atomically  to the replays directory to prevent parsing it before it is written
- No changes to UI

Test coverage is not great. What would you like to have tested exactly?

It's been 10 years or so since I've written any Java, so be gentle. ;)
