### PR TITLE
#1651-improve-chat-readability

### DIFF
--- a/src/main/java/com/faforever/client/chat/AbstractChatTabController.java
+++ b/src/main/java/com/faforever/client/chat/AbstractChatTabController.java
@@ -556,7 +556,7 @@ public abstract class AbstractChatTabController implements Controller<Tab> {
     String timeString = timeService.asShortTime(chatMessage.getTime());
     html = html.replace("{time}", timeString)
         .replace("{avatar}", StringUtils.defaultString(avatarUrl))
-        .replace("{username}", login)
+        .replace("{username}", login + ":")
         .replace("{clan-tag}", clanTag)
         .replace("{decorated-clan-tag}", decoratedClanTag)
         .replace("{country-flag}", StringUtils.defaultString(countryFlagUrl))

--- a/src/main/resources/theme/chat/compact/chat_section.html
+++ b/src/main/resources/theme/chat/compact/chat_section.html
@@ -1,14 +1,17 @@
 <table class="chat-section compact chat-section-{username}">
   <tr>
-    <td class="author">
+    <td>
       <span class="author" style="{inline-style}">
         <img class="avatar" src="{avatar}"/>
+      </span>
+    </td>
+    <td ; class="author" style="text-align: right">
+      <span class="author" style="{inline-style}">
         <img class="country-flag" src="{country-flag}"/>
         <span class="clan-tag {css-classes}"
               onmouseover="showClanInfo('{clan-tag}')"
               onmouseout="hideClanInfo()"
               onclick="showClanWebsite('{clan-tag}')">{decorated-clan-tag}</span>
-
         <span class="username {css-classes}"
               onmouseover="showPlayerInfo('{username}')"
               onmouseout="hidePlayerInfo()"


### PR DESCRIPTION
fixes #1651:
-adds ":" after the name in chat
-makes the flag/clan/name right aligned in chat