### PR TITLE
Added "View Replays" from the context menu in the chat user list

### DIFF
--- a/src/main/java/com/faforever/client/chat/ChatUserContextMenuController.java
+++ b/src/main/java/com/faforever/client/chat/ChatUserContextMenuController.java
@@ -8,6 +8,7 @@ import com.faforever.client.fx.StringListCell;
 import com.faforever.client.game.JoinGameHelper;
 import com.faforever.client.game.PlayerStatus;
 import com.faforever.client.i18n.I18n;
+import com.faforever.client.main.event.ShowUserReplaysEvent;
 import com.faforever.client.moderator.BanDialogController;
 import com.faforever.client.moderator.ModeratorService;
 import com.faforever.client.notification.ImmediateNotification;
@@ -153,6 +154,7 @@ public class ChatUserContextMenuController implements Controller<ContextMenu> {
   public void setChatUser(ChatChannelUser chatUser) {
     this.chatUser = chatUser;
     showUserInfo.visibleProperty().bind(chatUser.playerProperty().isNotNull());
+    viewReplaysItem.visibleProperty().bind(chatUser.playerProperty().isNotNull());
 
     ChatPrefs chatPrefs = preferencesService.getPreferences().getChat();
 
@@ -295,7 +297,8 @@ public class ChatUserContextMenuController implements Controller<ContextMenu> {
   }
 
   public void onViewReplaysSelected() {
-    // FIXME implement
+    Player player = getPlayer();
+    eventBus.post(new ShowUserReplaysEvent(player.getId()));
   }
 
   public void onInviteToGameSelected() {

--- a/src/main/java/com/faforever/client/main/event/ShowUserReplaysEvent.java
+++ b/src/main/java/com/faforever/client/main/event/ShowUserReplaysEvent.java
@@ -1,0 +1,10 @@
+package com.faforever.client.main.event;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class ShowUserReplaysEvent extends OpenOnlineReplayVaultEvent {
+  private final int playerId;
+}

--- a/src/main/java/com/faforever/client/replay/OnlineReplayVaultController.java
+++ b/src/main/java/com/faforever/client/replay/OnlineReplayVaultController.java
@@ -12,6 +12,7 @@ import com.faforever.client.notification.ImmediateNotification;
 import com.faforever.client.notification.NotificationService;
 import com.faforever.client.notification.Severity;
 import com.faforever.client.preferences.PreferencesService;
+import com.faforever.client.query.SearchablePropertyMappings;
 import com.faforever.client.reporting.ReportingService;
 import com.faforever.client.theme.UiService;
 import com.faforever.client.vault.search.SearchController;
@@ -43,8 +44,6 @@ import java.lang.invoke.MethodHandles;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
-
-import static com.faforever.client.query.SearchablePropertyMappings.GAME_PROPERTY_MAPPING;
 
 @Component
 @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
@@ -104,7 +103,7 @@ public class OnlineReplayVaultController extends AbstractViewController<Node> {
 
     searchController.setRootType(Game.class);
     searchController.setSearchListener(this::onSearch);
-    searchController.setSearchableProperties(GAME_PROPERTY_MAPPING);
+    searchController.setSearchableProperties(SearchablePropertyMappings.GAME_PROPERTY_MAPPING);
     searchController.setSortConfig(preferencesService.getPreferences().getVaultPrefs().onlineReplaySortConfigProperty());
 
     BooleanBinding inSearchableState = Bindings.createBooleanBinding(() -> state.get() != State.SEARCHING, state);

--- a/src/main/java/com/faforever/client/replay/ReplayService.java
+++ b/src/main/java/com/faforever/client/replay/ReplayService.java
@@ -26,6 +26,8 @@ import com.faforever.client.reporting.ReportingService;
 import com.faforever.client.task.TaskService;
 import com.faforever.client.vault.search.SearchController.SortConfig;
 import com.faforever.commons.replay.ReplayData;
+import com.github.rutledgepaulv.qbuilders.conditions.Condition;
+import com.github.rutledgepaulv.qbuilders.visitors.RSQLVisitor;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Splitter;
 import com.google.common.net.UrlEscapers;
@@ -64,6 +66,7 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import static com.faforever.client.notification.Severity.WARN;
+import static com.faforever.commons.api.elide.ElideNavigator.qBuilder;
 import static com.github.nocatch.NoCatch.noCatch;
 import static java.net.URLDecoder.decode;
 import static java.nio.charset.StandardCharsets.US_ASCII;
@@ -273,21 +276,23 @@ public class ReplayService {
     return fafService.getNewestReplays(topElementCount, page);
   }
 
+  public CompletableFuture<List<Replay>> getReplaysForPlayer(int playerId, int maxResults, int page, SortConfig sortConfig) {
+    Condition<?> filterCondition = qBuilder().intNum("playerStats.player.id").eq(playerId);
+    String query = filterCondition.query(new RSQLVisitor());
+    return fafService.findReplaysByQuery(query, maxResults, page, sortConfig);
+  }
 
   public CompletableFuture<List<Replay>> getHighestRatedReplays(int topElementCount, int page) {
     return fafService.getHighestRatedReplays(topElementCount, page);
   }
 
-
   public CompletableFuture<List<Replay>> findByQuery(String query, int maxResults, int page, SortConfig sortConfig) {
     return fafService.findReplaysByQuery(query, maxResults, page, sortConfig);
   }
 
-
   public CompletableFuture<Optional<Replay>> findById(int id) {
     return fafService.findReplayById(id);
   }
-
 
   public CompletableFuture<Path> downloadReplay(int id) {
     ReplayDownloadTask task = applicationContext.getBean(ReplayDownloadTask.class);

--- a/src/main/resources/theme/chat/chat_user_context_menu.fxml
+++ b/src/main/resources/theme/chat/chat_user_context_menu.fxml
@@ -18,7 +18,7 @@
                 text="%chat.userContext.privateMessage"/>
       <MenuItem fx:id="copyUsernameItem" mnemonicParsing="false" onAction="#onCopyUsernameSelected"
                 text="%chat.userContext.copyUsername"/>
-    <CustomMenuItem fx:id="colorPickerMenuItem" hideOnClick="false" mnemonicParsing="false">
+      <CustomMenuItem fx:id="colorPickerMenuItem" hideOnClick="false" mnemonicParsing="false">
         <content>
             <HBox alignment="CENTER_LEFT" spacing="10.0">
                 <children>
@@ -43,7 +43,7 @@
                 text="%chat.userContext.joinGame"/>
       <MenuItem fx:id="watchGameItem" mnemonicParsing="false" onAction="#onWatchGameSelected"
                 text="%chat.userContext.viewLiveReplay"/>
-      <MenuItem fx:id="viewReplaysItem" disable="true" mnemonicParsing="false" onAction="#onViewReplaysSelected"
+      <MenuItem fx:id="viewReplaysItem" mnemonicParsing="false" onAction="#onViewReplaysSelected"
                 text="%chat.userContext.viewReplays"/>
       <MenuItem fx:id="inviteItem" disable="true" mnemonicParsing="false" onAction="#onInviteToGameSelected"
                 text="%chat.userContext.inviteToGame"/>

--- a/src/test/java/com/faforever/client/chat/ChatChannelUserContextMenuControllerTest.java
+++ b/src/test/java/com/faforever/client/chat/ChatChannelUserContextMenuControllerTest.java
@@ -262,5 +262,6 @@ public class ChatChannelUserContextMenuControllerTest extends AbstractPlainJavaF
     chatUser.setPlayer(null);
     instance.setChatUser(chatUser);
     assertThat(instance.showUserInfo.isVisible(), is(false));
+    assertThat(instance.viewReplaysItem.isVisible(), is(false));
   }
 }


### PR DESCRIPTION
This PR enables the contextual menu item "View Replays" in the chat user list. When the menu item is clicked, the client switches to the replay vault view and fetches the last 100 replays of the respective user and displays them as search results.