### PR TITLE
Send ping with fixed delay instead of fixed rate

### DIFF
--- a/src/main/java/com/faforever/client/remote/FafServerAccessorImpl.java
+++ b/src/main/java/com/faforever/client/remote/FafServerAccessorImpl.java
@@ -523,7 +523,7 @@ public class FafServerAccessorImpl extends AbstractServerAccessor implements Faf
     gameLaunchFuture = null;
   }
 
-  @Scheduled(fixedRate = 60_000, initialDelay = 60_000)
+  @Scheduled(fixedDelay = 60_000, initialDelay = 60_000)
   @Override
   public void ping() {
     if (fafServerSocket == null || !fafServerSocket.isConnected() || serverWriter == null) {


### PR DESCRIPTION
Fixes #1667

Previously, a ping message would be queued every 60 seconds, regardless if the client was stopped (e.g. debugger paused or computer sleeping). This led to a larger number of pings being sent immediately after waking.
This PR changes the behavior to send a ping 60 seconds after the previous one (and only when the app is actually running).