### PR TITLE
Properly handle futures when the local replay directory has changed

### DIFF
--- a/src/main/java/com/faforever/client/replay/ReplayService.java
+++ b/src/main/java/com/faforever/client/replay/ReplayService.java
@@ -132,7 +132,7 @@ public class ReplayService {
   private final ExecutorService executorService;
   private Thread directoryWatcherThread;
   private WatchService watchService;
-  private List<Replay> localReplays = new ArrayList<Replay>();
+  protected List<Replay> localReplays = new ArrayList<Replay>();
 
   public void startLoadingAndWatchingLocalReplays() {
     Path replaysDirectory = preferencesService.getReplaysDirectory();
@@ -177,7 +177,8 @@ public class ReplayService {
     return thread;
   }
 
-  private void onLocalReplaysWatchEvent(WatchKey key) {
+  @VisibleForTesting
+  protected void onLocalReplaysWatchEvent(WatchKey key) {
     List<CompletableFuture<Replay>> newReplaysFutures = new ArrayList<CompletableFuture<Replay>>();
     Collection<Replay> deletedReplays = new ArrayList<Replay>();
     for (WatchEvent<?> watchEvent : key.pollEvents()) {

--- a/src/main/java/com/faforever/client/vault/replay/ReplayVaultController.java
+++ b/src/main/java/com/faforever/client/vault/replay/ReplayVaultController.java
@@ -15,15 +15,12 @@ import com.faforever.client.task.TaskService;
 import com.faforever.client.theme.UiService;
 import com.faforever.client.util.TimeService;
 import com.faforever.client.vault.map.MapPreviewTableCellController;
-import com.faforever.client.vault.review.Review;
 import com.google.common.base.Joiner;
-import javafx.application.Platform;
 import javafx.beans.binding.StringBinding;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.value.ObservableValue;
 import javafx.collections.ObservableMap;
 import javafx.scene.Node;
-import javafx.scene.control.Spinner;
 import javafx.scene.control.TableCell;
 import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableRow;
@@ -37,10 +34,7 @@ import lombok.RequiredArgsConstructor;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.context.ApplicationContext;
-import org.springframework.context.ApplicationListener;
-import org.springframework.context.annotation.Scope;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
@@ -183,9 +177,12 @@ public class ReplayVaultController extends AbstractViewController<Node> {
       protected void updateItem(MapBean map, boolean empty) {
         super.updateItem(map, empty);
 
-        if (empty || map == null) {
+        if (empty) {
           setText(null);
           setGraphic(null);
+        } else if (map == null) {
+          setGraphic(null);
+          setText(i18n.get("map.unknown"));
         } else {
           imageView.setImage(mapService.loadPreview(map.getFolderName(), PreviewSize.SMALL));
           setGraphic(imageView);

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -748,6 +748,7 @@ server.kicked.message=You were kicked from FAF by a moderator. Please refer to o
 game.kicked.title=You were kicked from the game
 game.kicked.message=Your game was closed by a moderator. Please refer to our rules for the lobby/game here {0}.
 gameQuality.undefined=-
+map.unknown=unknown
 replay.ignoreMapNotFound=Ignore and start replay
 replay.abortAfterMapNotFound=Abort and show more info
 replay.mapDownloadFailed=Map download failed for this replay


### PR DESCRIPTION
Fixes #1541.

Previously, the code failed to properly wait on completion of futures that load replays. Depending on the timing, the new local replays may have been added correctly or not. This PR fixes that.