### PR TITLE
Make popup windows more consistent

### DIFF
--- a/src/main/java/com/faforever/client/game/CreateGameController.java
+++ b/src/main/java/com/faforever/client/game/CreateGameController.java
@@ -179,7 +179,7 @@ public class CreateGameController implements Controller<Pane> {
   }
 
   public void onCloseButtonClicked() {
-    onCloseButtonClickedListener.run();
+    getRoot().setVisible(false);
   }
 
 
@@ -459,5 +459,13 @@ public class CreateGameController implements Controller<Pane> {
 
   void setOnCloseButtonClickedListener(Runnable onCloseButtonClickedListener) {
     this.onCloseButtonClickedListener = onCloseButtonClickedListener;
+  }
+
+  public void onDimmerClicked() {
+    onCloseButtonClicked();
+  }
+
+  public void onContentPaneClicked(MouseEvent event) {
+    event.consume();
   }
 }

--- a/src/main/java/com/faforever/client/game/CustomGamesController.java
+++ b/src/main/java/com/faforever/client/game/CustomGamesController.java
@@ -71,6 +71,7 @@ public class CustomGamesController extends AbstractViewController<Node> {
   public GameDetailController gameDetailController;
   public ColumnConstraints sidePaneColumn;
   private GamesTableController gamesTableController;
+  private CreateGameController createGameController;
 
   public GridPane gamesGridPane;
   public ToggleButton tableButton;
@@ -110,6 +111,11 @@ public class CustomGamesController extends AbstractViewController<Node> {
         createGameButton.disableProperty().unbind();
       }
     });
