### PR TITLE
Replay parsing efficiency improvement

### DIFF
--- a/src/main/java/com/faforever/client/replay/ReplayFileReaderImpl.java
+++ b/src/main/java/com/faforever/client/replay/ReplayFileReaderImpl.java
@@ -19,6 +19,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Stream;
+
+import static com.github.nocatch.NoCatch.noCatch;
 
 @Lazy
 @Component
@@ -37,22 +40,25 @@ public class ReplayFileReaderImpl implements ReplayFileReader {
   @SneakyThrows
   public LocalReplayInfo parseMetaData(Path replayFile) {
     logger.debug("Parsing metadata of replay file: {}", replayFile);
-    Optional<String> metadata = Files.lines(replayFile).findFirst();
-    if (metadata.isPresent()) {
-      return gson.fromJson(metadata.get(), LocalReplayInfo.class);
+    try (Stream<String> stream = Files.lines(replayFile)) {
+      return stream
+          .findFirst()
+          .map(jsonString -> gson.fromJson(jsonString, LocalReplayInfo.class))
+          .orElseThrow(() -> new IOException(String.format("Failed to extract metadata from replay file: {}", replayFile)));
     }
-    throw new IOException(String.format("Failed to extract metadata from replay file: {}", replayFile));
   }
 
   @Override
   @SneakyThrows
   public byte[] readRawReplayData(Path replayFile) {
     logger.debug("Reading replay file: {}", replayFile);
-    Optional<String> replayData = Files.lines(replayFile).skip(1).findFirst();
-    if (replayData.isPresent()) {
-      return QtCompress.qUncompress(BaseEncoding.base64().decode(replayData.get()));
+    try (Stream<String> stream = Files.lines(replayFile)) {
+      return stream
+          .skip(1)
+          .findFirst()
+          .map(base64String -> noCatch(() -> QtCompress.qUncompress(BaseEncoding.base64().decode(base64String))))
+          .orElseThrow(() -> new IOException(String.format("Failed to extract replay data from replay file: {}", replayFile)));
     }
-    throw new IOException(String.format("Failed to extract replay data from replay file: {}", replayFile));
   }
 
   @Override


### PR DESCRIPTION
Currently, `.fafreplay` files are combined from two lines of text:

1.  Metadata, encoded to JSON and without any linebreaks
2.  FA replay data (binary), encoded as a Base64 string

Previously, parsing the replay and reading the metadata would read in the whole file, requiring lots of memory. This patch uses a NIO stream to only read the first line, thereby reducing the required amount of memory and possibly accelerate parsing.