### PR TITLE
Leaderboard now selects the player when searching by rank

### DIFF
--- a/src/main/java/com/faforever/client/leaderboard/LeaderboardController.java
+++ b/src/main/java/com/faforever/client/leaderboard/LeaderboardController.java
@@ -74,8 +74,9 @@ public class LeaderboardController extends AbstractViewController<Node> {
 
     searchTextField.textProperty().addListener((observable, oldValue, newValue) -> {
       if (Validator.isInt(newValue)) {
-        ratingTable.scrollTo(Integer.parseInt(newValue) - 1);
-        ratingTable.getSelectionModel().select(Integer.parseInt(newValue) - 1);
+        int ranking = Integer.parseInt(newValue) - 1;
+        ratingTable.scrollTo(ranking);
+        ratingTable.getSelectionModel().select(ranking);
       } else {
         LeaderboardEntry foundPlayer = null;
         for (LeaderboardEntry leaderboardEntry : ratingTable.getItems()) {

--- a/src/main/java/com/faforever/client/leaderboard/LeaderboardController.java
+++ b/src/main/java/com/faforever/client/leaderboard/LeaderboardController.java
@@ -75,6 +75,7 @@ public class LeaderboardController extends AbstractViewController<Node> {
     searchTextField.textProperty().addListener((observable, oldValue, newValue) -> {
       if (Validator.isInt(newValue)) {
         ratingTable.scrollTo(Integer.parseInt(newValue) - 1);
+        ratingTable.getSelectionModel().select(Integer.parseInt(newValue) - 1);
       } else {
         LeaderboardEntry foundPlayer = null;
         for (LeaderboardEntry leaderboardEntry : ratingTable.getItems()) {

--- a/src/test/java/com/faforever/client/leaderboard/LeaderboardControllerTest.java
+++ b/src/test/java/com/faforever/client/leaderboard/LeaderboardControllerTest.java
@@ -60,6 +60,26 @@ public class LeaderboardControllerTest extends AbstractPlainJavaFxTest {
   }
 
   @Test
+  public void testFilterByRank() throws Exception {
+    LeaderboardEntry entry1 = new LeaderboardEntry();
+    entry1.setUsername("Aa");
+    LeaderboardEntry entry2 = new LeaderboardEntry();
+    entry2.setUsername("Ab");
+
+    when(leaderboardService.getEntries(KnownFeaturedMod.LADDER_1V1)).thenReturn(CompletableFuture.completedFuture(Arrays.asList(
+        entry1, entry2
+    )));
+    instance.setRatingType(KnownFeaturedMod.LADDER_1V1);
+    instance.display(new OpenLadder1v1LeaderboardEvent());
+
+    assertThat(instance.ratingTable.getSelectionModel().getSelectedItem(), nullValue());
+
+    instance.searchTextField.setText("2");
+    assertThat(instance.ratingTable.getItems(), hasSize(2));
+    assertThat(instance.ratingTable.getSelectionModel().getSelectedItem().getUsername(), is("Ab"));
+  }
+
+  @Test
   public void testFilterByNamePlayerExactMatch() throws Exception {
     LeaderboardEntry entry1 = new LeaderboardEntry();
     entry1.setUsername("Aa");


### PR DESCRIPTION
Searching by name selects the player, but searching by rank doesn't. This makes it so that searching by rank also selects the player.