### PR TITLE
Issue/#1292 Localize authentication_failed messages

### DIFF
--- a/src/main/java/com/faforever/client/config/ClientProperties.java
+++ b/src/main/java/com/faforever/client/config/ClientProperties.java
@@ -128,6 +128,7 @@ public class ClientProperties {
     private String baseUrl;
     private String forgotPasswordUrl;
     private String createAccountUrl;
+    private String steamLinkUrl;
   }
 
   @Data

--- a/src/main/java/com/faforever/client/remote/FafServerAccessorImpl.java
+++ b/src/main/java/com/faforever/client/remote/FafServerAccessorImpl.java
@@ -484,21 +484,23 @@ public class FafServerAccessorImpl extends AbstractServerAccessor implements Faf
   }
 
   private String translateAuthenticationMessage(AuthenticationFailedMessage message) {
-    ArrayList<String> key = new ArrayList(Arrays.asList("login", "error"));
-    ArrayList<Object> args = new ArrayList();
-
     String context = message.getContext();
-    if (context != null) {
-      key.add(context);
-      args.add(clientProperties.getWebsite().getSteamLinkUrl());
-
-      String result = message.getResult();
-      if (context.equals("policy") && result != null) {
-        key.add(result);
-        args.add(result);
-      }
+    if (context == null) {
+      // Fallback to displayaing server side text
+      String messageText = message.getText();
+      return messageText != null ? messageText: i18n.get("login.error");
     }
 
+    ArrayList<String> key = new ArrayList(Arrays.asList("login", "error", context));
+    ArrayList<Object> args = new ArrayList(Arrays.asList(clientProperties.getWebsite().getSteamLinkUrl()));
+
+    String result = message.getResult();
+    if (context.equals("policy") && result != null) {
+      key.add(result);
+      args.add(result);
+    }
+
+    // Resolve the most detailed message we can
     Object[] argsArray = args.toArray();
     while(key.size() > 1) {
       try {
@@ -508,8 +510,8 @@ public class FafServerAccessorImpl extends AbstractServerAccessor implements Faf
       }
     }
 
-    String messageText = message.getText();
-    return messageText != null ? messageText: i18n.get("login.error");
+    // Our localization file is messed up
+    return "login.error";
   }
 
   private void onFafLoginSucceeded(LoginMessage loginServerMessage) {

--- a/src/main/java/com/faforever/client/remote/FafServerAccessorImpl.java
+++ b/src/main/java/com/faforever/client/remote/FafServerAccessorImpl.java
@@ -499,9 +499,10 @@ public class FafServerAccessorImpl extends AbstractServerAccessor implements Faf
       }
     }
 
