### PR TITLE
Change "Ø Rating" to "Avg. Rating"

### DIFF
--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -197,7 +197,7 @@ game.title=Title
 game.players=Players
 game.map=Map
 game.ratingRange=Rating Range
-game.averageRating=Ø Rating
+game.averageRating=Avg. Rating
 game.ratingFormat.minOnly=>={0,number,#}
 game.ratingFormat.maxOnly=<={0,number,#}
 game.ratingFormat.minMax={0,number,#} - {1,number,#}


### PR DESCRIPTION
Change "Ø Rating" to "Avg. Rating" on the game list because this symbol is not commonly known to mean "Average" in some English-speaking countries. Should probably change in other localizations as well but I don't know how other languages would commonly abbreviate or otherwise represent "Average" so I don't want to change it myself and make it worse.