### PR TITLE
Slightly improved ladder counter efficiency

### DIFF
--- a/src/main/java/com/faforever/client/rankedmatch/Ladder1v1Controller.java
+++ b/src/main/java/com/faforever/client/rankedmatch/Ladder1v1Controller.java
@@ -170,7 +170,7 @@ public class Ladder1v1Controller extends AbstractViewController<Node> implements
     });
     
     timeUntilQueuePopLabel.setVisible(false);
-    queuePopTimeUpdater = new Timeline(new KeyFrame(javafx.util.Duration.seconds(0), (ActionEvent event) -> {
+    queuePopTimeUpdater = new Timeline(1,new KeyFrame(javafx.util.Duration.seconds(0), (ActionEvent event) -> {
       if (nextQueuePopTime != null) {
         Instant now = Instant.now();
         Duration timeUntilPopQueue = Duration.between(now, nextQueuePopTime);

--- a/src/test/java/com/faforever/client/rankedmatch/Ladder1V1ControllerTest.java
+++ b/src/test/java/com/faforever/client/rankedmatch/Ladder1V1ControllerTest.java
@@ -48,6 +48,7 @@ import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -214,7 +215,7 @@ public class Ladder1V1ControllerTest extends AbstractPlainJavaFxTest {
     
     listenerCaptor.getValue().accept(message);
     WaitForAsyncUtils.waitFor(3, TimeUnit.SECONDS, () -> instance.timeUntilQueuePopLabel.isVisible());
-    verify(i18n).get(any(), eq(1L), anyInt());
+    verify(i18n, atLeast(1)).get(any(), eq(1L), anyInt());
     WaitForAsyncUtils.waitForFxEvents();
   }
 }


### PR DESCRIPTION
Might help with https://github.com/FAForever/downlords-faf-client/issues/1518
Previously, the counter and the corresponding label would be updated 60 times/second. With this patch, this is reduced to once a second, which has no downsides in this case.