### PR TITLE
Fix placeholders in german localization for game duration

### DIFF
--- a/src/main/resources/i18n/messages_de.properties
+++ b/src/main/resources/i18n/messages_de.properties
@@ -394,8 +394,8 @@ mapNotFound = Die Karte ''{0}'' konnte weder auf dem Server noch auf diesem Comp
 replayCouldNotBeStarted = Replay {0,number,\#} konnte nicht gestartet werden. Siehe unten stehende Fehlermeldung.
 liveReplayCouldNotBeStarted = Live-Replay konnte nicht gestartet werden. Siehe unten stehende Fehlermeldung.
 duration.seconds = {0,number,\#}s
-duration.minutesSeconds = {0,number,\#}min {0,number,\#}s
-duration.hourMinutes = {0,number,\#}h {0,number,\#}min
+duration.minutesSeconds = {0,number,\#}min {1,number,\#}s
+duration.hourMinutes = {0,number,\#}h {1,number,\#}min
 # suppress inspection "TrailingSpacesInProperty"
 vsSeparator=\ vs 
 # suppress inspection "TrailingSpacesInProperty"


### PR DESCRIPTION
Fixes #1673

Previously, game duration in the replay vault would be shown incorrectly when using the german localization because the same placeholder was being used for minutes/seconds and seconds/hours.

(All other localizations seem to be fine.)