+    createGameController = uiService.loadFxml("theme/play/create_game.fxml");
+    Pane createGameRoot = createGameController.getRoot();
+    gamesRoot.getChildren().add(createGameRoot);
+    JavaFxUtil.setAnchors(createGameRoot, 0d);
+    createGameRoot.setVisible(false);
 
     chooseSortingTypeChoiceBox.setVisible(false);
     chooseSortingTypeChoiceBox.setConverter(new StringConverter<>() {
@@ -201,17 +207,12 @@ public class CustomGamesController extends AbstractViewController<Node> {
       return;
     }
 
-    CreateGameController createGameController = uiService.loadFxml("theme/play/create_game.fxml");
-
     if (mapFolderName != null && !createGameController.selectMap(mapFolderName)) {
       log.warn("Map with folder name '{}' could not be found in map list", mapFolderName);
     }
 
-    Pane root = createGameController.getRoot();
-    JFXDialog dialog = uiService.showInDialog(gamesRoot, root, i18n.get("games.create"));
-    createGameController.setOnCloseButtonClickedListener(dialog::close);
-
-    root.requestFocus();
+    createGameController.getRoot().setVisible(true);
+    createGameController.getRoot().requestFocus();
   }
 
   public Node getRoot() {

--- a/src/main/resources/theme/play/create_game.fxml
+++ b/src/main/resources/theme/play/create_game.fxml
@@ -15,7 +15,12 @@
 <?import javafx.scene.layout.Pane?>
 <?import javafx.scene.layout.RowConstraints?>
 <?import javafx.scene.layout.VBox?>
-<GridPane xmlns:fx="http://javafx.com/fxml/1" fx:id="createGameRoot" hgap="10.0" styleClass="create-game-root" vgap="10.0" xmlns="http://javafx.com/javafx/8.0.141" fx:controller="com.faforever.client.game.CreateGameController">
+<?import javafx.scene.layout.StackPane?>
+<?import javafx.scene.layout.AnchorPane?>
+<StackPane xmlns:fx="http://javafx.com/fxml/1" fx:id="createGameRoot" alignment="CENTER" xmlns="http://javafx.com/javafx/8.0.141"
+           fx:controller="com.faforever.client.game.CreateGameController" onMouseClicked="#onDimmerClicked" styleClass="dimmer">
+    <AnchorPane maxWidth="1000" minWidth="880" onMouseClicked="#onContentPaneClicked" styleClass="modal-popup">
+    <GridPane hgap="10.0" vgap="10.0" AnchorPane.bottomAnchor="20.0" AnchorPane.leftAnchor="20.0" AnchorPane.rightAnchor="20.0" AnchorPane.topAnchor="20.0">
     <columnConstraints>
         <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="256.0" />
         <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="256.0" />
@@ -43,11 +48,11 @@
         <Label alignment="CENTER_RIGHT" maxWidth="1.7976931348623157E308" text="%game.create.rating" textAlignment="JUSTIFY" GridPane.columnIndex="2" GridPane.rowIndex="1" />
         <HBox alignment="CENTER" maxWidth="1.7976931348623157E308" spacing="10.0" GridPane.columnIndex="3" GridPane.columnSpan="2147483647" GridPane.rowIndex="1">
             <children>
-                <JFXTextField fx:id="minRankingTextField" minWidth="30.0" prefWidth="60.0" promptText="%games.create.minRating" HBox.hgrow="NEVER" />
                 <Label text="%games.create.minRating" />
+                <JFXTextField fx:id="minRankingTextField" minWidth="30.0" prefWidth="40.0" promptText="%games.create.minRating" HBox.hgrow="NEVER" />
                 <Pane minHeight="0.0" minWidth="0.0" HBox.hgrow="ALWAYS" />
                 <Label text="%games.create.maxRating" />
-                <JFXTextField fx:id="maxRankingTextField" minWidth="30.0" prefWidth="60.0" promptText="%games.create.maxRating" HBox.hgrow="NEVER" />
+                <JFXTextField fx:id="maxRankingTextField" minWidth="30.0" prefWidth="40.0" promptText="%games.create.maxRating" HBox.hgrow="NEVER" />
             </children>
             <padding>
                 <Insets left="2.0" right="2.0" top="2.0" />
@@ -134,15 +139,7 @@
         	</graphic>
        	</JFXButton>
         
-        <!-- Cancel, Ok -->
-        <JFXButton mnemonicParsing="false" onAction="#onCloseButtonClicked" text="%cancel"
-        		 styleClass="more-button-padding"
-        		 GridPane.halignment="LEFT" GridPane.columnIndex="0" GridPane.rowIndex="8">
-        	<GridPane.margin><Insets top="15"/></GridPane.margin>
-        	<padding>
-				<Insets left="100.0" right="100.0" />
-			</padding>
-        </JFXButton>
+        <!-- Ok -->
         <JFXButton fx:id="createGameButton" defaultButton="true" minWidth="-Infinity" mnemonicParsing="false" onAction="#onCreateButtonClicked" text="%game.create.create"
         		 styleClass="more-button-padding"
         		 GridPane.halignment="RIGHT" GridPane.columnIndex="3" GridPane.rowIndex="8" GridPane.columnSpan="2">
@@ -153,7 +150,12 @@
         </JFXButton>
         			
     </children>
+    </GridPane>
+        <JFXButton cancelButton="true" focusTraversable="false" onAction="#onCloseButtonClicked" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0"
+                   styleClass="window-button, close-button">
+        </JFXButton>
+    </AnchorPane>
     <padding>
-        <Insets left="20.0" right="20.0" />
+        <Insets bottom="40.0" left="40.0" right="40.0" top="40.0" />
     </padding>
-</GridPane>
+</StackPane>

--- a/src/main/resources/theme/vault/map/map_detail.fxml
+++ b/src/main/resources/theme/vault/map/map_detail.fxml
@@ -1,157 +1,118 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import com.jfoenix.controls.JFXButton?>
-<?import com.jfoenix.controls.JFXProgressBar?>
-<?import javafx.geometry.Insets?>
-<?import javafx.scene.control.Label?>
-<?import javafx.scene.control.ScrollPane?>
-<?import javafx.scene.control.Separator?>
-<?import javafx.scene.image.ImageView?>
-<?import javafx.scene.layout.AnchorPane?>
-<?import javafx.scene.layout.ColumnConstraints?>
-<?import javafx.scene.layout.GridPane?>
-<?import javafx.scene.layout.HBox?>
-<?import javafx.scene.layout.RowConstraints?>
-<?import javafx.scene.layout.VBox?>
-<?import java.lang.String?>
-<AnchorPane xmlns:fx="http://javafx.com/fxml/1" fx:id="mapDetailRoot" maxHeight="1.7976931348623157E308"
-            maxWidth="1.7976931348623157E308" onMouseClicked="#onDimmerClicked" styleClass="dimmer"
-            xmlns="http://javafx.com/javafx/10.0.2" fx:controller="com.faforever.client.map.MapDetailController">
-  <children>
-      <AnchorPane onMouseClicked="#onContentPaneClicked" styleClass="modal-popup" AnchorPane.bottomAnchor="50.0"
-                  AnchorPane.leftAnchor="50.0" AnchorPane.rightAnchor="50.0" AnchorPane.topAnchor="50.0">
-      <children>
-          <ScrollPane fx:id="scrollPane" fitToWidth="true" AnchorPane.bottomAnchor="10.0" AnchorPane.leftAnchor="10.0"
-                      AnchorPane.rightAnchor="10.0" AnchorPane.topAnchor="20.0">
-              <content>
-                  <VBox alignment="TOP_CENTER" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308"
-                        spacing="20.0">
-                      <children>
-                          <GridPane fx:id="gridPane" hgap="20.0" vgap="20.0">
-                              <columnConstraints>
-                                  <ColumnConstraints hgrow="NEVER" minWidth="10.0"/>
-                                  <ColumnConstraints hgrow="NEVER" minWidth="10.0"/>
-                                  <ColumnConstraints hgrow="NEVER" minWidth="10.0"/>
-                                  <ColumnConstraints hgrow="NEVER" minWidth="10.0"/>
-                                  <ColumnConstraints hgrow="NEVER" minWidth="10.0"/>
-                                  <ColumnConstraints hgrow="ALWAYS" minWidth="10.0"/>
-                              </columnConstraints>
-                              <rowConstraints>
-                                  <RowConstraints minHeight="10.0" vgrow="NEVER"/>
-                                  <RowConstraints minHeight="10.0" vgrow="NEVER"/>
-                                  <RowConstraints minHeight="10.0" vgrow="NEVER"/>
-                                  <RowConstraints fillHeight="false" minHeight="10.0" vgrow="ALWAYS"/>
-                                  <RowConstraints fx:id="hideRow" fillHeight="false"/>
-                                  <RowConstraints fillHeight="false" minHeight="10.0" vgrow="ALWAYS"/>
-                                  <RowConstraints fillHeight="false" minHeight="10.0" prefHeight="60.0" vgrow="ALWAYS"/>
-                              </rowConstraints>
-                              <children>
-                                  <ImageView fx:id="thumbnailImageView" fitHeight="256.0" fitWidth="256.0"
-                                             pickOnBounds="true" preserveRatio="true" GridPane.halignment="CENTER"
-                                             GridPane.rowSpan="2147483647" GridPane.valignment="TOP"/>
-                                  <VBox GridPane.columnIndex="1" GridPane.columnSpan="2147483647"
-                                        GridPane.hgrow="ALWAYS">
-                                      <children>
-                                          <Label fx:id="nameLabel" styleClass="h1" text="&lt;Title&gt;"/>
-                                          <Label fx:id="mapIdLabel" text="#&lt;id&gt;"/>
-                                      </children>
-                                  </VBox>
-                                  <Label fx:id="dimensionsLabel" text="Label" GridPane.columnIndex="1"
-                                         GridPane.rowIndex="2">
-                                      <graphic>
-                                          <Label styleClass="icon" text=""/>
-                                      </graphic>
-                                  </Label>
-                                  <Label fx:id="maxPlayersLabel" graphicTextGap="10.0" text="&lt;Max Players&gt;"
-                                         GridPane.columnIndex="2" GridPane.rowIndex="2">
-                                      <graphic>
-                                          <Label styleClass="icon" text=""/>
-                                      </graphic>
-                                  </Label>
-                                  <Label fx:id="dateLabel" graphicTextGap="10.0" text="&lt;Date&gt;"
-                                         GridPane.columnIndex="3" GridPane.rowIndex="2">
-                                      <graphic>
-                                          <Label styleClass="icon" text=""/>
-                                      </graphic>
-                                  </Label>
-                                  <VBox alignment="TOP_RIGHT" spacing="10.0" GridPane.columnIndex="1"
-                                        GridPane.columnSpan="2147483647">
-                                      <HBox alignment="TOP_RIGHT" spacing="10.0">
-                                          <children>
-                                              <JFXButton fx:id="createGameButton" defaultButton="true"
-                                                         mnemonicParsing="false" onAction="#onCreateGameButtonClicked"
-                                                         text="%games.create"/>
-                                              <JFXButton fx:id="installButton" defaultButton="true"
-                                                         mnemonicParsing="false" onAction="#onInstallButtonClicked"
-                                                         text="%mapVault.installButtonFormat"/>
-                                              <JFXButton fx:id="uninstallButton" mnemonicParsing="false"
-                                                         onAction="#onUninstallButtonClicked"
-                                                         text="%mapVault.uninstall"/>
-                                          </children>
-                                      </HBox>
-                                      <VBox fx:id="loadingContainer" alignment="TOP_RIGHT" maxWidth="300.0">
-                                          <children>
-                                              <Label fx:id="progressLabel"/>
-                                              <JFXProgressBar fx:id="progressBar" maxWidth="1.7976931348623157E308"
-                                                              progress="0.0"/>
-                                          </children>
-                                      </VBox>
-                                  </VBox>
-                                  <Label fx:id="authorLabel" styleClass="secondary" text="&lt;Author&gt;"
-                                         GridPane.columnIndex="1" GridPane.columnSpan="2147483647" GridPane.rowIndex="1"
-                                         GridPane.valignment="TOP"/>
-                                  <Label maxWidth="1.7976931348623157E308" styleClass="h2" text="%map.description"
-                                         GridPane.columnIndex="1" GridPane.columnSpan="2147483647"
-                                         GridPane.hgrow="ALWAYS" GridPane.rowIndex="5"/>
-                                  <Label fx:id="mapDescriptionLabel" maxWidth="1.7976931348623157E308" minWidth="0.0"
-                                         text="&lt;Description&gt;" wrapText="true" GridPane.columnIndex="1"
-                                         GridPane.columnSpan="2147483647" GridPane.rowIndex="6"
-                                         GridPane.valignment="TOP"/>
-                                  <HBox spacing="10.0" GridPane.columnIndex="1" GridPane.columnSpan="2147483647"
-                                        GridPane.rowIndex="3">
-                                      <children>
-                                          <Label maxHeight="1.7976931348623157E308" text="%map.ranked"/>
-                                          <Label fx:id="isRankedLabel" maxHeight="1.7976931348623157E308"/>
-                                          <JFXButton fx:id="unrankButton" mnemonicParsing="false" onAction="#unrankMap"
-                                                     text="%map.unrank"/>
-                                      </children>
-                                  </HBox>
-                                  <HBox fx:id="hideBox" spacing="10.0" GridPane.columnIndex="1"
-                                        GridPane.columnSpan="2147483647" GridPane.rowIndex="4">
-                                      <children>
-                                          <Label maxHeight="1.7976931348623157E308" minHeight="0.0" minWidth="0.0"
-                                                 text="%map.hidden"/>
-                                          <Label fx:id="isHiddenLabel" maxHeight="1.7976931348623157E308"/>
-                                          <JFXButton fx:id="hideButton" minHeight="0.0" minWidth="0.0"
-                                                     mnemonicParsing="false" onAction="#hideMap" text="%map.hide"/>
-                                      </children>
-                                  </HBox>
-                              </children>
-                              <VBox.margin>
-                                  <Insets/>
-                              </VBox.margin>
-                          </GridPane>
-                          <Separator layoutX="10.0" layoutY="251.0" maxWidth="1.7976931348623157E308"/>
-                          <VBox alignment="TOP_CENTER" maxWidth="640.0">
-                              <children>
-                                  <fx:include fx:id="reviews" source="../review/reviews.fxml"/>
-                              </children>
-                          </VBox>
-                      </children>
-                      <padding>
-                          <Insets bottom="20.0" left="20.0" right="20.0" top="20.0"/>
-                      </padding>
-                  </VBox>
-              </content>
-          </ScrollPane>
-          <JFXButton cancelButton="true" focusTraversable="false" onAction="#onCloseButtonClicked"
-                     AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
-              <styleClass>
-                  <String fx:value="window-button"/>
-                  <String fx:value="close-button"/>
-              </styleClass>
-          </JFXButton>
-      </children>
-    </AnchorPane>
-  </children>
-</AnchorPane>
+<?import com.jfoenix.controls.*?>
+<?import java.lang.*?>
+<?import javafx.geometry.*?>
+<?import javafx.scene.control.*?>
+<?import javafx.scene.image.*?>
+<?import javafx.scene.layout.*?>
+
+<StackPane fx:id="mapDetailRoot" alignment="CENTER" onMouseClicked="#onDimmerClicked" styleClass="dimmer" xmlns="http://javafx.com/javafx/10.0.2-internal" xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.faforever.client.map.MapDetailController">
+  <AnchorPane maxHeight="800" maxWidth="800" minWidth="700" onMouseClicked="#onContentPaneClicked" styleClass="modal-popup">
+       <children>
+           <ScrollPane fx:id="scrollPane" fitToWidth="true" AnchorPane.bottomAnchor="10.0" AnchorPane.leftAnchor="10.0" AnchorPane.rightAnchor="10.0" AnchorPane.topAnchor="20.0">
+               <content>
+                   <VBox alignment="TOP_CENTER" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" spacing="20.0">
+                       <children>
+                           <GridPane fx:id="gridPane" hgap="20.0" vgap="20.0">
+                               <columnConstraints>
+                                   <ColumnConstraints hgrow="NEVER" minWidth="10.0" />
+                                   <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" />
+                                   <ColumnConstraints hgrow="NEVER" minWidth="10.0" />
+                                   <ColumnConstraints hgrow="NEVER" minWidth="10.0" />
+                                   <ColumnConstraints hgrow="NEVER" minWidth="10.0" />
+                                   <ColumnConstraints hgrow="ALWAYS" minWidth="10.0" />
+                               </columnConstraints>
+                               <rowConstraints>
+                                   <RowConstraints minHeight="10.0" vgrow="NEVER" />
+                                   <RowConstraints minHeight="10.0" vgrow="NEVER" />
+                                   <RowConstraints minHeight="10.0" vgrow="NEVER" />
+                                   <RowConstraints fillHeight="false" minHeight="10.0" vgrow="ALWAYS" />
+                                   <RowConstraints fx:id="hideRow" fillHeight="false" />
+                                   <RowConstraints fillHeight="false" minHeight="10.0" vgrow="ALWAYS" />
+                                   <RowConstraints fillHeight="false" minHeight="10.0" prefHeight="60.0" vgrow="ALWAYS" />
+                               </rowConstraints>
+                               <children>
+                                   <ImageView fx:id="thumbnailImageView" fitHeight="256.0" fitWidth="256.0" pickOnBounds="true" preserveRatio="true" GridPane.halignment="CENTER" GridPane.rowSpan="2147483647" GridPane.valignment="TOP" />
+                                   <VBox GridPane.columnIndex="1" GridPane.columnSpan="2147483647" GridPane.hgrow="ALWAYS">
+                                       <children>
+                                           <Label fx:id="nameLabel" styleClass="h1" text="&lt;Title&gt;" />
+                                           <Label fx:id="mapIdLabel" text="#&lt;id&gt;" />
+                                       </children>
+                                   </VBox>
+                                   <Label fx:id="dimensionsLabel" text="Label" GridPane.columnIndex="1" GridPane.rowIndex="2">
+                                       <graphic>
+                                           <Label styleClass="icon" text="" />
+                                       </graphic>
+                                   </Label>
+                                   <Label fx:id="maxPlayersLabel" graphicTextGap="10.0" text="&lt;Max Players&gt;" GridPane.columnIndex="2" GridPane.rowIndex="2">
+                                       <graphic>
+                                           <Label styleClass="icon" text="" />
+                                       </graphic>
+                                   </Label>
+                                   <Label fx:id="dateLabel" graphicTextGap="10.0" text="&lt;Date&gt;" GridPane.columnIndex="3" GridPane.rowIndex="2">
+                                       <graphic>
+                                           <Label styleClass="icon" text="" />
+                                       </graphic>
+                                   </Label>
+                                   <VBox alignment="TOP_RIGHT" spacing="10.0" GridPane.columnIndex="1" GridPane.rowIndex="3" GridPane.columnSpan="5" GridPane.rowSpan="2">
+                                       <HBox alignment="TOP_RIGHT" spacing="10.0">
+                                           <children>
+                                               <JFXButton fx:id="createGameButton" defaultButton="true" mnemonicParsing="false" onAction="#onCreateGameButtonClicked" text="%games.create" />
+                                               <JFXButton fx:id="installButton" defaultButton="true" mnemonicParsing="false" onAction="#onInstallButtonClicked" text="%mapVault.installButtonFormat" />
+                                               <JFXButton fx:id="uninstallButton" mnemonicParsing="false" onAction="#onUninstallButtonClicked" text="%mapVault.uninstall" />
+                                           </children>
+                                       </HBox>
+                                       <VBox fx:id="loadingContainer" alignment="TOP_RIGHT" maxWidth="300.0">
+                                           <children>
+                                               <Label fx:id="progressLabel" />
+                                               <JFXProgressBar fx:id="progressBar" maxWidth="1.7976931348623157E308" progress="0.0" />
+                                           </children>
+                                       </VBox>
+                                   </VBox>
+                                   <Label fx:id="authorLabel" styleClass="secondary" text="&lt;Author&gt;" GridPane.columnIndex="1" GridPane.columnSpan="2147483647" GridPane.rowIndex="1" GridPane.valignment="TOP" />
+                                   <Label fx:id="mapDescriptionLabel" maxWidth="1.7976931348623157E308" minWidth="0.0" text="&lt;Description&gt;" wrapText="true" GridPane.columnIndex="1" GridPane.columnSpan="2147483647" GridPane.rowSpan="2" GridPane.rowIndex="5" GridPane.valignment="TOP" />
+                                   <HBox spacing="10.0" GridPane.columnIndex="1" GridPane.rowIndex="3">
+                                       <children>
+                                           <Label maxHeight="1.7976931348623157E308" text="%map.ranked" />
+                                           <Label fx:id="isRankedLabel" maxHeight="1.7976931348623157E308" />
+                                           <JFXButton fx:id="unrankButton" mnemonicParsing="false" onAction="#unrankMap" text="%map.unrank" />
+                                       </children>
+                                   </HBox>
+                                   <HBox fx:id="hideBox" spacing="10.0" GridPane.columnIndex="1" GridPane.rowIndex="4">
+                                       <children>
+                                           <Label maxHeight="1.7976931348623157E308" minHeight="0.0" minWidth="0.0" text="%map.hidden" />
+                                           <Label fx:id="isHiddenLabel" maxHeight="1.7976931348623157E308" />
+                                           <JFXButton fx:id="hideButton" minHeight="0.0" minWidth="0.0" mnemonicParsing="false" onAction="#hideMap" text="%map.hide" />
+                                       </children>
+                                   </HBox>
+                               </children>
+                               <VBox.margin>
+                                   <Insets />
+                               </VBox.margin>
+                           </GridPane>
+                           <Separator layoutX="10.0" layoutY="251.0" maxWidth="1.7976931348623157E308" />
+                           <VBox alignment="TOP_CENTER" maxWidth="640.0">
+                               <children>
+                                   <fx:include fx:id="reviews" source="../review/reviews.fxml" />
+                               </children>
+                           </VBox>
+                       </children>
+                       <padding>
+                           <Insets bottom="20.0" left="20.0" right="20.0" top="20.0" />
+                       </padding>
+                   </VBox>
+               </content>
+           </ScrollPane>
+           <JFXButton cancelButton="true" focusTraversable="false" onAction="#onCloseButtonClicked" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
+               <styleClass>
+                   <String fx:value="window-button" />
+                   <String fx:value="close-button" />
+               </styleClass>
+           </JFXButton>
+       </children>
+  </AnchorPane>
+   <padding>
+      <Insets bottom="40.0" left="40.0" right="40.0" top="40.0" />
+   </padding>
+</StackPane>

--- a/src/main/resources/theme/vault/mod/mod_detail.fxml
+++ b/src/main/resources/theme/vault/mod/mod_detail.fxml
@@ -1,100 +1,95 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import com.jfoenix.controls.JFXButton?>
-<?import com.jfoenix.controls.JFXProgressBar?>
-<?import javafx.geometry.Insets?>
-<?import javafx.scene.control.Label?>
-<?import javafx.scene.control.ScrollPane?>
-<?import javafx.scene.control.Separator?>
-<?import javafx.scene.image.ImageView?>
-<?import javafx.scene.layout.AnchorPane?>
-<?import javafx.scene.layout.ColumnConstraints?>
-<?import javafx.scene.layout.GridPane?>
-<?import javafx.scene.layout.RowConstraints?>
-<?import javafx.scene.layout.VBox?>
-<?import java.lang.String?>
-<AnchorPane fx:id="modDetailRoot" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" onMouseClicked="#onDimmerClicked" styleClass="dimmer" xmlns="http://javafx.com/javafx/11.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.faforever.client.mod.ModDetailController">
-    <children>
-        <AnchorPane onMouseClicked="#onContentPaneClicked" styleClass="modal-popup" AnchorPane.bottomAnchor="50.0" AnchorPane.leftAnchor="50.0" AnchorPane.rightAnchor="50.0" AnchorPane.topAnchor="50.0">
-            <children>
-                <ScrollPane fx:id="scrollPane" fitToWidth="true" AnchorPane.bottomAnchor="10.0" AnchorPane.leftAnchor="10.0" AnchorPane.rightAnchor="10.0" AnchorPane.topAnchor="20.0">
-                    <content>
-                        <VBox alignment="TOP_CENTER" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" spacing="20.0">
-                            <children>
-                                <GridPane hgap="20.0" maxWidth="1.7976931348623157E308" vgap="10.0">
-                                    <columnConstraints>
-                                        <ColumnConstraints hgrow="NEVER" minWidth="10.0" />
-                                        <ColumnConstraints hgrow="NEVER" minWidth="10.0" />
-                                        <ColumnConstraints hgrow="ALWAYS" minWidth="10.0" />
-                                        <ColumnConstraints />
-                                    </columnConstraints>
-                                    <rowConstraints>
-                                        <RowConstraints minHeight="10.0" vgrow="NEVER" />
-                                        <RowConstraints minHeight="10.0" vgrow="NEVER" />
-                                    </rowConstraints>
-                                    <children>
-                                        <Label fx:id="nameLabel" maxWidth="1.7976931348623157E308" styleClass="h1" text="&lt;Name&gt;" GridPane.columnIndex="1" GridPane.columnSpan="2" />
-                                        <ImageView fx:id="thumbnailImageView" fitHeight="128.0" fitWidth="128.0" pickOnBounds="true" preserveRatio="true" GridPane.rowSpan="2" />
-                                        <VBox fx:id="progressPane" alignment="CENTER_LEFT" maxWidth="300.0" GridPane.columnIndex="2" GridPane.halignment="RIGHT" GridPane.rowIndex="1">
-                                            <children>
-                                                <Label fx:id="progressLabel" text="" />
-                                                <JFXProgressBar fx:id="progressBar" maxWidth="1.7976931348623157E308" progress="0.0" />
-                                            </children>
-                                        </VBox>
-                                        <JFXButton fx:id="uninstallButton" mnemonicParsing="false" onAction="#onUninstallButtonClicked" text="%modVault.uninstall" GridPane.columnIndex="2" GridPane.halignment="RIGHT" GridPane.rowIndex="1" />
-                                        <JFXButton fx:id="installButton" mnemonicParsing="false" onAction="#onInstallButtonClicked" styleClass="highlighted-button" text="%modVault.install" GridPane.columnIndex="2" GridPane.halignment="RIGHT" GridPane.rowIndex="1" />
-                              <VBox GridPane.columnIndex="1" GridPane.rowIndex="1">
-                                 <children>
-                                    <Label fx:id="authorLabel" text="&lt;Author&gt;" />
-                                     <Label fx:id="uploaderLabel" text="&lt;Uploader&gt;" wrapText="true"/>
-                                 </children>
-                              </VBox>
-                                    </children>
-                                </GridPane>
-                                <Label fx:id="modDescriptionLabel" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" text="&lt;Description&gt;" wrapText="true" />
-                                <Separator layoutX="10.0" layoutY="251.0" maxWidth="1.7976931348623157E308" />
-                                <VBox alignment="TOP_CENTER" maxWidth="640.0">
-                                    <children>
-                                        <fx:include fx:id="reviews" source="../review/reviews.fxml" />
-                                    </children>
-                                </VBox>
-                                <Separator prefWidth="200.0" />
-                                <Label layoutX="10.0" layoutY="204.0" styleClass="h2" text="%mod.detail.moreInfo" />
-                                <GridPane hgap="20.0" maxWidth="640.0">
-                                    <columnConstraints>
-                                        <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
-                                        <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
-                                        <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
-                                    </columnConstraints>
-                                    <rowConstraints>
-                                        <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-                                        <RowConstraints minHeight="10.0" prefHeight="40.0" vgrow="SOMETIMES" />
-                                    </rowConstraints>
-                                    <children>
-                                        <Label styleClass="h3" text="%mod.detail.updated" />
-                                        <Label styleClass="h3" text="%mod.detail.size" GridPane.columnIndex="1" />
-                                        <Label layoutX="217.0" layoutY="15.0" styleClass="h3" text="%mod.detail.version" GridPane.columnIndex="2" />
-                                        <Label fx:id="updatedLabel" text="&lt;Updated&gt;" GridPane.rowIndex="1" GridPane.valignment="TOP" />
-                                        <Label fx:id="sizeLabel" text="&lt;Size&gt;" GridPane.columnIndex="1" GridPane.rowIndex="1" GridPane.valignment="TOP" />
-                                        <Label fx:id="versionLabel" text="&lt;Version&gt;" GridPane.columnIndex="2" GridPane.rowIndex="1" GridPane.valignment="TOP" />
-                                    </children>
-                                </GridPane>
-                                <Label fx:id="dependenciesTitle" styleClass="h2" text="%mod.detail.dependencies" />
-                                <VBox fx:id="dependenciesContainer" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" />
-                            </children>
-                            <padding>
-                                <Insets bottom="20.0" left="20.0" right="20.0" top="20.0" />
-                            </padding>
+<?import com.jfoenix.controls.*?>
+<?import java.lang.*?>
+<?import javafx.geometry.*?>
+<?import javafx.scene.control.*?>
+<?import javafx.scene.image.*?>
+<?import javafx.scene.layout.*?>
+
+<StackPane fx:id="modDetailRoot" alignment="CENTER" onMouseClicked="#onDimmerClicked" styleClass="dimmer" xmlns="http://javafx.com/javafx/10.0.2-internal" xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.faforever.client.mod.ModDetailController">
+    <AnchorPane maxHeight="800" maxWidth="800" minWidth="500" onMouseClicked="#onContentPaneClicked" styleClass="modal-popup">
+      <children>
+          <ScrollPane fx:id="scrollPane" fitToWidth="true" AnchorPane.bottomAnchor="10.0" AnchorPane.leftAnchor="10.0" AnchorPane.rightAnchor="10.0" AnchorPane.topAnchor="20.0">
+              <content>
+                  <VBox alignment="TOP_CENTER" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" spacing="20.0">
+                      <children>
+                          <GridPane focusTraversable="true" hgap="20.0" maxWidth="1.7976931348623157E308" vgap="10.0">
+                              <columnConstraints>
+                                  <ColumnConstraints hgrow="NEVER" minWidth="10.0" />
+                                  <ColumnConstraints hgrow="NEVER" minWidth="10.0" />
+                                  <ColumnConstraints hgrow="ALWAYS" minWidth="10.0" />
+                                  <ColumnConstraints />
+                              </columnConstraints>
+                              <rowConstraints>
+                                  <RowConstraints minHeight="10.0" vgrow="NEVER" />
+                                  <RowConstraints minHeight="10.0" vgrow="NEVER" />
+                              </rowConstraints>
+                              <children>
+                                  <Label fx:id="nameLabel" maxWidth="1.7976931348623157E308" styleClass="h1" text="&lt;Name&gt;" GridPane.columnIndex="1" GridPane.columnSpan="2" />
+                                  <ImageView fx:id="thumbnailImageView" fitHeight="128.0" fitWidth="128.0" pickOnBounds="true" preserveRatio="true" GridPane.rowSpan="2" />
+                                  <VBox fx:id="progressPane" alignment="CENTER_LEFT" maxWidth="300.0" GridPane.columnIndex="2" GridPane.halignment="RIGHT" GridPane.rowIndex="1">
+                                      <children>
+                                          <Label fx:id="progressLabel" text="" />
+                                          <JFXProgressBar fx:id="progressBar" maxWidth="1.7976931348623157E308" progress="0.0" />
+                                      </children>
+                                  </VBox>
+                                  <JFXButton fx:id="uninstallButton" mnemonicParsing="false" onAction="#onUninstallButtonClicked" text="%modVault.uninstall" GridPane.columnIndex="2" GridPane.halignment="RIGHT" GridPane.rowIndex="1" />
+                                  <JFXButton fx:id="installButton" defaultButton="true" mnemonicParsing="false" onAction="#onInstallButtonClicked" text="%modVault.install" GridPane.columnIndex="2" GridPane.halignment="RIGHT" GridPane.rowIndex="1" />
+                        <VBox GridPane.columnIndex="1" GridPane.rowIndex="1">
+                           <children>
+                              <Label fx:id="authorLabel" text="&lt;Author&gt;" />
+                               <Label fx:id="uploaderLabel" text="&lt;Uploader&gt;" wrapText="true" />
+                           </children>
                         </VBox>
-                    </content>
-                </ScrollPane>
-                <JFXButton cancelButton="true" focusTraversable="false" onAction="#onCloseButtonClicked" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
-                    <styleClass>
-                        <String fx:value="window-button" />
-                        <String fx:value="close-button" />
-                    </styleClass>
-                </JFXButton>
-            </children>
-        </AnchorPane>
-    </children>
-</AnchorPane>
+                              </children>
+                          </GridPane>
+                          <Label fx:id="modDescriptionLabel" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" text="&lt;Description&gt;" wrapText="true" />
+                          <Separator layoutX="10.0" layoutY="251.0" maxWidth="1.7976931348623157E308" />
+                          <VBox alignment="TOP_CENTER" maxWidth="640.0">
+                              <children>
+                                  <fx:include fx:id="reviews" source="../review/reviews.fxml" />
+                              </children>
+                          </VBox>
+                          <Separator prefWidth="200.0" />
+                          <Label layoutX="10.0" layoutY="204.0" styleClass="h2" text="%mod.detail.moreInfo" />
+                          <GridPane hgap="20.0" maxWidth="640.0">
+                              <columnConstraints>
+                                  <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
+                                  <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
+                                  <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
+                              </columnConstraints>
+                              <rowConstraints>
+                                  <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+                                  <RowConstraints minHeight="10.0" prefHeight="40.0" vgrow="SOMETIMES" />
+                              </rowConstraints>
+                              <children>
+                                  <Label styleClass="h3" text="%mod.detail.updated" />
+                                  <Label styleClass="h3" text="%mod.detail.size" GridPane.columnIndex="1" />
+                                  <Label layoutX="217.0" layoutY="15.0" styleClass="h3" text="%mod.detail.version" GridPane.columnIndex="2" />
+                                  <Label fx:id="updatedLabel" text="&lt;Updated&gt;" GridPane.rowIndex="1" GridPane.valignment="TOP" />
+                                  <Label fx:id="sizeLabel" text="&lt;Size&gt;" GridPane.columnIndex="1" GridPane.rowIndex="1" GridPane.valignment="TOP" />
+                                  <Label fx:id="versionLabel" text="&lt;Version&gt;" GridPane.columnIndex="2" GridPane.rowIndex="1" GridPane.valignment="TOP" />
+                              </children>
+                          </GridPane>
+                          <Label fx:id="dependenciesTitle" styleClass="h2" text="%mod.detail.dependencies" />
+                          <VBox fx:id="dependenciesContainer" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" />
+                      </children>
+                      <padding>
+                          <Insets bottom="20.0" left="20.0" right="20.0" top="20.0" />
+                      </padding>
+                  </VBox>
+              </content>
+          </ScrollPane>
+          <JFXButton cancelButton="true" focusTraversable="false" onAction="#onCloseButtonClicked" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
+              <styleClass>
+                  <String fx:value="window-button" />
+                  <String fx:value="close-button" />
+              </styleClass>
+          </JFXButton>
+      </children>
+    </AnchorPane>
+    <padding>
+        <Insets bottom="40.0" left="40.0" right="40.0" top="40.0" />
+    </padding>
+</StackPane>

--- a/src/main/resources/theme/vault/replay/replay_detail.fxml
+++ b/src/main/resources/theme/vault/replay/replay_detail.fxml
@@ -16,12 +16,12 @@
 <?import javafx.scene.layout.RowConstraints?>
 <?import javafx.scene.layout.VBox?>
 <?import java.lang.String?>
-<AnchorPane xmlns:fx="http://javafx.com/fxml/1" fx:id="replayDetailRoot" onMouseClicked="#onDimmerClicked"
-            styleClass="dimmer" xmlns="http://javafx.com/javafx/8.0.121"
-            fx:controller="com.faforever.client.replay.ReplayDetailController">
+<?import javafx.scene.layout.StackPane?>
+<StackPane xmlns:fx="http://javafx.com/fxml/1" fx:id="replayDetailRoot" onMouseClicked="#onDimmerClicked"
+           styleClass="dimmer" xmlns="http://javafx.com/javafx/8.0.121" alignment="CENTER"
+           fx:controller="com.faforever.client.replay.ReplayDetailController">
    <children>
-       <AnchorPane onMouseClicked="#onContentPaneClicked" styleClass="modal-popup" AnchorPane.bottomAnchor="50.0"
-                   AnchorPane.leftAnchor="50.0" AnchorPane.rightAnchor="50.0" AnchorPane.topAnchor="50.0">
+       <AnchorPane maxHeight="800" maxWidth="800" minWidth="660" onMouseClicked="#onContentPaneClicked" styleClass="modal-popup">
          <children>
              <ScrollPane fx:id="scrollPane" fitToWidth="true" layoutX="21.0" layoutY="31.0"
                          AnchorPane.bottomAnchor="10.0" AnchorPane.leftAnchor="10.0" AnchorPane.rightAnchor="10.0"
@@ -212,4 +212,7 @@
          </children>
       </AnchorPane>
    </children>
-</AnchorPane>
+    <padding>
+        <Insets bottom="40.0" left="40.0" right="40.0" top="40.0" />
+    </padding>
+</StackPane>

--- a/src/test/java/com/faforever/client/game/CustomGamesControllerTest.java
+++ b/src/test/java/com/faforever/client/game/CustomGamesControllerTest.java
@@ -42,6 +42,8 @@ public class CustomGamesControllerTest extends AbstractPlainJavaFxTest {
   @Mock
   private GamesTableController gamesTableController;
   @Mock
+  private CreateGameController createGameController;
+  @Mock
   private EventBus eventBus;
   @Mock
   private GameDetailController gameDetailController;
@@ -71,6 +73,8 @@ public class CustomGamesControllerTest extends AbstractPlainJavaFxTest {
     when(preferencesService.getPreferences()).thenReturn(preferences);
     when(uiService.loadFxml("theme/play/games_table.fxml")).thenReturn(gamesTableController);
     when(uiService.loadFxml("theme/play/games_tiles_container.fxml")).thenReturn(gamesTilesContainerController);
+    when(uiService.loadFxml("theme/play/create_game.fxml")).thenReturn(createGameController);
+    when(createGameController.getRoot()).thenReturn(new Pane());
     when(gamesTilesContainerController.getRoot()).thenReturn(new Pane());
     when(gamesTableController.getRoot()).thenReturn(new Pane());
     when(gamesTableController.selectedGameProperty()).thenReturn(new SimpleObjectProperty<>());


### PR DESCRIPTION
Brings the style of the popup windows (map, mod, and replay detail and create game) more in line with each other and fixes minor UI Issues.

All windows keep sensible min and max sizes and hover in the middle of the screen.

The Create Game window now has a proper cancel button and no superfluous title anymore
"Min" is now in front of the text field instead of behind
![grafik](https://user-images.githubusercontent.com/52536103/82610526-d9e55b80-9bbe-11ea-8d57-74cb83dfa862.png)

Map detail buttons are lower so they don't crash with the map name
"Description" removed
![grafik](https://user-images.githubusercontent.com/52536103/82610660-13b66200-9bbf-11ea-80fa-96a2353ab716.png)

Mod detail install button is now a highlighted button
![grafik](https://user-images.githubusercontent.com/52536103/82610710-2a5cb900-9bbf-11ea-9c1b-8997e53859c8.png)
