### PR TITLE
Replay parsing efficiency improvement (wrong branch)

### DIFF
--- a/src/main/java/com/faforever/client/main/event/LocalReplaysChangedEvent.java
+++ b/src/main/java/com/faforever/client/main/event/LocalReplaysChangedEvent.java
@@ -1,0 +1,13 @@
+package com.faforever.client.main.event;
+
+import com.faforever.client.replay.Replay;
+import lombok.Data;
+
+import java.util.Collection;
+
+@Data
+public class LocalReplaysChangedEvent {
+  private final Collection<Replay> newReplays;
+  private final Collection<Replay> deletedReplays;
+}
+

--- a/src/main/java/com/faforever/client/main/event/OpenReplayVaultEvent.java
+++ b/src/main/java/com/faforever/client/main/event/OpenReplayVaultEvent.java
@@ -1,0 +1,7 @@
+package com.faforever.client.main.event;
+
+public class OpenReplayVaultEvent extends NavigateEvent {
+  public OpenReplayVaultEvent() {
+    super(NavigationItem.VAULT);
+  }
+}

--- a/src/main/java/com/faforever/client/replay/LoadLocalReplaysTask.java
+++ b/src/main/java/com/faforever/client/replay/LoadLocalReplaysTask.java
@@ -26,7 +26,6 @@ public class LoadLocalReplaysTask extends CompletableTask<Collection<Replay>> {
   @Override
   protected Collection<Replay> call() throws Exception {
     updateTitle(i18n.get("replays.loadingLocalTask.title"));
-    return replayService.getLocalReplays();
+    return replayService.loadLocalReplays().get();
   }
-
 }

