### PR TITLE
Remove player choice from live replay button

### DIFF
--- a/src/main/java/com/faforever/client/chat/ChatUserContextMenuController.java
+++ b/src/main/java/com/faforever/client/chat/ChatUserContextMenuController.java
@@ -287,7 +287,7 @@ public class ChatUserContextMenuController implements Controller<ContextMenu> {
   public void onWatchGameSelected() {
     Player player = getPlayer();
     try {
-      replayService.runLiveReplay(player.getGame().getId(), player.getId());
+      replayService.runLiveReplay(player.getGame().getId());
     } catch (Exception e) {
       logger.error("Cannot display live replay {}", e.getCause());
       String title = i18n.get("replays.live.loadFailure.title");

--- a/src/main/java/com/faforever/client/discord/ClientDiscordEventHandler.java
+++ b/src/main/java/com/faforever/client/discord/ClientDiscordEventHandler.java
@@ -48,7 +48,7 @@ public class ClientDiscordEventHandler extends DiscordEventHandlers {
   private void onSpectate(String spectateSecret) {
     DiscordSpectateSecret discordSpectateSecret = new Gson().fromJson(spectateSecret, DiscordSpectateSecret.class);
     try {
-      applicationEventPublisher.publishEvent(new DiscordSpectateEvent(discordSpectateSecret.getGameId(), discordSpectateSecret.getPlayerId()));
+      applicationEventPublisher.publishEvent(new DiscordSpectateEvent(discordSpectateSecret.getGameId()));
     } catch (Exception e) {
       notificationService.addImmediateErrorNotification(e, "replay.couldNotOpen", discordSpectateSecret.getGameId());
       log.error("Could not join game from discord rich presence", e);

--- a/src/main/java/com/faforever/client/discord/DiscordRichPresenceService.java
+++ b/src/main/java/com/faforever/client/discord/DiscordRichPresenceService.java
@@ -86,7 +86,7 @@ public class DiscordRichPresenceService implements DisposableBean {
       }
 
       if (game.getStatus() == GameStatus.PLAYING && game.getStartTime() != null && game.getStartTime().isAfter(Instant.now().plus(5, ChronoUnit.MINUTES))) {
-        spectateSecret = new Gson().toJson(new DiscordSpectateSecret(game.getId(),currentPlayerId));
+        spectateSecret = new Gson().toJson(new DiscordSpectateSecret(game.getId()));
       }
 
       discordRichPresence.setSecrets(joinSecret, spectateSecret);

--- a/src/main/java/com/faforever/client/discord/DiscordSpectateEvent.java
+++ b/src/main/java/com/faforever/client/discord/DiscordSpectateEvent.java
@@ -5,5 +5,4 @@ import lombok.Data;
 @Data
 public class DiscordSpectateEvent {
   private final Integer replayId;
-  private final Integer playerId;
 }

--- a/src/main/java/com/faforever/client/discord/DiscordSpectateSecret.java
+++ b/src/main/java/com/faforever/client/discord/DiscordSpectateSecret.java
@@ -1,10 +1,8 @@
 package com.faforever.client.discord;
 
-import com.google.gson.JsonElement;
 import lombok.Value;
 
 @Value
 public class DiscordSpectateSecret{
   private int gameId;
-  private int playerId;
 }

--- a/src/main/java/com/faforever/client/vault/replay/WatchButtonController.java
+++ b/src/main/java/com/faforever/client/vault/replay/WatchButtonController.java
@@ -4,44 +4,34 @@ import com.faforever.client.config.ClientProperties;
 import com.faforever.client.fx.Controller;
 import com.faforever.client.game.Game;
 import com.faforever.client.i18n.I18n;
-import com.faforever.client.player.Player;
-import com.faforever.client.player.PlayerService;
 import com.faforever.client.replay.ReplayService;
 import com.faforever.client.util.TimeService;
 import javafx.animation.KeyFrame;
 import javafx.animation.Timeline;
 import javafx.scene.Node;
-import javafx.scene.control.MenuButton;
-import javafx.scene.control.MenuItem;
+import javafx.scene.control.Button;
 import javafx.util.Duration;
-import org.jetbrains.annotations.NotNull;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 import org.springframework.util.Assert;
 
 import java.time.Instant;
-import java.util.Collection;
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
 
 @Component
 @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
 public class WatchButtonController implements Controller<Node> {
   private final ReplayService replayService;
-  private final PlayerService playerService;
   private final ClientProperties clientProperties;
   private final TimeService timeService;
 
-  public MenuButton watchButton;
+  public Button watchButton;
   private Game game;
   private I18n i18n;
   private Timeline delayTimeline;
 
-  public WatchButtonController(ReplayService replayService, PlayerService playerService, ClientProperties clientProperties, TimeService timeService, I18n i18n) {
+  public WatchButtonController(ReplayService replayService, ClientProperties clientProperties, TimeService timeService, I18n i18n) {
     this.replayService = replayService;
-    this.playerService = playerService;
     this.clientProperties = clientProperties;
     this.timeService = timeService;
     this.i18n = i18n;
@@ -55,30 +45,13 @@ public class WatchButtonController implements Controller<Node> {
     delayTimeline.setCycleCount(Timeline.INDEFINITE);
 
     watchButton.setDisable(true);
+    watchButton.setOnAction(event -> replayService.runLiveReplay(game.getId()));
   }
 
   public void setGame(Game game) {
     this.game = game;
     Assert.notNull(game.getStartTime(), "The game's start must not be null: " + game);
-
-    List<MenuItem> menuItems = game.getTeams().values().stream()
-        .flatMap(Collection::stream)
-        .map(playerService::getPlayerForUsername)
-        .filter(Optional::isPresent)
-        .map(Optional::get)
-        .map(player -> createMenuItem(game, player))
-        .collect(Collectors.toList());
-
-    watchButton.getItems().setAll(menuItems);
     delayTimeline.play();
-  }
-
-  @NotNull
-  private MenuItem createMenuItem(Game game, Player player) {
-    MenuItem menuItem = new MenuItem(player.getUsername());
-    menuItem.setUserData(player.getId());
-    menuItem.setOnAction(event -> replayService.runLiveReplay(game.getId(), player.getId()));
-    return menuItem;
   }
 
   private void updateWatchButtonTimer() {

--- a/src/main/resources/theme/vault/replay/watch_button.fxml
+++ b/src/main/resources/theme/vault/replay/watch_button.fxml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 
-<?import javafx.scene.control.MenuButton?>
-<MenuButton xmlns:fx="http://javafx.com/fxml/1" fx:id="watchButton" disable="true" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minHeight="-Infinity" minWidth="-Infinity" mnemonicParsing="false" text="%game.watchButtonFormat" xmlns="http://javafx.com/javafx/8.0.141" fx:controller="com.faforever.client.vault.replay.WatchButtonController" />
+<?import com.jfoenix.controls.JFXButton?>
+<JFXButton xmlns:fx="http://javafx.com/fxml/1" fx:id="watchButton" disable="true" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minHeight="-Infinity" minWidth="-Infinity" mnemonicParsing="false" text="%game.watchButtonFormat" xmlns="http://javafx.com/javafx/8.0.141" fx:controller="com.faforever.client.vault.replay.WatchButtonController" />

--- a/src/test/java/com/faforever/client/chat/ChatChannelUserContextMenuControllerTest.java
+++ b/src/test/java/com/faforever/client/chat/ChatChannelUserContextMenuControllerTest.java
@@ -219,14 +219,14 @@ public class ChatChannelUserContextMenuControllerTest extends AbstractPlainJavaF
 
     instance.onWatchGameSelected();
 
-    verify(replayService).runLiveReplay(player.getGame().getId(), player.getId());
+    verify(replayService).runLiveReplay(player.getGame().getId());
   }
 
   @Test
   public void testOnWatchGameThrowsIoExceptionTriggersNotification() {
     instance.setChatUser(chatUser);
 
-    doThrow(new RuntimeException("Error in runLiveReplay")).when(replayService).runLiveReplay(anyInt(), anyInt());
+    doThrow(new RuntimeException("Error in runLiveReplay")).when(replayService).runLiveReplay(anyInt());
 
     instance.onWatchGameSelected();
 

--- a/src/test/java/com/faforever/client/replay/ReplayServiceTest.java
+++ b/src/test/java/com/faforever/client/replay/ReplayServiceTest.java
@@ -12,6 +12,7 @@ import com.faforever.client.mod.ModService;
 import com.faforever.client.notification.ImmediateNotification;
 import com.faforever.client.notification.NotificationService;
 import com.faforever.client.notification.PersistentNotification;
+import com.faforever.client.player.PlayerService;
 import com.faforever.client.preferences.PreferencesService;
 import com.faforever.client.remote.FafService;
 import com.faforever.client.reporting.ReportingService;
@@ -130,6 +131,8 @@ public class ReplayServiceTest {
   @Mock
   private GameService gameService;
   @Mock
+  private PlayerService playerService;
+  @Mock
   private FafService fafService;
   @Mock
   private ReportingService reportingService;
@@ -148,7 +151,7 @@ public class ReplayServiceTest {
   public void setUp() throws Exception {
     MockitoAnnotations.initMocks(this);
 
-    instance = new ReplayService(new ClientProperties(), preferencesService, replayFileReader, notificationService, gameService,
+    instance = new ReplayService(new ClientProperties(), preferencesService, replayFileReader, notificationService, gameService, playerService,
         taskService, i18n, reportingService, applicationContext, platformService, fafService, modService, mapService, publisher, executorService);
 
     when(preferencesService.getReplaysDirectory()).thenReturn(replayDirectory.getRoot().toPath());


### PR DESCRIPTION
Current live replay server merges all incoming streams into one,
therefore there's no need to select a specific player when launching a
live replay. Remove the selection from the UI, but still pick and send
some player's name in case the replay server finds it useful.

Fixes #1375.

Signed-off-by: Igor Kotrasinski <i.kotrasinsk@gmail.com>