### PR TITLE
Don't omit coop maps from the local map list

### DIFF
--- a/src/main/java/com/faforever/client/game/CreateGameController.java
+++ b/src/main/java/com/faforever/client/game/CreateGameController.java
@@ -6,6 +6,7 @@ import com.faforever.client.fx.JavaFxUtil;
 import com.faforever.client.fx.StringListCell;
 import com.faforever.client.i18n.I18n;
 import com.faforever.client.map.MapBean;
+import com.faforever.client.map.MapBean.Type;
 import com.faforever.client.map.MapService;
 import com.faforever.client.map.MapService.PreviewSize;
 import com.faforever.client.map.MapSize;
@@ -112,7 +113,7 @@ public class CreateGameController implements Controller<Pane> {
     mapPreviewPane.prefHeightProperty().bind(mapPreviewPane.widthProperty());
     mapSearchTextField.textProperty().addListener((observable, oldValue, newValue) -> {
       if (newValue.isEmpty()) {
-        filteredMapBeans.setPredicate(mapInfoBean -> true);
+        filteredMapBeans.setPredicate(null);
       } else {
         filteredMapBeans.setPredicate(mapInfoBean -> mapInfoBean.getDisplayName().toLowerCase().contains(newValue.toLowerCase())
             || mapInfoBean.getFolderName().toLowerCase().contains(newValue.toLowerCase()));
@@ -237,7 +238,7 @@ public class CreateGameController implements Controller<Pane> {
 
   private void initMapSelection() {
     filteredMapBeans = new FilteredList<>(
-        mapService.getInstalledMaps().sorted((o1, o2) -> o1.getDisplayName().compareToIgnoreCase(o2.getDisplayName()))
+        mapService.getInstalledMaps().filtered(mapBean -> mapBean.getType() == Type.SKIRMISH).sorted((o1, o2) -> o1.getDisplayName().compareToIgnoreCase(o2.getDisplayName()))
     );
 
     mapListView.setItems(filteredMapBeans);

--- a/src/main/java/com/faforever/client/map/MapService.java
+++ b/src/main/java/com/faforever/client/map/MapService.java
@@ -94,7 +94,7 @@ public class MapService implements InitializingBean, DisposableBean {
   private final String mapDownloadUrlFormat;
   private final String mapPreviewUrlFormat;
   private final Map<Path, MapBean> pathToMap = new HashMap<>();
-  private final ObservableList<MapBean> installedSkirmishMaps = FXCollections.observableArrayList();
+  private final ObservableList<MapBean> installedMaps = FXCollections.observableArrayList();
   private final Map<String, MapBean> mapsByFolderName = new HashMap<>();
   private Thread directoryWatcherThread;
 
@@ -124,7 +124,7 @@ public class MapService implements InitializingBean, DisposableBean {
     this.mapDownloadUrlFormat = vault.getMapDownloadUrlFormat();
     this.mapPreviewUrlFormat = vault.getMapPreviewUrlFormat();
 
-    installedSkirmishMaps.addListener((ListChangeListener<MapBean>) change -> {
+    installedMaps.addListener((ListChangeListener<MapBean>) change -> {
       while (change.next()) {
         for (MapBean mapBean : change.getRemoved()) {
           mapsByFolderName.remove(mapBean.getFolderName().toLowerCase());
@@ -182,7 +182,7 @@ public class MapService implements InitializingBean, DisposableBean {
       // TODO notify user
     }
 
-    installedSkirmishMaps.clear();
+    installedMaps.clear();
     loadInstalledMaps();
   }
 
@@ -223,7 +223,7 @@ public class MapService implements InitializingBean, DisposableBean {
           long mapsRead = 0;
           for (Path mapPath : mapPaths) {
             updateProgress(++mapsRead, totalMaps);
-            addSkirmishMap(mapPath);
+            addInstalledMap(mapPath);
           }
         } catch (IOException e) {
           logger.warn("Maps could not be read from: " + forgedAlliancePreferences.getCustomMapsDirectory(), e);
@@ -234,15 +234,15 @@ public class MapService implements InitializingBean, DisposableBean {
   }
 
   private void removeMap(Path path) {
-    installedSkirmishMaps.remove(pathToMap.remove(path));
+    installedMaps.remove(pathToMap.remove(path));
   }
 
-  private void addSkirmishMap(Path path) throws MapLoadException {
+  private void addInstalledMap(Path path) throws MapLoadException {
     try {
       MapBean mapBean = readMap(path);
       pathToMap.put(path, mapBean);
-      if (!mapsByFolderName.containsKey(mapBean.getFolderName()) && mapBean.getType() == Type.SKIRMISH) {
-        installedSkirmishMaps.add(mapBean);
+      if (!mapsByFolderName.containsKey(mapBean.getFolderName())) {
+        installedMaps.add(mapBean);
       }
     } catch (MapLoadException e) {
       logger.warn("Map could not be read: " + path.getFileName(), e);
@@ -251,7 +251,7 @@ public class MapService implements InitializingBean, DisposableBean {
 
   @Subscribe
   public void onMapGenerated(MapGeneratedEvent event) {
-    addSkirmishMap(getPathForMap(event.getMapName()));
+    addInstalledMap(getPathForMap(event.getMapName()));
   }
 
 
@@ -303,24 +303,19 @@ public class MapService implements InitializingBean, DisposableBean {
 
 
   public ObservableList<MapBean> getInstalledMaps() {
-    return installedSkirmishMaps;
+    return installedMaps;
   }
-
 
   public Optional<MapBean> getMapLocallyFromName(String mapFolderName) {
     logger.debug("Trying to find map '{}' locally", mapFolderName);
-    ObservableList<MapBean> installedMaps = getInstalledMaps();
-    synchronized (installedMaps) {
-      for (MapBean mapBean : installedMaps) {
-        if (mapFolderName.equalsIgnoreCase(mapBean.getFolderName())) {
-          logger.debug("Found map {} locally", mapFolderName);
-          return Optional.of(mapBean);
-        }
-      }
+    String mapFolderKey = mapFolderName.toLowerCase();
+    if (!mapsByFolderName.containsKey(mapFolderKey)) {
+      return Optional.empty();
+    } else {
+      MapBean mapBean = mapsByFolderName.get(mapFolderKey);
+      return Optional.of(mapBean);
     }
-    return Optional.empty();
   }
-
 
   public boolean isOfficialMap(String mapName) {
     return officialMaps.stream().anyMatch(name -> name.equalsIgnoreCase(mapName));
@@ -506,7 +501,7 @@ public class MapService implements InitializingBean, DisposableBean {
     }
 
     return taskService.submitTask(task).getFuture()
-        .thenAccept(aVoid -> noCatch(() -> addSkirmishMap(getPathForMapInsensitive(folderName))));
+        .thenAccept(aVoid -> noCatch(() -> addInstalledMap(getPathForMapInsensitive(folderName))));
   }
 
   public CompletableFuture<List<MapBean>> getOwnedMaps(int playerId, int loadMoreCount, int page) {

--- a/src/main/java/com/faforever/client/map/MapService.java
+++ b/src/main/java/com/faforever/client/map/MapService.java
@@ -309,12 +309,7 @@ public class MapService implements InitializingBean, DisposableBean {
   public Optional<MapBean> getMapLocallyFromName(String mapFolderName) {
     logger.debug("Trying to find map '{}' locally", mapFolderName);
     String mapFolderKey = mapFolderName.toLowerCase();
-    if (!mapsByFolderName.containsKey(mapFolderKey)) {
-      return Optional.empty();
-    } else {
-      MapBean mapBean = mapsByFolderName.get(mapFolderKey);
-      return Optional.of(mapBean);
-    }
+    return Optional.ofNullable(mapsByFolderName.get(mapFolderKey));
   }
 
   public boolean isOfficialMap(String mapName) {

--- a/src/test/java/com/faforever/client/map/MapBuilder.java
+++ b/src/test/java/com/faforever/client/map/MapBuilder.java
@@ -1,5 +1,7 @@
 package com.faforever.client.map;
 
+import com.faforever.client.map.MapBean.Type;
+
 public class MapBuilder {
 
   private final MapBean mapBean;
@@ -15,6 +17,7 @@ public class MapBuilder {
   public MapBuilder defaultValues() {
     return displayName("Map name")
         .folderName("map_name.v001")
+        .type(Type.SKIRMISH)
         .mapSize(MapSize.valueOf(512, 512));
   }
 
@@ -30,6 +33,11 @@ public class MapBuilder {
 
   public MapBuilder displayName(String displayName) {
     mapBean.setDisplayName(displayName);
+    return this;
+  }
+
+  public MapBuilder type(Type type) {
+    mapBean.setType(type);
     return this;
   }
 


### PR DESCRIPTION
Fixes #1560 and probably also #1246.

Previously, only skirmish maps were added to the list of installed maps. This led to replays of coop missions not showing up.
This patch fixes this while retaining the filter for skirmish maps when creating a new game.