--- a/src/main/java/com/faforever/client/replay/ReplayService.java
+++ b/src/main/java/com/faforever/client/replay/ReplayService.java
@@ -262,7 +262,15 @@ public class ReplayService {
     List<CompletableFuture<Replay>> replayFutures = StreamSupport.stream(directoryStream.spliterator(), false)
         .sorted(Comparator.comparing(path -> noCatch(() -> Files.getLastModifiedTime((Path) path))).reversed())
         .limit(MAX_REPLAYS)
-        .map(replayFile -> noCatch(() -> loadLocalReplay(replayFile)))
+        .map( replayFile -> {
+          try {
+            return loadLocalReplay(replayFile);
+          } catch (Exception e) {
+            // do nothing; notification should already be shown to user
+            return null;
+          }
+        })
+        .filter(replay -> replay != null)
         .collect(Collectors.toList());
 
     CompletableFuture[] replayFuturesArray = replayFutures.toArray(new CompletableFuture[replayFutures.size()]);

--- a/src/main/java/com/faforever/client/replay/ReplayService.java
+++ b/src/main/java/com/faforever/client/replay/ReplayService.java
@@ -134,14 +134,11 @@ public class ReplayService {
   private List<Replay> localReplays = new ArrayList<Replay>();
 
   public void startLoadingAndWatchingLocalReplays() {
-    // TODO: Create task?
-    executorService.execute(() -> {
-      LoadLocalReplaysTask loadLocalReplaysTask = new LoadLocalReplaysTask(this, i18n);
-      taskService.submitTask(loadLocalReplaysTask).getFuture().thenAccept( replays -> {
-        localReplays.clear();
-        localReplays.addAll(replays);
-        eventBus.post(new LocalReplaysChangedEvent(replays, new ArrayList<Replay>()));
-      });
+    LoadLocalReplaysTask loadLocalReplaysTask = applicationContext.getBean(LoadLocalReplaysTask.class);
+    taskService.submitTask(loadLocalReplaysTask).getFuture().thenAccept( replays -> {
+      localReplays.clear();
+      localReplays.addAll(replays);
+      eventBus.post(new LocalReplaysChangedEvent(replays, new ArrayList<Replay>()));
     });
 
     try {
@@ -156,7 +153,7 @@ public class ReplayService {
     return localReplays;
   }
 
-  private Thread startDirectoryWatcher(Path replaysDirectory) throws IOException {
+  protected Thread startDirectoryWatcher(Path replaysDirectory) throws IOException {
     Thread thread = new Thread(() -> noCatch(() -> {
       try (WatchService watcher = replaysDirectory.getFileSystem().newWatchService()) {
         replaysDirectory.register(watcher, ENTRY_CREATE, ENTRY_MODIFY, ENTRY_DELETE);

--- a/src/main/java/com/faforever/client/replay/ReplayService.java
+++ b/src/main/java/com/faforever/client/replay/ReplayService.java
@@ -7,6 +7,8 @@ import com.faforever.client.game.Game;
 import com.faforever.client.game.GameService;
 import com.faforever.client.game.KnownFeaturedMod;
 import com.faforever.client.i18n.I18n;
+import com.faforever.client.main.event.LocalReplaysChangedEvent;
+import com.faforever.client.map.MapBean;
 import com.faforever.client.map.MapService;
 import com.faforever.client.mod.FeaturedMod;
 import com.faforever.client.mod.ModService;
@@ -28,6 +30,7 @@ import com.faforever.client.vault.search.SearchController.SortConfig;
 import com.faforever.commons.replay.ReplayData;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Splitter;
+import com.google.common.eventbus.EventBus;
 import com.google.common.net.UrlEscapers;
 import com.google.common.primitives.Bytes;
 import lombok.RequiredArgsConstructor;
@@ -36,22 +39,30 @@ import lombok.extern.slf4j.Slf4j;
 import org.eclipse.jgit.util.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.InitializingBean;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.ByteArrayInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.RandomAccessFile;
 import java.lang.invoke.MethodHandles;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.channels.FileLock;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchKey;
+import java.nio.file.WatchService;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
@@ -60,21 +71,26 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutorService;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import static com.faforever.client.notification.Severity.WARN;
 import static com.github.nocatch.NoCatch.noCatch;
+import static java.lang.Thread.sleep;
 import static java.net.URLDecoder.decode;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.nio.file.Files.createDirectories;
 import static java.nio.file.Files.move;
+import static java.nio.file.StandardWatchEventKinds.ENTRY_CREATE;
+import static java.nio.file.StandardWatchEventKinds.ENTRY_DELETE;
+import static java.nio.file.StandardWatchEventKinds.ENTRY_MODIFY;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
 import static java.util.Collections.singletonList;
-
 
 @Lazy
 @Service
@@ -111,6 +127,82 @@ public class ReplayService {
   private final FafService fafService;
   private final ModService modService;
   private final MapService mapService;
+  private final EventBus eventBus;
+  private final ExecutorService executorService;
+  private Thread directoryWatcherThread;
+  private WatchService watchService;
+  private List<Replay> localReplays = new ArrayList<Replay>();
+
+  public void startLoadingAndWatchingLocalReplays() {
+    // TODO: Create task?
+    executorService.execute(() -> {
+      loadLocalReplays().thenAccept( replays -> {
+        localReplays.clear();
+        localReplays.addAll(replays);
+        eventBus.post(new LocalReplaysChangedEvent(replays, new ArrayList<Replay>()));
+      });
+    });
+
+    try {
+      Optional.ofNullable(directoryWatcherThread).ifPresent(Thread::interrupt);
+      directoryWatcherThread = startDirectoryWatcher(preferencesService.getReplaysDirectory());
+    } catch (IOException e) {
+      logger.debug("Failed to start watching the local replays directory");
+    }
+  }
+
+  public Collection<Replay> getLocalReplays() {
+    return localReplays;
+  }
+
+  private Thread startDirectoryWatcher(Path replaysDirectory) throws IOException {
+    Thread thread = new Thread(() -> noCatch(() -> {
+      try (WatchService watcher = replaysDirectory.getFileSystem().newWatchService()) {
+        replaysDirectory.register(watcher, ENTRY_CREATE, ENTRY_MODIFY, ENTRY_DELETE);
+        while (!Thread.interrupted()) {
+          WatchKey key = watcher.take();
+          onLocalReplaysWatchEvent(key);
+          key.reset();
+        }
+      } catch (InterruptedException e) {
+        logger.debug("Local replay directory watcher terminated ({})", e.getMessage());
+      }
+    }));
+    thread.setDaemon(true);
+    thread.start();
+    return thread;
+  }
+
+  private void onLocalReplaysWatchEvent(WatchKey key) {
+    Collection<Replay> newReplays = new ArrayList<Replay>();
+    Collection<Replay> deletedReplays = new ArrayList<Replay>();
+    for (WatchEvent<?> watchEvent : key.pollEvents()) {
+      Path path = (Path) watchEvent.context();
+      Path fullPathToReplay = preferencesService.getReplaysDirectory().resolve(path);
+
+      if (watchEvent.kind() == ENTRY_CREATE) {
+        try {
+          loadLocalReplay(fullPathToReplay)
+              .thenAccept(newReplay -> {
+                newReplays.add(newReplay);
+              });
+        } catch (Exception e) {
+          logger.warn("Failed to load local replay file '{}'", path, e);
+        }
+
+      } else if (watchEvent.kind() == ENTRY_DELETE) {
+        Optional<Replay> existingReplay = localReplays.stream().filter(replay -> replay.getReplayFile().compareTo(fullPathToReplay) == 0).findFirst();
+        if (existingReplay.isPresent()) {
+          Replay deletedReplay = existingReplay.get();
+          deletedReplays.add(deletedReplay);
+          localReplays.remove(deletedReplay);
+        }
+      }
+    }
+
+    localReplays.addAll(newReplays);
+    eventBus.post(new LocalReplaysChangedEvent(newReplays, deletedReplays));
+  }
 
   @VisibleForTesting
   static Integer parseSupComVersion(byte[] rawReplayBytes) {
@@ -156,9 +248,8 @@ public class ReplayService {
    * Loads some, but not all, local replays. Loading all local replays could result in OOME.
    */
   @SneakyThrows
-  public Collection<Replay> getLocalReplays() {
-    Collection<Replay> replayInfos = new ArrayList<>();
-
+  @Async
+  private CompletableFuture<Collection<Replay>> loadLocalReplays() {
     String replayFileGlob = clientProperties.getReplay().getReplayFileGlob();
 
     Path replaysDirectory = preferencesService.getReplaysDirectory();
@@ -166,25 +257,42 @@ public class ReplayService {
       noCatch(() -> createDirectories(replaysDirectory));
     }
 
-    try (DirectoryStream<Path> directoryStream = Files.newDirectoryStream(replaysDirectory, replayFileGlob)) {
-      StreamSupport.stream(directoryStream.spliterator(), false)
-          .sorted(Comparator.comparing(path -> noCatch(() -> Files.getLastModifiedTime((Path) path))).reversed())
-          .limit(MAX_REPLAYS)
-          .forEach(replayFile -> {
-            try {
-              LocalReplayInfo replayInfo = replayFileReader.parseMetaData(replayFile);
-              FeaturedMod featuredMod = modService.getFeaturedMod(replayInfo.getFeaturedMod()).get();
+    DirectoryStream<Path> directoryStream = Files.newDirectoryStream(replaysDirectory, replayFileGlob);
+    List<CompletableFuture<Replay>> replayFutures = StreamSupport.stream(directoryStream.spliterator(), false)
+        .sorted(Comparator.comparing(path -> noCatch(() -> Files.getLastModifiedTime((Path) path))).reversed())
+        .limit(MAX_REPLAYS)
+        .map(replayFile -> noCatch(() -> loadLocalReplay(replayFile)))
+        .collect(Collectors.toList());
 
-              mapService.findByMapFolderName(replayInfo.getMapname())
-                  .thenAccept(mapBean -> replayInfos.add(new Replay(replayInfo, replayFile, featuredMod, mapBean.orElse(null))));
-            } catch (Exception e) {
-              logger.warn("Could not read replay file '{}'", replayFile, e);
-              moveCorruptedReplayFile(replayFile);
-            }
-          });
+    CompletableFuture[] replayFuturesArray = replayFutures.toArray(new CompletableFuture[replayFutures.size()]);
+    return CompletableFuture.allOf(replayFuturesArray)
+        .thenApply(ignoredVoid ->
+            replayFutures.stream()
+                .map(future -> future.join())
+                .collect(Collectors.toList()));
+
+  }
+
+  @Async
+  private CompletableFuture<Replay> loadLocalReplay(Path replayFile) throws Exception  {
+    try {
+      LocalReplayInfo replayInfo = replayFileReader.parseMetaData(replayFile);
+
+      CompletableFuture<FeaturedMod> featuredModFuture = modService.getFeaturedMod(replayInfo.getFeaturedMod());
+      CompletableFuture<Optional<MapBean>> mapBeanFuture = mapService.findByMapFolderName(replayInfo.getMapname());
+
+      return CompletableFuture.allOf(featuredModFuture, mapBeanFuture).thenApply(ignoredVoid  -> {
+        Optional<MapBean> mapBean = mapBeanFuture.join();
+        if (!mapBean.isPresent()) {
+          throw new CompletionException(new FileNotFoundException());
+        }
+        return new Replay(replayInfo, replayFile, featuredModFuture.join(), mapBean.get());
+      });
+    } catch (Exception e) {
+      logger.warn("Could not read replay file '{}'", replayFile, e);
+      moveCorruptedReplayFile(replayFile);
+      throw e;
     }
-
-    return replayInfos;
   }
 
   private void moveCorruptedReplayFile(Path replayFile) {

--- a/src/main/java/com/faforever/client/replay/ReplayService.java
+++ b/src/main/java/com/faforever/client/replay/ReplayService.java
@@ -136,7 +136,8 @@ public class ReplayService {
   public void startLoadingAndWatchingLocalReplays() {
     // TODO: Create task?
     executorService.execute(() -> {
-      loadLocalReplays().thenAccept( replays -> {
+      LoadLocalReplaysTask loadLocalReplaysTask = new LoadLocalReplaysTask(this, i18n);
+      taskService.submitTask(loadLocalReplaysTask).getFuture().thenAccept( replays -> {
         localReplays.clear();
         localReplays.addAll(replays);
         eventBus.post(new LocalReplaysChangedEvent(replays, new ArrayList<Replay>()));
@@ -249,7 +250,7 @@ public class ReplayService {
    */
   @SneakyThrows
   @Async
-  private CompletableFuture<Collection<Replay>> loadLocalReplays() {
+  public CompletableFuture<Collection<Replay>> loadLocalReplays() {
     String replayFileGlob = clientProperties.getReplay().getReplayFileGlob();
 
     Path replaysDirectory = preferencesService.getReplaysDirectory();

--- a/src/main/java/com/faforever/client/vault/VaultController.java
+++ b/src/main/java/com/faforever/client/vault/VaultController.java
@@ -5,9 +5,11 @@ import com.faforever.client.main.event.NavigateEvent;
 import com.faforever.client.main.event.OpenMapVaultEvent;
 import com.faforever.client.main.event.OpenModVaultEvent;
 import com.faforever.client.main.event.OpenOnlineReplayVaultEvent;
+import com.faforever.client.main.event.OpenReplayVaultEvent;
 import com.faforever.client.map.MapVaultController;
 import com.faforever.client.mod.ModVaultController;
 import com.faforever.client.replay.OnlineReplayVaultController;
+import com.faforever.client.vault.replay.ReplayVaultController;
 import com.google.common.eventbus.EventBus;
 import javafx.scene.Node;
 import javafx.scene.control.Tab;
@@ -29,7 +31,9 @@ public class VaultController extends AbstractViewController<Node> {
   public MapVaultController mapVaultController;
   public ModVaultController modVaultController;
   public OnlineReplayVaultController onlineReplayVaultController;
+  public ReplayVaultController localReplayVaultController;
   public Tab onlineReplayVaultTab;
+  public Tab localReplayVaultTab;
   private boolean isHandlingEvent;
 
   public VaultController(EventBus eventBus) {
@@ -54,6 +58,8 @@ public class VaultController extends AbstractViewController<Node> {
         eventBus.post(new OpenModVaultEvent());
       } else if (newValue == onlineReplayVaultTab) {
         eventBus.post(new OpenOnlineReplayVaultEvent());
+      } else if (newValue == localReplayVaultTab) {
+        eventBus.post(new OpenReplayVaultEvent());
       }
       // TODO implement other tabs
     });
@@ -76,6 +82,10 @@ public class VaultController extends AbstractViewController<Node> {
       if (navigateEvent instanceof OpenOnlineReplayVaultEvent) {
         vaultRoot.getSelectionModel().select(onlineReplayVaultTab);
         onlineReplayVaultController.display(navigateEvent);
+      }
+      if (navigateEvent instanceof OpenReplayVaultEvent) {
+        vaultRoot.getSelectionModel().select(localReplayVaultTab);
+        localReplayVaultController.display(navigateEvent);
       }
     } finally {
       isHandlingEvent = false;

--- a/src/main/java/com/faforever/client/vault/replay/ReplayVaultController.java
+++ b/src/main/java/com/faforever/client/vault/replay/ReplayVaultController.java
@@ -118,14 +118,18 @@ public class ReplayVaultController extends AbstractViewController<Node> {
 
   @Override
   protected void onDisplay(NavigateEvent navigateEvent) {
-    // TODO: Display information that view contents are loading
     if (isDisplayingForFirstTime) {
-      eventBus.register(this);
-      replayService.startLoadingAndWatchingLocalReplays();
+      loadLocalReplaysInBackground();
       isDisplayingForFirstTime = false;
     }
 
     super.onDisplay(navigateEvent);
+  }
+
+  protected void loadLocalReplaysInBackground() {
+    // TODO: Display information that view contents are loading
+    eventBus.register(this);
+    replayService.startLoadingAndWatchingLocalReplays();
   }
 
   @NotNull

--- a/src/main/java/com/faforever/client/vault/replay/ReplayVaultController.java
+++ b/src/main/java/com/faforever/client/vault/replay/ReplayVaultController.java
@@ -1,7 +1,9 @@
 package com.faforever.client.vault.replay;
 
+import com.faforever.client.fx.AbstractViewController;
 import com.faforever.client.fx.Controller;
 import com.faforever.client.i18n.I18n;
+import com.faforever.client.main.event.NavigateEvent;
 import com.faforever.client.map.MapBean;
 import com.faforever.client.map.MapService;
 import com.faforever.client.map.MapService.PreviewSize;
@@ -58,7 +60,7 @@ import static java.util.Arrays.asList;
 @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
 @RequiredArgsConstructor
 // TODO reduce dependencies
-public class ReplayVaultController implements Controller<Node> {
+public class ReplayVaultController extends AbstractViewController<Node> {
 
   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
   private final NotificationService notificationService;
@@ -106,6 +108,11 @@ public class ReplayVaultController implements Controller<Node> {
     durationColumn.setCellFactory(this::durationCellFactory);
 
     loadLocalReplaysInBackground();
+  }
+
+  @Override
+  protected void onDisplay(NavigateEvent navigateEvent) {
+    super.onDisplay(navigateEvent);
   }
 
   @NotNull

--- a/src/test/java/com/faforever/client/replay/ReplayServiceTest.java
+++ b/src/test/java/com/faforever/client/replay/ReplayServiceTest.java
@@ -18,6 +18,7 @@ import com.faforever.client.task.TaskService;
 import com.faforever.client.test.FakeTestException;
 import com.faforever.commons.replay.ReplayData;
 
+import com.google.common.eventbus.EventBus;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -25,6 +26,7 @@ import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+
 import org.springframework.context.ApplicationContext;
 
 import java.net.URI;
@@ -35,6 +37,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
@@ -122,13 +125,17 @@ public class ReplayServiceTest {
   private ModService modService;
   @Mock
   private MapService mapService;
+  @Mock
+  private EventBus eventBus;
+  @Mock
+  private ExecutorService executorService;
 
   @Before
   public void setUp() throws Exception {
     MockitoAnnotations.initMocks(this);
 
     instance = new ReplayService(new ClientProperties(), preferencesService, replayFileReader, notificationService, gameService,
-        taskService, i18n, reportingService, applicationContext, platformService, fafService, modService, mapService);
+        taskService, i18n, reportingService, applicationContext, platformService, fafService, modService, mapService, eventBus, executorService);
 
     when(preferencesService.getReplaysDirectory()).thenReturn(replayDirectory.getRoot().toPath());
     when(preferencesService.getCorruptedReplaysDirectory()).thenReturn(replayDirectory.getRoot().toPath().resolve("corrupt"));

--- a/src/test/java/com/faforever/client/vault/replay/ReplayVaultControllerTest.java
+++ b/src/test/java/com/faforever/client/vault/replay/ReplayVaultControllerTest.java
@@ -1,9 +1,10 @@
 package com.faforever.client.vault.replay;
 
 import com.faforever.client.i18n.I18n;
+import com.faforever.client.main.event.LocalReplaysChangedEvent;
 import com.faforever.client.map.MapService;
 import com.faforever.client.notification.NotificationService;
-import com.faforever.client.replay.LoadLocalReplaysTask;
+import com.faforever.client.replay.Replay;
 import com.faforever.client.replay.ReplayInfoBeanBuilder;
 import com.faforever.client.replay.ReplayService;
 import com.faforever.client.reporting.ReportingService;
@@ -19,23 +20,17 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.springframework.context.ApplicationContext;
 
+import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
-import static org.mockito.Mockito.when;
 
 public class ReplayVaultControllerTest extends AbstractPlainJavaFxTest {
 
@@ -60,15 +55,13 @@ public class ReplayVaultControllerTest extends AbstractPlainJavaFxTest {
   private UiService uiService;
   @Mock
   private EventBus eventBus;
+  @Mock
+  private ExecutorService executorService;
 
   @Before
   public void setUp() throws Exception {
     instance = new ReplayVaultController(notificationService, replayService, mapService, taskService, i18n, timeService,
         reportingService, applicationContext, uiService, eventBus);
-
-    doReturn(new LoadLocalReplaysTask(replayService, i18n)).when(applicationContext).getBean(eq(LoadLocalReplaysTask.class));
-
-    doAnswer(invocation -> invocation.getArgument(0)).when(taskService).submitTask(any());
 
     loadFxml("theme/vault/replay/replay_vault.fxml", clazz -> instance);
   }
@@ -81,24 +74,22 @@ public class ReplayVaultControllerTest extends AbstractPlainJavaFxTest {
 
   @Test
   public void testLoadLocalReplaysInBackground() throws Exception {
-    LoadLocalReplaysTask task = mock(LoadLocalReplaysTask.class);
-    when(task.getFuture()).thenReturn(CompletableFuture.completedFuture(Arrays.asList(
+
+    var replays = Arrays.asList(
         ReplayInfoBeanBuilder.create().get(),
         ReplayInfoBeanBuilder.create().get(),
         ReplayInfoBeanBuilder.create().get()
-    )));
-
-    when(applicationContext.getBean(LoadLocalReplaysTask.class)).thenReturn(task);
+    );
 
     CountDownLatch loadedLatch = new CountDownLatch(1);
     ((TableView) instance.getRoot()).getItems().addListener((InvalidationListener) observable -> loadedLatch.countDown());
 
     instance.loadLocalReplaysInBackground();
+    instance.onLocalReplaysChanged(new LocalReplaysChangedEvent(replays, new ArrayList<Replay>()));
 
     assertTrue(loadedLatch.await(5000, TimeUnit.MILLISECONDS));
     assertThat(((TableView) instance.getRoot()).getItems().size(), is(3));
 
-    verify(taskService).submitTask(task);
     verifyZeroInteractions(notificationService);
   }
 }

--- a/src/test/java/com/faforever/client/vault/replay/ReplayVaultControllerTest.java
+++ b/src/test/java/com/faforever/client/vault/replay/ReplayVaultControllerTest.java
@@ -11,6 +11,7 @@ import com.faforever.client.task.TaskService;
 import com.faforever.client.test.AbstractPlainJavaFxTest;
 import com.faforever.client.theme.UiService;
 import com.faforever.client.util.TimeService;
+import com.google.common.eventbus.EventBus;
 import javafx.beans.InvalidationListener;
 import javafx.scene.control.TableView;
 import org.junit.Before;
@@ -57,11 +58,13 @@ public class ReplayVaultControllerTest extends AbstractPlainJavaFxTest {
   private ReportingService reportingService;
   @Mock
   private UiService uiService;
+  @Mock
+  private EventBus eventBus;
 
   @Before
   public void setUp() throws Exception {
     instance = new ReplayVaultController(notificationService, replayService, mapService, taskService, i18n, timeService,
-        reportingService, applicationContext, uiService);
+        reportingService, applicationContext, uiService, eventBus);
 
     doReturn(new LoadLocalReplaysTask(replayService, i18n)).when(applicationContext).getBean(eq(LoadLocalReplaysTask.class));
 


### PR DESCRIPTION
Currently, `.fafreplay` files are combined from two lines of text:

1. Metadata, encoded to JSON and without any linebreaks
2. FA replay data (binary), encoded as a Base64 string

Previously, parsing the replay and reading the metadata would read in the whole file, requiring lots of memory. This patch uses a NIO stream to only read the first line, thereby reducing the required amount of memory and possibly accelerate parsing.