### PR TITLE
Feature/#1777 Starting ladder matchmaking methods refactoring

### DIFF
--- a/src/main/java/com/faforever/client/fa/ForgedAllianceService.java
+++ b/src/main/java/com/faforever/client/fa/ForgedAllianceService.java
@@ -53,6 +53,8 @@ public class ForgedAllianceService {
     float mean;
 
     switch (ratingMode) {
+      case LADDER_2V2:
+        //TODO change deviation or mean here if it should be different from a 1vs1 ladder game (don't forget a "break;" statement)
       case LADDER_1V1:
         deviation = currentPlayer.getLeaderboardRatingDeviation();
         mean = currentPlayer.getLeaderboardRatingMean();

--- a/src/main/java/com/faforever/client/fa/RatingMode.java
+++ b/src/main/java/com/faforever/client/fa/RatingMode.java
@@ -1,7 +1,20 @@
 package com.faforever.client.fa;
 
+import com.faforever.client.game.KnownFeaturedMod;
+
 public enum RatingMode {
   GLOBAL,
   LADDER_1V1,
-  NONE
+  LADDER_2V2,
+  NONE;
+
+  public KnownFeaturedMod getCorrespondingFeatureMod() {
+    switch (this) {
+      case LADDER_1V1: return KnownFeaturedMod.LADDER_1V1;
+      case LADDER_2V2: return KnownFeaturedMod.LADDER_2V2;
+      default: throw new UnsupportedOperationException("FeatureMod for this rating mod is unsupported or not created yet");
+    }
+  }
 }
+
+

--- a/src/main/java/com/faforever/client/game/GameService.java
+++ b/src/main/java/com/faforever/client/game/GameService.java
@@ -303,7 +303,7 @@ public class GameService implements InitializingBean {
       return gameDirectoryFuture.thenCompose(path -> hostGame(newGameInfo));
     }
 
-    stopSearchLadder();
+    stopSearchLadder(ratingMode);
 
     return updateGameIfNecessary(newGameInfo.getFeaturedMod(), null, emptyMap(), newGameInfo.getSimMods())
         .thenCompose(aVoid -> downloadMapIfNecessary(newGameInfo.getMap()))
@@ -324,7 +324,7 @@ public class GameService implements InitializingBean {
 
     log.info("Joining game: '{}' ({})", game.getTitle(), game.getId());
 
-    stopSearchLadder();
+    stopSearchLadder(ratingMode);
 
     Map<String, Integer> featuredModVersions = game.getFeaturedModVersions();
     Set<String> simModUIds = game.getSimMods().keySet();
@@ -519,7 +519,7 @@ public class GameService implements InitializingBean {
         });
   }
 
-  public void stopSearchLadder() {
+  public void stopSearchLadder(RatingMode ratingMode) {
     if (searchingLadder.get()) {
       fafService.stopSearchingRanked(ratingMode);
       searchingLadder.set(false);
@@ -570,7 +570,7 @@ public class GameService implements InitializingBean {
       return;
     }
 
-    stopSearchLadder();
+    stopSearchLadder(ratingMode);
     int uid = gameLaunchMessage.getUid();
     replayServer.start(uid, () -> getByUid(uid))
         .thenCompose(port -> {

--- a/src/main/java/com/faforever/client/game/KnownFeaturedMod.java
+++ b/src/main/java/com/faforever/client/game/KnownFeaturedMod.java
@@ -13,6 +13,7 @@ public enum KnownFeaturedMod {
   FAF_DEVELOP("fafdevelop"),
   BALANCE_TESTING("balancetesting"),
   LADDER_1V1("ladder1v1"),
+  LADDER_2V2("ladder2v2"),
   COOP("coop"),
   GALACTIC_WAR("gw"),
   MATCHMAKER("matchmaker"),

--- a/src/main/java/com/faforever/client/main/MainController.java
+++ b/src/main/java/com/faforever/client/main/MainController.java
@@ -308,7 +308,7 @@ public class MainController implements Controller<Node> {
   private void onMatchmakerMessage(MatchmakerInfoMessage message) {
     if (message.getQueues() == null
         || gameService.gameRunningProperty().get()
-        || gameService.searching1v1Property().get()
+        || gameService.searchingLadderProperty().get()
         || !preferencesService.getPreferences().getNotification().getLadder1v1ToastEnabled()
         || !playerService.getCurrentPlayer().isPresent()) {
       return;

--- a/src/main/java/com/faforever/client/rankedmatch/Ladder1v1Controller.java
+++ b/src/main/java/com/faforever/client/rankedmatch/Ladder1v1Controller.java
@@ -1,6 +1,7 @@
 package com.faforever.client.rankedmatch;
 
 import com.faforever.client.config.ClientProperties;
+import com.faforever.client.fa.RatingMode;
 import com.faforever.client.fx.AbstractViewController;
 import com.faforever.client.fx.JavaFxUtil;
 import com.faforever.client.game.Faction;
@@ -216,7 +217,7 @@ public class Ladder1v1Controller extends AbstractViewController<Node> implements
   }
 
   public void onCancelButtonClicked() {
-    gameService.stopSearchLadder();
+    gameService.stopSearchLadder(RatingMode.LADDER_1V1);
     setSearching(false);
   }
 
@@ -236,7 +237,7 @@ public class Ladder1v1Controller extends AbstractViewController<Node> implements
     ObservableList<Faction> factions = preferencesService.getPreferences().getLadder1v1Prefs().getFactions();
 
     Faction randomFaction = factions.get(random.nextInt(factions.size()));
-    gameService.startSearchLadder(randomFaction);
+    gameService.startSearchLadder(RatingMode.LADDER_1V1, randomFaction);
   }
 
   public void onFactionButtonClicked() {

--- a/src/main/java/com/faforever/client/rankedmatch/Ladder1v1Controller.java
+++ b/src/main/java/com/faforever/client/rankedmatch/Ladder1v1Controller.java
@@ -143,7 +143,7 @@ public class Ladder1v1Controller extends AbstractViewController<Node> implements
 
     setSearching(false);
 
-    JavaFxUtil.addListener(gameService.searching1v1Property(), (observable, oldValue, newValue) -> setSearching(newValue));
+    JavaFxUtil.addListener(gameService.searchingLadderProperty(), (observable, oldValue, newValue) -> setSearching(newValue));
 
     ObservableList<Faction> factions = preferencesService.getPreferences().getLadder1v1Prefs().getFactions();
     for (Faction faction : EnumSet.of(AEON, CYBRAN, UEF, SERAPHIM)) {
@@ -216,7 +216,7 @@ public class Ladder1v1Controller extends AbstractViewController<Node> implements
   }
 
   public void onCancelButtonClicked() {
-    gameService.stopSearchLadder1v1();
+    gameService.stopSearchLadder();
     setSearching(false);
   }
 
@@ -236,7 +236,7 @@ public class Ladder1v1Controller extends AbstractViewController<Node> implements
     ObservableList<Faction> factions = preferencesService.getPreferences().getLadder1v1Prefs().getFactions();
 
     Faction randomFaction = factions.get(random.nextInt(factions.size()));
-    gameService.startSearchLadder1v1(randomFaction);
+    gameService.startSearchLadder(randomFaction);
   }
 
   public void onFactionButtonClicked() {

--- a/src/main/java/com/faforever/client/rankedmatch/SearchLadderClientMessage.java
+++ b/src/main/java/com/faforever/client/rankedmatch/SearchLadderClientMessage.java
@@ -1,16 +1,17 @@
 package com.faforever.client.rankedmatch;
 
+import com.faforever.client.fa.RatingMode;
 import com.faforever.client.game.Faction;
 import com.faforever.client.game.KnownFeaturedMod;
 import com.faforever.client.remote.domain.ClientMessageType;
 
-public class SearchLadder1v1ClientMessage extends MatchMakerClientMessage {
+public class SearchLadderClientMessage extends MatchMakerClientMessage {
 
   private Faction faction;
 
-  public SearchLadder1v1ClientMessage(Faction faction) {
+  public SearchLadderClientMessage(RatingMode ratingMode, Faction faction) {
     super(ClientMessageType.GAME_MATCH_MAKING);
-    mod = KnownFeaturedMod.LADDER_1V1.getTechnicalName();
+    mod = ratingMode.getCorrespondingFeatureMod().getTechnicalName();
     state = "start";
     this.faction = faction;
   }

--- a/src/main/java/com/faforever/client/rankedmatch/StopSearchLadder1v1ClientMessage.java
+++ b/src/main/java/com/faforever/client/rankedmatch/StopSearchLadder1v1ClientMessage.java
@@ -1,12 +1,13 @@
 package com.faforever.client.rankedmatch;
 
+import com.faforever.client.fa.RatingMode;
 import com.faforever.client.remote.domain.ClientMessageType;
 
 public class StopSearchLadder1v1ClientMessage extends MatchMakerClientMessage {
 
-  public StopSearchLadder1v1ClientMessage() {
+  public StopSearchLadder1v1ClientMessage(RatingMode ratingMode) {
     super(ClientMessageType.GAME_MATCH_MAKING);
     state = "stop";
-    mod = "ladder1v1";
+    mod = ratingMode.getCorrespondingFeatureMod().getTechnicalName();
   }
 }

--- a/src/main/java/com/faforever/client/remote/FafServerAccessor.java
+++ b/src/main/java/com/faforever/client/remote/FafServerAccessor.java
@@ -1,5 +1,6 @@
 package com.faforever.client.remote;
 
+import com.faforever.client.fa.RatingMode;
 import com.faforever.client.fa.relay.GpgGameMessage;
 import com.faforever.client.game.Faction;
 import com.faforever.client.game.NewGameInfo;
@@ -46,9 +47,9 @@ public interface FafServerAccessor {
 
   void requestMatchmakerInfo();
 
-  CompletableFuture<GameLaunchMessage> startSearchLadder1v1(Faction faction);
+  CompletableFuture<GameLaunchMessage> startSearchLadder(RatingMode ratingMode, Faction faction);
 
-  void stopSearchingRanked();
+  void stopSearchingRanked(RatingMode ratingMode);
 
   void sendGpgMessage(GpgGameMessage message);
 

--- a/src/main/java/com/faforever/client/remote/FafServerAccessorImpl.java
+++ b/src/main/java/com/faforever/client/remote/FafServerAccessorImpl.java
@@ -5,6 +5,7 @@ import com.faforever.client.config.CacheNames;
 import com.faforever.client.config.ClientProperties;
 import com.faforever.client.config.ClientProperties.Server;
 import com.faforever.client.fa.CloseGameEvent;
+import com.faforever.client.fa.RatingMode;
 import com.faforever.client.fa.relay.GpgClientMessageSerializer;
 import com.faforever.client.fa.relay.GpgGameMessage;
 import com.faforever.client.fa.relay.GpgServerMessageType;
@@ -22,7 +23,7 @@ import com.faforever.client.notification.ReportAction;
 import com.faforever.client.notification.Severity;
 import com.faforever.client.preferences.PreferencesService;
 import com.faforever.client.rankedmatch.MatchmakerInfoClientMessage;
-import com.faforever.client.rankedmatch.SearchLadder1v1ClientMessage;
+import com.faforever.client.rankedmatch.SearchLadderClientMessage;
 import com.faforever.client.rankedmatch.StopSearchLadder1v1ClientMessage;
 import com.faforever.client.remote.domain.AddFoeMessage;
 import com.faforever.client.remote.domain.AddFriendMessage;
@@ -358,15 +359,15 @@ public class FafServerAccessorImpl extends AbstractServerAccessor implements Faf
   }
 
   @Override
-  public CompletableFuture<GameLaunchMessage> startSearchLadder1v1(Faction faction) {
+  public CompletableFuture<GameLaunchMessage> startSearchLadder(RatingMode ratingMode, Faction faction) {
     gameLaunchFuture = new CompletableFuture<>();
-    writeToServer(new SearchLadder1v1ClientMessage(faction));
+    writeToServer(new SearchLadderClientMessage(ratingMode, faction));
     return gameLaunchFuture;
   }
 
   @Override
-  public void stopSearchingRanked() {
-    writeToServer(new StopSearchLadder1v1ClientMessage());
+  public void stopSearchingRanked(RatingMode ratingMode) {
+    writeToServer(new StopSearchLadder1v1ClientMessage(ratingMode));
     gameLaunchFuture = null;
   }
 

--- a/src/main/java/com/faforever/client/remote/FafService.java
+++ b/src/main/java/com/faforever/client/remote/FafService.java
@@ -17,6 +17,7 @@ import com.faforever.client.clan.Clan;
 import com.faforever.client.config.CacheNames;
 import com.faforever.client.coop.CoopMission;
 import com.faforever.client.domain.RatingHistoryDataPoint;
+import com.faforever.client.fa.RatingMode;
 import com.faforever.client.fa.relay.GpgGameMessage;
 import com.faforever.client.game.Faction;
 import com.faforever.client.game.KnownFeaturedMod;
@@ -91,16 +92,16 @@ public class FafService {
     return fafServerAccessor.requestJoinGame(gameId, password);
   }
 
-  public CompletableFuture<GameLaunchMessage> startSearchLadder1v1(Faction faction) {
-    return fafServerAccessor.startSearchLadder1v1(faction);
+  public CompletableFuture<GameLaunchMessage> startSearchLadder(RatingMode ratingMode, Faction faction) {
+    return fafServerAccessor.startSearchLadder(ratingMode, faction);
   }
 
   public void requestMatchmakerInfo() {
     fafServerAccessor.requestMatchmakerInfo();
   }
 
-  public void stopSearchingRanked() {
-    fafServerAccessor.stopSearchingRanked();
+  public void stopSearchingRanked(RatingMode ratingMode) {
+    fafServerAccessor.stopSearchingRanked(ratingMode);
   }
 
   public void sendGpgGameMessage(GpgGameMessage message) {

--- a/src/main/java/com/faforever/client/remote/MockFafServerAccessor.java
+++ b/src/main/java/com/faforever/client/remote/MockFafServerAccessor.java
@@ -1,6 +1,7 @@
 package com.faforever.client.remote;
 
 import com.faforever.client.FafClientApplication;
+import com.faforever.client.fa.RatingMode;
 import com.faforever.client.fa.relay.GpgGameMessage;
 import com.faforever.client.game.Faction;
 import com.faforever.client.game.KnownFeaturedMod;
@@ -245,7 +246,7 @@ public class MockFafServerAccessor implements FafServerAccessor {
   }
 
   @Override
-  public CompletableFuture<GameLaunchMessage> startSearchLadder(Faction faction) {
+  public CompletableFuture<GameLaunchMessage> startSearchLadder(RatingMode ratingMode, Faction faction) {
     logger.debug("Searching 1v1 match with faction: {}", faction);
     GameLaunchMessage gameLaunchMessage = new GameLaunchMessage();
     gameLaunchMessage.setUid(123);
@@ -254,7 +255,7 @@ public class MockFafServerAccessor implements FafServerAccessor {
   }
 
   @Override
-  public void stopSearchingRanked() {
+  public void stopSearchingRanked(RatingMode ratingMode) {
     logger.debug("Stopping searching 1v1 match");
   }
 

--- a/src/main/java/com/faforever/client/remote/MockFafServerAccessor.java
+++ b/src/main/java/com/faforever/client/remote/MockFafServerAccessor.java
@@ -245,7 +245,7 @@ public class MockFafServerAccessor implements FafServerAccessor {
   }
 
   @Override
-  public CompletableFuture<GameLaunchMessage> startSearchLadder1v1(Faction faction) {
+  public CompletableFuture<GameLaunchMessage> startSearchLadder(Faction faction) {
     logger.debug("Searching 1v1 match with faction: {}", faction);
     GameLaunchMessage gameLaunchMessage = new GameLaunchMessage();
     gameLaunchMessage.setUid(123);

--- a/src/test/java/com/faforever/client/game/GameServiceTest.java
+++ b/src/test/java/com/faforever/client/game/GameServiceTest.java
@@ -426,15 +426,15 @@ public class GameServiceTest extends AbstractPlainJavaFxTest {
 
     String[] additionalArgs = {"/team", "1", "/players", "2", "/startspot", "4"};
     mockStartGameProcess(uid, RatingMode.LADDER_1V1, CYBRAN, false, additionalArgs);
-    when(fafService.startSearchLadder1v1(CYBRAN)).thenReturn(completedFuture(gameLaunchMessage));
+    when(fafService.startSearchLadder(CYBRAN)).thenReturn(completedFuture(gameLaunchMessage));
     when(gameUpdater.update(featuredMod, null, Collections.emptyMap(), Collections.emptySet())).thenReturn(completedFuture(null));
     when(mapService.isInstalled(map)).thenReturn(false);
     when(mapService.download(map)).thenReturn(completedFuture(null));
     when(modService.getFeaturedMod(LADDER_1V1.getTechnicalName())).thenReturn(completedFuture(featuredMod));
 
-    instance.startSearchLadder1v1(CYBRAN).toCompletableFuture();
+    instance.startSearchLadder(CYBRAN).toCompletableFuture();
 
-    verify(fafService).startSearchLadder1v1(CYBRAN);
+    verify(fafService).startSearchLadder(CYBRAN);
     verify(mapService).download(map);
     verify(replayService).start(eq(uid), any());
     verify(forgedAllianceService).startGame(
@@ -464,24 +464,24 @@ public class GameServiceTest extends AbstractPlainJavaFxTest {
     instance.hostGame(newGameInfo);
     gameRunningLatch.await(TIMEOUT, TIME_UNIT);
 
-    instance.startSearchLadder1v1(AEON);
+    instance.startSearchLadder(AEON);
 
-    assertThat(instance.searching1v1Property().get(), is(false));
+    assertThat(instance.searchingLadderProperty().get(), is(false));
   }
 
   @Test
   public void testStopSearchLadder1v1() {
-    instance.searching1v1Property().set(true);
-    instance.stopSearchLadder1v1();
-    assertThat(instance.searching1v1Property().get(), is(false));
+    instance.searchingLadderProperty().set(true);
+    instance.stopSearchLadder();
+    assertThat(instance.searchingLadderProperty().get(), is(false));
     verify(fafService).stopSearchingRanked();
   }
 
   @Test
   public void testStopSearchLadder1v1NotSearching() {
-    instance.searching1v1Property().set(false);
-    instance.stopSearchLadder1v1();
-    assertThat(instance.searching1v1Property().get(), is(false));
+    instance.searchingLadderProperty().set(false);
+    instance.stopSearchLadder();
+    assertThat(instance.searchingLadderProperty().get(), is(false));
     verify(fafService, never()).stopSearchingRanked();
   }
 
@@ -557,7 +557,7 @@ public class GameServiceTest extends AbstractPlainJavaFxTest {
   @Test
   public void startSearchLadder1v1IfNoGameSet() {
     when(preferencesService.isGamePathValid()).thenReturn(false);
-    instance.startSearchLadder1v1(null);
+    instance.startSearchLadder(null);
     verify(eventBus).post(any(GameDirectoryChooseEvent.class));
   }
 

--- a/src/test/java/com/faforever/client/game/GameServiceTest.java
+++ b/src/test/java/com/faforever/client/game/GameServiceTest.java
@@ -208,7 +208,7 @@ public class GameServiceTest extends AbstractPlainJavaFxTest {
     assertThat(future.get(TIMEOUT, TIME_UNIT), is(nullValue()));
     verify(mapService, never()).download(any());
     verify(replayService).start(eq(game.getId()), any());
-    
+
     verify(forgedAllianceService).startGame(
         gameLaunchMessage.getUid(), null, asList(), GLOBAL,
         GPG_PORT, LOCAL_REPLAY_PORT, false, junitPlayer);
@@ -426,15 +426,15 @@ public class GameServiceTest extends AbstractPlainJavaFxTest {
 
     String[] additionalArgs = {"/team", "1", "/players", "2", "/startspot", "4"};
     mockStartGameProcess(uid, RatingMode.LADDER_1V1, CYBRAN, false, additionalArgs);
-    when(fafService.startSearchLadder(CYBRAN)).thenReturn(completedFuture(gameLaunchMessage));
+    when(fafService.startSearchLadder(RatingMode.LADDER_1V1, CYBRAN)).thenReturn(completedFuture(gameLaunchMessage));
     when(gameUpdater.update(featuredMod, null, Collections.emptyMap(), Collections.emptySet())).thenReturn(completedFuture(null));
     when(mapService.isInstalled(map)).thenReturn(false);
     when(mapService.download(map)).thenReturn(completedFuture(null));
     when(modService.getFeaturedMod(LADDER_1V1.getTechnicalName())).thenReturn(completedFuture(featuredMod));
 
-    instance.startSearchLadder(CYBRAN).toCompletableFuture();
+    instance.startSearchLadder(RatingMode.LADDER_1V1, CYBRAN).toCompletableFuture();
 
-    verify(fafService).startSearchLadder(CYBRAN);
+    verify(fafService).startSearchLadder(RatingMode.LADDER_1V1, CYBRAN);
     verify(mapService).download(map);
     verify(replayService).start(eq(uid), any());
     verify(forgedAllianceService).startGame(
@@ -464,7 +464,7 @@ public class GameServiceTest extends AbstractPlainJavaFxTest {
     instance.hostGame(newGameInfo);
     gameRunningLatch.await(TIMEOUT, TIME_UNIT);
 
-    instance.startSearchLadder(AEON);
+    instance.startSearchLadder(RatingMode.LADDER_1V1, AEON);
 
     assertThat(instance.searchingLadderProperty().get(), is(false));
   }
@@ -472,17 +472,17 @@ public class GameServiceTest extends AbstractPlainJavaFxTest {
   @Test
   public void testStopSearchLadder1v1() {
     instance.searchingLadderProperty().set(true);
-    instance.stopSearchLadder();
+    instance.stopSearchLadder(RatingMode.LADDER_1V1);
     assertThat(instance.searchingLadderProperty().get(), is(false));
-    verify(fafService).stopSearchingRanked();
+    verify(fafService).stopSearchingRanked(RatingMode.LADDER_1V1);
   }
 
   @Test
   public void testStopSearchLadder1v1NotSearching() {
     instance.searchingLadderProperty().set(false);
-    instance.stopSearchLadder();
+    instance.stopSearchLadder(RatingMode.LADDER_1V1);
     assertThat(instance.searchingLadderProperty().get(), is(false));
-    verify(fafService, never()).stopSearchingRanked();
+    verify(fafService, never()).stopSearchingRanked(RatingMode.LADDER_1V1);
   }
 
   @Test
@@ -557,7 +557,7 @@ public class GameServiceTest extends AbstractPlainJavaFxTest {
   @Test
   public void startSearchLadder1v1IfNoGameSet() {
     when(preferencesService.isGamePathValid()).thenReturn(false);
-    instance.startSearchLadder(null);
+    instance.startSearchLadder(RatingMode.LADDER_1V1, null);
     verify(eventBus).post(any(GameDirectoryChooseEvent.class));
   }
 

--- a/src/test/java/com/faforever/client/main/MainControllerTest.java
+++ b/src/test/java/com/faforever/client/main/MainControllerTest.java
@@ -139,7 +139,7 @@ public class MainControllerTest extends AbstractPlainJavaFxTest {
     gameRunningProperty = new SimpleBooleanProperty();
     BooleanProperty searching1v1Property = new SimpleBooleanProperty();
     when(gameService.gameRunningProperty()).thenReturn(gameRunningProperty);
-    when(gameService.searching1v1Property()).thenReturn(searching1v1Property);
+    when(gameService.searchingLadderProperty()).thenReturn(searching1v1Property);
 
     when(uiService.loadFxml("theme/persistent_notifications.fxml")).thenReturn(persistentNotificationsController);
     when(uiService.loadFxml("theme/transient_notifications.fxml")).thenReturn(transientNotificationsController);

--- a/src/test/java/com/faforever/client/rankedmatch/Ladder1V1ControllerTest.java
+++ b/src/test/java/com/faforever/client/rankedmatch/Ladder1V1ControllerTest.java
@@ -104,7 +104,7 @@ public class Ladder1V1ControllerTest extends AbstractPlainJavaFxTest {
 
     when(leaderboardService.getLadder1v1Stats()).thenReturn(CompletableFuture.completedFuture(new ArrayList<>()));
     when(leaderboardService.getEntryForPlayer(PLAYER_ID)).thenReturn(CompletableFuture.completedFuture(leaderboardEntry));
-    when(gameService.searching1v1Property()).thenReturn(searching1v1Property);
+    when(gameService.searchingLadderProperty()).thenReturn(searching1v1Property);
     when(preferencesService.getPreferences()).thenReturn(preferences);
     when(preferences.getLadder1v1Prefs()).thenReturn(ladder1V1Prefs);
     when(ladder1V1Prefs.getFactions()).thenReturn(factionList);
@@ -147,7 +147,7 @@ public class Ladder1V1ControllerTest extends AbstractPlainJavaFxTest {
   public void testOnCancelButtonClicked() throws Exception {
     instance.onCancelButtonClicked();
 
-    verify(gameService).stopSearchLadder1v1();
+    verify(gameService).stopSearchLadder();
     assertThat(instance.cancelButton.isVisible(), is(false));
     assertThat(instance.playButton.isVisible(), is(true));
     assertThat(instance.searchingForOpponentLabel.isVisible(), is(false));
@@ -166,7 +166,7 @@ public class Ladder1V1ControllerTest extends AbstractPlainJavaFxTest {
     instance.onPlayButtonClicked();
     instance.setSearching(true);
 
-    verify(gameService).startSearchLadder1v1(any());
+    verify(gameService).startSearchLadder(any());
     assertThat(instance.cancelButton.isVisible(), is(true));
     assertThat(instance.playButton.isVisible(), is(false));
     assertThat(instance.searchProgressIndicator.isVisible(), is(true));
@@ -182,7 +182,7 @@ public class Ladder1V1ControllerTest extends AbstractPlainJavaFxTest {
 
     instance.onPlayButtonClicked();
 
-    verify(gameService, never()).startSearchLadder1v1(any());
+    verify(gameService, never()).startSearchLadder(any());
     verify(eventBus).post(new MissingGamePathEvent(true));
 
     assertThat(instance.cancelButton.isVisible(), is(false));

--- a/src/test/java/com/faforever/client/rankedmatch/Ladder1V1ControllerTest.java
+++ b/src/test/java/com/faforever/client/rankedmatch/Ladder1V1ControllerTest.java
@@ -147,7 +147,7 @@ public class Ladder1V1ControllerTest extends AbstractPlainJavaFxTest {
   public void testOnCancelButtonClicked() throws Exception {
     instance.onCancelButtonClicked();
 
-    verify(gameService).stopSearchLadder();
+    verify(gameService).stopSearchLadder(any());
     assertThat(instance.cancelButton.isVisible(), is(false));
     assertThat(instance.playButton.isVisible(), is(true));
     assertThat(instance.searchingForOpponentLabel.isVisible(), is(false));
@@ -166,7 +166,7 @@ public class Ladder1V1ControllerTest extends AbstractPlainJavaFxTest {
     instance.onPlayButtonClicked();
     instance.setSearching(true);
 
-    verify(gameService).startSearchLadder(any());
+    verify(gameService).startSearchLadder(any(), any());
     assertThat(instance.cancelButton.isVisible(), is(true));
     assertThat(instance.playButton.isVisible(), is(false));
     assertThat(instance.searchProgressIndicator.isVisible(), is(true));
@@ -182,7 +182,7 @@ public class Ladder1V1ControllerTest extends AbstractPlainJavaFxTest {
 
     instance.onPlayButtonClicked();
 
-    verify(gameService, never()).startSearchLadder(any());
+    verify(gameService, never()).startSearchLadder(any(), any());
     verify(eventBus).post(new MissingGamePathEvent(true));
 
     assertThat(instance.cancelButton.isVisible(), is(false));
@@ -210,11 +210,11 @@ public class Ladder1V1ControllerTest extends AbstractPlainJavaFxTest {
     @SuppressWarnings("unchecked")
     ArgumentCaptor<Consumer<MatchmakerInfoMessage>> listenerCaptor = ArgumentCaptor.forClass(Consumer.class);
     verify(gameService).addOnRankedMatchNotificationListener(listenerCaptor.capture());
-    
+
     MatchmakerInfoMessage message = new MatchmakerInfoMessage();
     String timeString = DateTimeFormatter.ISO_INSTANT.format(Instant.now().plusSeconds(65));
     message.setQueues(List.of(new MatchmakerInfoMessage.MatchmakerQueue(QueueName.LADDER_1V1, timeString, null, null)));
-    
+
     listenerCaptor.getValue().accept(message);
     WaitForAsyncUtils.waitFor(3, TimeUnit.SECONDS, () -> instance.timeUntilQueuePopLabel.isVisible());
     verify(i18n, atLeast(1)).get(any(), eq(1L), anyInt());

--- a/src/test/java/com/faforever/client/remote/ServerAccessorImplTest.java
+++ b/src/test/java/com/faforever/client/remote/ServerAccessorImplTest.java
@@ -2,6 +2,7 @@ package com.faforever.client.remote;
 
 import com.faforever.client.config.ClientProperties;
 import com.faforever.client.fa.CloseGameEvent;
+import com.faforever.client.fa.RatingMode;
 import com.faforever.client.game.Faction;
 import com.faforever.client.i18n.I18n;
 import com.faforever.client.legacy.FactionDeserializer;
@@ -330,7 +331,7 @@ public class ServerAccessorImplTest extends AbstractPlainJavaFxTest {
   public void startSearchLadder1v1WithAeon() throws Exception {
     connectAndLogIn();
 
-    CompletableFuture<GameLaunchMessage> future = instance.startSearchLadder(Faction.AEON).toCompletableFuture();
+    CompletableFuture<GameLaunchMessage> future = instance.startSearchLadder(RatingMode.LADDER_1V1, Faction.AEON).toCompletableFuture();
 
     String clientMessage = messagesReceivedByFafServer.poll(TIMEOUT, TIMEOUT_UNIT);
     SearchLadderClientMessage searchRanked1v1Message = gson.fromJson(clientMessage, SearchLadderClientMessage.class);
@@ -351,7 +352,7 @@ public class ServerAccessorImplTest extends AbstractPlainJavaFxTest {
   public void stopSearchingLadder1v1Match() throws Exception {
     connectAndLogIn();
 
-    instance.stopSearchingRanked();
+    instance.stopSearchingRanked(RatingMode.LADDER_1V1);
 
     String clientMessage = messagesReceivedByFafServer.poll(TIMEOUT, TIMEOUT_UNIT);
     StopSearchLadder1v1ClientMessage stopSearchRanked1v1Message = gson.fromJson(clientMessage, StopSearchLadder1v1ClientMessage.class);

--- a/src/test/java/com/faforever/client/remote/ServerAccessorImplTest.java
+++ b/src/test/java/com/faforever/client/remote/ServerAccessorImplTest.java
@@ -14,7 +14,7 @@ import com.faforever.client.preferences.LoginPrefs;
 import com.faforever.client.preferences.PreferencesService;
 import com.faforever.client.rankedmatch.MatchmakerInfoMessage;
 import com.faforever.client.rankedmatch.MatchmakerInfoMessage.MatchmakerQueue.QueueName;
-import com.faforever.client.rankedmatch.SearchLadder1v1ClientMessage;
+import com.faforever.client.rankedmatch.SearchLadderClientMessage;
 import com.faforever.client.rankedmatch.StopSearchLadder1v1ClientMessage;
 import com.faforever.client.remote.domain.ClientMessageType;
 import com.faforever.client.remote.domain.FafServerMessage;
@@ -330,12 +330,12 @@ public class ServerAccessorImplTest extends AbstractPlainJavaFxTest {
   public void startSearchLadder1v1WithAeon() throws Exception {
     connectAndLogIn();
 
-    CompletableFuture<GameLaunchMessage> future = instance.startSearchLadder1v1(Faction.AEON).toCompletableFuture();
+    CompletableFuture<GameLaunchMessage> future = instance.startSearchLadder(Faction.AEON).toCompletableFuture();
 
     String clientMessage = messagesReceivedByFafServer.poll(TIMEOUT, TIMEOUT_UNIT);
-    SearchLadder1v1ClientMessage searchRanked1v1Message = gson.fromJson(clientMessage, SearchLadder1v1ClientMessage.class);
+    SearchLadderClientMessage searchRanked1v1Message = gson.fromJson(clientMessage, SearchLadderClientMessage.class);
 
-    assertThat(searchRanked1v1Message, instanceOf(SearchLadder1v1ClientMessage.class));
+    assertThat(searchRanked1v1Message, instanceOf(SearchLadderClientMessage.class));
     assertThat(searchRanked1v1Message.getFaction(), is(Faction.AEON));
 
     GameLaunchMessage gameLaunchMessage = new GameLaunchMessage();


### PR DESCRIPTION
Now It is working with 1v1 and 2v2 modes and other modes can be added easily. Changed names of corresponding variables and methods to reflect the changes. Changed some tests to correspond to the changed code.

To add a new ladder mode later (for example 3v3 or 4v4) we just need to modify enums: RatingMode enum and KnownFeatureMod enum. Also, we need to add a switch case to the startGame() method in ForgedAllianceService class.