+    Object[] argsArray = args.toArray();
     while(key.size() > 1) {
       try {
-        return i18n.get(String.join(".", key), args.toArray());
+        return i18n.get(String.join(".", key), argsArray);
       } catch(NoSuchMessageException e) {
         key.remove(key.size() - 1);
       }

--- a/src/main/java/com/faforever/client/remote/FafServerAccessorImpl.java
+++ b/src/main/java/com/faforever/client/remote/FafServerAccessorImpl.java
@@ -473,7 +473,24 @@ public class FafServerAccessorImpl extends AbstractServerAccessor implements Faf
 
   private void dispatchAuthenticationFailed(AuthenticationFailedMessage message) {
     fafConnectionTask.cancel();
-    loginFuture.completeExceptionally(new LoginFailedException(message.getText()));
+
+    String text;
+
+    String context = message.getContext();
+    if (context == null) { context = ""; }
+
+    switch (context) {
+      case "denied":
+        text = i18n.get("login.deniedError");
+        break;
+      case "steam_link":
+        text = i18n.get("login.steamLinkError", clientProperties.getWebsite().getSteamLinkUrl());
+        break;
+      default:
+        text = i18n.get("login.failedError");
+    }
+
+    loginFuture.completeExceptionally(new LoginFailedException(text));
     loginFuture = null;
   }
 

--- a/src/main/java/com/faforever/client/remote/domain/AuthenticationFailedMessage.java
+++ b/src/main/java/com/faforever/client/remote/domain/AuthenticationFailedMessage.java
@@ -1,18 +1,16 @@
 package com.faforever.client.remote.domain;
 
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
 public class AuthenticationFailedMessage extends FafServerMessage {
 
   private String text;
+  private String context;
 
   public AuthenticationFailedMessage() {
     super(FafServerMessageType.AUTHENTICATION_FAILED);
-  }
-
-  public String getText() {
-    return text;
-  }
-
-  public void setText(String text) {
-    this.text = text;
   }
 }

--- a/src/main/java/com/faforever/client/remote/domain/AuthenticationFailedMessage.java
+++ b/src/main/java/com/faforever/client/remote/domain/AuthenticationFailedMessage.java
@@ -9,7 +9,10 @@ public class AuthenticationFailedMessage extends FafServerMessage {
 
   private String text;
   private String context;
-  // Policy server result when context == "policy"
+  /**
+   * Policy server result when context == "policy". Expect this to be null
+   * otherwise.
+   */
   private String result;
 
   public AuthenticationFailedMessage() {

--- a/src/main/java/com/faforever/client/remote/domain/AuthenticationFailedMessage.java
+++ b/src/main/java/com/faforever/client/remote/domain/AuthenticationFailedMessage.java
@@ -9,6 +9,8 @@ public class AuthenticationFailedMessage extends FafServerMessage {
 
   private String text;
   private String context;
+  // Policy server result when context == "policy"
+  private String result;
 
   public AuthenticationFailedMessage() {
     super(FafServerMessageType.AUTHENTICATION_FAILED);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -27,6 +27,7 @@ faf-client:
   website:
       forgot-password-url: ${faf-client.website.base-url}/account/password/reset
       create-account-url: ${faf-client.website.base-url}/account/register
+      steam-link-url: ${faf-client.website.base-url}/account/link
 
   imgur:
     upload:

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -292,6 +292,9 @@ login.replayServerHost=Replay server host
 login.ircServerHost=IRC server host
 login.apiBaseUrl=API base URL
 login.withEmailWarning=Please login with your username and not your email.
+login.failedError=Login failed for an unknown reason.
+login.deniedError=Login not found or password incorrect. They are case sensitive.
+login.steamLinkError=Unfortunately, you must currently link your account to Steam in order to play Forged Alliance Forever. You can do so on {0}.
 
 vault.maps=Maps
 vault.mods=Mods

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -295,6 +295,10 @@ login.withEmailWarning=Please login with your username and not your email.
 login.failedError=Login failed for an unknown reason.
 login.deniedError=Login not found or password incorrect. They are case sensitive.
 login.steamLinkError=Unfortunately, you must currently link your account to Steam in order to play Forged Alliance Forever. You can do so on {0}.
+login.policyError=Login failed due to a policy violation: '{0}'. Please contact an admin or moderator on the forums if you feel this is a false positive.
+login.policyVMError=Your computer seems to be a virtual machine.\n\nIn order to log in from a VM, you have to link your account to Steam: {0}. If you need an exception, please contact an admin or moderator on the forums.
+login.policyAssociatedError=Your computer is already associated with another FAF account.\n\nIn order to log in with an additional account, you have to link it to Steam: {0}.\nIf you need an exception, please contact an admin or moderator on the forums.
+login.policyFraudulentError=Fraudulent login attempt detected. As a precautionary measure, your account has been banned permanently. Please contact an admin or moderator on the forums if you feel this is a false positive.
 
 vault.maps=Maps
 vault.mods=Mods

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -292,13 +292,15 @@ login.replayServerHost=Replay server host
 login.ircServerHost=IRC server host
 login.apiBaseUrl=API base URL
 login.withEmailWarning=Please login with your username and not your email.
-login.failedError=Login failed for an unknown reason.
-login.deniedError=Login not found or password incorrect. They are case sensitive.
-login.steamLinkError=Unfortunately, you must currently link your account to Steam in order to play Forged Alliance Forever. You can do so on {0}.
-login.policyError=Login failed due to a policy violation: '{0}'. Please contact an admin or moderator on the forums if you feel this is a false positive.
-login.policyVMError=Your computer seems to be a virtual machine.\n\nIn order to log in from a VM, you have to link your account to Steam: {0}. If you need an exception, please contact an admin or moderator on the forums.
-login.policyAssociatedError=Your computer is already associated with another FAF account.\n\nIn order to log in with an additional account, you have to link it to Steam: {0}.\nIf you need an exception, please contact an admin or moderator on the forums.
-login.policyFraudulentError=Fraudulent login attempt detected. As a precautionary measure, your account has been banned permanently. Please contact an admin or moderator on the forums if you feel this is a false positive.
+# For all login.error messages {0} is the steam link url
+# The first argument starts at {1}
+login.error=Login failed for an unknown reason.
+login.error.denied=Login not found or password incorrect. They are case sensitive.
+login.error.steam_link=Unfortunately, you must currently link your account to Steam in order to play Forged Alliance Forever. You can do so on {0}.
+login.error.policy=Login failed due to a policy violation: ''{1}''. Please contact an admin or moderator on the forums if you feel this is a false positive.
+login.error.policy.vm=Your computer seems to be a virtual machine.\n\nIn order to log in from a VM, you have to link your account to Steam: {0}. If you need an exception, please contact an admin or moderator on the forums.
+login.error.policy.already_associated=Your computer is already associated with another FAF account.\n\nIn order to log in with an additional account, you have to link it to Steam: {0}.\nIf you need an exception, please contact an admin or moderator on the forums.
+login.error.policy.fraudulent=Fraudulent login attempt detected. As a precautionary measure, your account has been banned permanently. Please contact an admin or moderator on the forums if you feel this is a false positive.
 
 vault.maps=Maps
 vault.mods=Mods


### PR DESCRIPTION
Related #1292.

Add localization for some messages that are currently hard coded strings in the lobby server.

Managed to to get these working with my server PR https://github.com/FAForever/server/pull/505. I plan on adding more messages in a separate PR after I get more comfortable with how all the pieces of the code work together. 