### PR TITLE
#1668-fix-faction-mapping

### DIFF
--- a/src/main/java/com/faforever/client/game/Faction.java
+++ b/src/main/java/com/faforever/client/game/Faction.java
@@ -8,9 +8,10 @@ import java.util.Map;
 
 public enum Faction {
   // Order is crucial
+  // Same order as the info from the server (1=UEF etc.)
+  UEF("uef"),
   AEON("aeon"),
   CYBRAN("cybran"),
-  UEF("uef"),
   SERAPHIM("seraphim"),
   RANDOM("random"),
   CIVILIAN("civilian");


### PR DESCRIPTION
fixes #1668:
-changes the order in the Faction enum so it reflects the order the server reports in
-added a comment to explain why the order is important, since that is not intuitive
-that fixes the icons in the replay overview being wrong for everything but Sera