### PR TITLE
Feature/#1231 basic search fields for the vault

### DIFF
--- a/src/main/java/com/faforever/client/map/MapVaultController.java
+++ b/src/main/java/com/faforever/client/map/MapVaultController.java
@@ -102,6 +102,7 @@ public class MapVaultController extends AbstractViewController<Node> {
   public JFXButton nextButton;
   public Label currentPageLabel;
   public HBox paginationHBox;
+  public ScrollPane searchScrollPane;
   private MapDetailController mapDetailController;
   private int currentPage;
   private Supplier<CompletableFuture<List<MapBean>>> currentSupplier;
@@ -125,6 +126,7 @@ public class MapVaultController extends AbstractViewController<Node> {
   public void initialize() {
     super.initialize();
     JavaFxUtil.fixScrollSpeed(scrollPane);
+    JavaFxUtil.fixScrollSpeed(searchScrollPane);
 
     loadingLabel.managedProperty().bind(loadingLabel.visibleProperty());
     showroomGroup.managedProperty().bind(showroomGroup.visibleProperty());
@@ -140,6 +142,7 @@ public class MapVaultController extends AbstractViewController<Node> {
     AnchorPane.setBottomAnchor(mapDetailRoot, 0d);
     AnchorPane.setLeftAnchor(mapDetailRoot, 0d);
     mapDetailRoot.setVisible(false);
+    searchController.basicSearchPaneMaps.setVisible(true);
 
     eventBus.register(this);
 

--- a/src/main/java/com/faforever/client/mod/ModVaultController.java
+++ b/src/main/java/com/faforever/client/mod/ModVaultController.java
@@ -84,6 +84,7 @@ public class ModVaultController extends AbstractViewController<Node> {
   public Button backButton;
   public SearchController searchController;
   public Button moreButton;
+  public ScrollPane searchScrollPane;
 
   private boolean initialized;
   private ModDetailController modDetailController;
@@ -107,6 +108,7 @@ public class ModVaultController extends AbstractViewController<Node> {
   public void initialize() {
     super.initialize();
     JavaFxUtil.fixScrollSpeed(scrollPane);
+    JavaFxUtil.fixScrollSpeed(searchScrollPane);
 
     loadingLabel.managedProperty().bind(loadingLabel.visibleProperty());
     showroomGroup.managedProperty().bind(showroomGroup.visibleProperty());
@@ -122,6 +124,7 @@ public class ModVaultController extends AbstractViewController<Node> {
     AnchorPane.setBottomAnchor(modDetailRoot, 0d);
     AnchorPane.setLeftAnchor(modDetailRoot, 0d);
     modDetailRoot.setVisible(false);
+    searchController.basicSearchPaneMods.setVisible(true);
 
     eventBus.register(this);
 

--- a/src/main/java/com/faforever/client/replay/OnlineReplayVaultController.java
+++ b/src/main/java/com/faforever/client/replay/OnlineReplayVaultController.java
@@ -75,6 +75,7 @@ public class OnlineReplayVaultController extends AbstractViewController<Node> {
   public SearchController searchController;
   public Button moreButton;
   public VBox ownReplaysPane;
+  public ScrollPane searchScrollPane;
 
   private ReplayDetailController replayDetailController;
   private int currentPage;
@@ -96,11 +97,13 @@ public class OnlineReplayVaultController extends AbstractViewController<Node> {
   public void initialize() {
     super.initialize();
     JavaFxUtil.fixScrollSpeed(scrollPane);
+    JavaFxUtil.fixScrollSpeed(searchScrollPane);
     loadingPane.managedProperty().bind(loadingPane.visibleProperty());
     showroomGroup.managedProperty().bind(showroomGroup.visibleProperty());
     searchResultGroup.managedProperty().bind(searchResultGroup.visibleProperty());
     backButton.managedProperty().bind(backButton.visibleProperty());
     moreButton.managedProperty().bind(moreButton.visibleProperty());
+    searchController.basicSearchPaneReplays.setVisible(true);
 
     searchController.setRootType(Game.class);
     searchController.setSearchListener(this::onSearch);

--- a/src/main/java/com/faforever/client/vault/search/SearchController.java
+++ b/src/main/java/com/faforever/client/vault/search/SearchController.java
@@ -10,6 +10,7 @@ import com.faforever.client.theme.UiService;
 import com.github.rutledgepaulv.qbuilders.builders.QBuilder;
 import com.github.rutledgepaulv.qbuilders.conditions.Condition;
 import com.github.rutledgepaulv.qbuilders.visitors.RSQLVisitor;
+import com.jfoenix.controls.JFXToggleButton;
 import javafx.application.Platform;
 import javafx.beans.InvalidationListener;
 import javafx.beans.binding.BooleanBinding;
@@ -21,6 +22,7 @@ import javafx.scene.control.TextField;
 import javafx.scene.input.KeyCode;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Pane;
+import javafx.scene.layout.VBox;
 import javafx.util.StringConverter;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -54,6 +56,12 @@ public class SearchController implements Controller<Pane> {
   public ComboBox<Property> sortPropertyComboBox;
   public ComboBox<SortOrder> sortOrderChoiceBox;
   public HBox sortBox;
+  public JFXToggleButton revealAdvancedSearchButton;
+  public VBox advancedSearchPane;
+  public VBox basicSearchPane;
+  public VBox basicSearchPaneMaps;
+  public VBox basicSearchPaneMods;
+  public VBox basicSearchPaneReplays;
 
   private List<LogicalNodeController> queryNodes;
   private InvalidationListener queryInvalidationListener;
@@ -77,6 +85,13 @@ public class SearchController implements Controller<Pane> {
   public void initialize() {
     queryTextField.managedProperty().bind(queryTextField.visibleProperty());
     queryTextField.visibleProperty().bind(displayQueryCheckBox.selectedProperty());
+    advancedSearchPane.managedProperty().bind(advancedSearchPane.visibleProperty());
+    advancedSearchPane.visibleProperty().bind(revealAdvancedSearchButton.selectedProperty());
+    basicSearchPane.managedProperty().bind(basicSearchPane.visibleProperty());
+    basicSearchPane.visibleProperty().bind(revealAdvancedSearchButton.selectedProperty().not());
+    basicSearchPaneMaps.managedProperty().bind(basicSearchPaneMaps.visibleProperty());
+    basicSearchPaneMods.managedProperty().bind(basicSearchPaneMods.visibleProperty());
+    basicSearchPaneReplays.managedProperty().bind(basicSearchPaneReplays.visibleProperty());
 
     initialLogicalNodeController.logicalOperatorField.managedProperty()
         .bind(initialLogicalNodeController.logicalOperatorField.visibleProperty());
@@ -241,7 +256,7 @@ public class SearchController implements Controller<Pane> {
   }
 
   public void setSearchButtonDisabledCondition(BooleanBinding inSearchableState) {
-    searchButton.disableProperty().bind(queryTextField.textProperty().isEmpty().or(inSearchableState.not()));
+    searchButton.disableProperty().bind(inSearchableState.not());
   }
 
   @Getter

--- a/src/main/resources/theme/style.css
+++ b/src/main/resources/theme/style.css
@@ -253,6 +253,17 @@
   -fx-font-size: 2em;
 }
 
+.icon-button.decline {
+  -fx-background-radius: 1em;
+  -fx-pref-width: 1em;
+  -fx-pref-height: 1em;
+}
+
+.icon-button.decline > .text {
+  -fx-fill: -red-400;
+  -fx-font-size: 1em;
+}
+
 .icon-button:hover {
   -fx-background-color: transparent;
 }
@@ -1031,6 +1042,17 @@
   -fx-border-color: -divider-color;
   -fx-padding: 1em;
   -fx-graphic-text-gap: 1em;
+}
+
+/***************** Match maker *****************/
+
+
+.invite-card {
+  -fx-background-color: #141414;
+  -fx-border-color: #818181;
+  -fx-background-radius: 9;
+  -fx-border-radius: 9;
+  -fx-border-width: 1;
 }
 
 /***************** Faction buttons *****************/

--- a/src/main/resources/theme/vault/map/map_vault.fxml
+++ b/src/main/resources/theme/vault/map/map_vault.fxml
@@ -6,13 +6,15 @@
 <?import javafx.scene.layout.*?>
 
 <StackPane fx:id="mapVaultRoot" xmlns="http://javafx.com/javafx/10.0.2-internal" xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.faforever.client.map.MapVaultController">
-    <children>
-        <ScrollPane fx:id="scrollPane" fitToWidth="true" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308">
+    <HBox>
+        <ScrollPane fx:id="searchScrollPane" hbarPolicy="NEVER">
+            <fx:include fx:id="search" source="../search/search.fxml"/>
+        </ScrollPane>
+        <ScrollPane fx:id="scrollPane" fitToWidth="true" maxHeight="1.7976931348623157E308"
+                    maxWidth="1.7976931348623157E308" HBox.hgrow="ALWAYS" prefWidth="10.0">
             <content>
                 <VBox spacing="10.0">
                     <children>
-                        <fx:include fx:id="search" source="../search/search.fxml" />
-                        <Separator maxWidth="1.7976931348623157E308" />
                         <HBox spacing="10.0">
                             <children>
                                 <JFXButton fx:id="backButton" mnemonicParsing="false" onAction="#onBackButtonClicked" text="%back">
@@ -85,10 +87,10 @@
                         </Label>
                     </children>
                     <padding>
-                        <Insets bottom="20.0" left="20.0" right="20.0" top="20.0" />
+                        <Insets bottom="20.0" left="10.0" right="20.0" top="20.0" />
                     </padding>
                 </VBox>
             </content>
         </ScrollPane>
-    </children>
+    </HBox>
 </StackPane>

--- a/src/main/resources/theme/vault/mod/mod_vault.fxml
+++ b/src/main/resources/theme/vault/mod/mod_vault.fxml
@@ -5,21 +5,21 @@
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.control.ScrollPane?>
-<?import javafx.scene.control.Separator?>
 <?import javafx.scene.layout.FlowPane?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
 <StackPane xmlns:fx="http://javafx.com/fxml/1" fx:id="modVaultRoot" xmlns="http://javafx.com/javafx/8.0.111"
            fx:controller="com.faforever.client.mod.ModVaultController">
-    <children>
+    <HBox>
+        <ScrollPane fx:id="searchScrollPane" hbarPolicy="NEVER">
+            <fx:include fx:id="search" source="../search/search.fxml"/>
+        </ScrollPane>
         <ScrollPane fx:id="scrollPane" fitToWidth="true" maxHeight="1.7976931348623157E308"
-                    maxWidth="1.7976931348623157E308">
+                    maxWidth="1.7976931348623157E308" HBox.hgrow="ALWAYS" prefWidth="10.0">
             <content>
                 <VBox spacing="10.0">
                     <children>
-                        <fx:include fx:id="search" source="../search/search.fxml"/>
-                        <Separator maxWidth="1.7976931348623157E308"/>
                         <HBox spacing="10.0">
                             <children>
                                 <JFXButton fx:id="backButton" mnemonicParsing="false" onAction="#onBackButtonClicked"
@@ -84,10 +84,10 @@
                         </Label>
                     </children>
                     <padding>
-                        <Insets bottom="20.0" left="20.0" right="20.0" top="20.0"/>
+                        <Insets bottom="20.0" left="10.0" right="20.0" top="20.0"/>
                     </padding>
                 </VBox>
             </content>
         </ScrollPane>
-    </children>
+    </HBox>
 </StackPane>

--- a/src/main/resources/theme/vault/replay/online_replays.fxml
+++ b/src/main/resources/theme/vault/replay/online_replays.fxml
@@ -5,20 +5,20 @@
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.control.ScrollPane?>
-<?import javafx.scene.control.Separator?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
 <StackPane xmlns:fx="http://javafx.com/fxml/1" fx:id="replayVaultRoot" xmlns="http://javafx.com/javafx/8.0.111"
            fx:controller="com.faforever.client.replay.OnlineReplayVaultController">
-    <children>
+    <HBox>
+        <ScrollPane fx:id="searchScrollPane" hbarPolicy="NEVER">
+            <fx:include fx:id="search" source="../search/search.fxml"/>
+        </ScrollPane>
         <ScrollPane fx:id="scrollPane" fitToWidth="true" maxHeight="1.7976931348623157E308"
-                    maxWidth="1.7976931348623157E308">
+                    maxWidth="1.7976931348623157E308" HBox.hgrow="ALWAYS" prefWidth="10.0">
             <content>
                 <VBox fx:id="contentPane" spacing="10.0">
                     <children>
-                        <fx:include fx:id="search" source="../search/search.fxml"/>
-                        <Separator maxWidth="1.7976931348623157E308"/>
                         <HBox spacing="10.0">
                             <children>
                                 <JFXButton fx:id="backButton" mnemonicParsing="false" onAction="#onBackButtonClicked"
@@ -62,7 +62,7 @@
                         </VBox>
                     </children>
                     <padding>
-                        <Insets bottom="20.0" left="20.0" right="20.0" top="30.0"/>
+                        <Insets bottom="20.0" left="10.0" right="20.0" top="20.0"/>
                     </padding>
                 </VBox>
             </content>
@@ -77,5 +77,5 @@
                 </Label>
             </children>
         </VBox>
-    </children>
+    </HBox>
 </StackPane>

--- a/src/main/resources/theme/vault/search/logical_node.fxml
+++ b/src/main/resources/theme/vault/search/logical_node.fxml
@@ -3,13 +3,21 @@
 <?import com.jfoenix.controls.JFXButton?>
 <?import com.jfoenix.controls.JFXComboBox?>
 <?import javafx.scene.layout.HBox?>
+<?import javafx.geometry.Insets?>
 <HBox xmlns:fx="http://javafx.com/fxml/1" fx:id="logicalNodeRoot" alignment="CENTER_LEFT" maxHeight="-Infinity"
-      maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" spacing="10.0"
+      maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity"
       xmlns="http://javafx.com/javafx/8.0.60" fx:controller="com.faforever.client.query.LogicalNodeController">
     <children>
-        <JFXComboBox fx:id="logicalOperatorField" maxHeight="1.7976931348623157E308" prefWidth="100.0"/>
+        <JFXComboBox fx:id="logicalOperatorField" maxHeight="1.7976931348623157E308">
+            <padding>
+                <Insets right="10.0"/>
+            </padding>
+        </JFXComboBox>
         <fx:include fx:id="specification" source="specification.fxml"/>
         <JFXButton fx:id="removeCriteriaButton" maxWidth="1.7976931348623157E308" mnemonicParsing="false"
-                   onAction="#onRemoveCriteriaButtonClicked" text="%query.removeCriteria"/>
+                   onAction="#onRemoveCriteriaButtonClicked" styleClass="decline, icon-button" text=""/>
     </children>
+    <padding>
+        <Insets right="-15.0"/>
+    </padding>
 </HBox>

--- a/src/main/resources/theme/vault/search/search.fxml
+++ b/src/main/resources/theme/vault/search/search.fxml
@@ -1,61 +1,105 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import com.jfoenix.controls.JFXButton?>
-<?import com.jfoenix.controls.JFXCheckBox?>
-<?import com.jfoenix.controls.JFXComboBox?>
-<?import com.jfoenix.controls.JFXTextField?>
-<?import javafx.geometry.Insets?>
-<?import javafx.scene.control.Label?>
-<?import javafx.scene.layout.HBox?>
-<?import javafx.scene.layout.VBox?>
-<VBox xmlns:fx="http://javafx.com/fxml/1" fx:id="searchRoot" maxHeight="-Infinity" maxWidth="-Infinity"
-      minHeight="-Infinity" minWidth="-Infinity" spacing="10.0" xmlns="http://javafx.com/javafx/8.0.121"
-      fx:controller="com.faforever.client.vault.search.SearchController">
-    <children>
-        <VBox fx:id="criteriaPane">
-            <children>
-                <HBox alignment="CENTER_LEFT" spacing="10.0">
-                    <children>
-                        <fx:include fx:id="initialLogicalNode" source="logical_node.fxml"/>
-                    </children>
+<?import com.jfoenix.controls.*?>
+<?import javafx.geometry.*?>
+<?import javafx.scene.control.*?>
+<?import javafx.scene.layout.*?>
+
+<VBox fx:id="searchRoot" alignment="TOP_CENTER" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" spacing="10.0" xmlns="http://javafx.com/javafx/10.0.2-internal" xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.faforever.client.vault.search.SearchController">
+    <VBox spacing="20.0" styleClass="invite-card">
+        <HBox spacing="10" alignment="CENTER_LEFT">
+            <Label text="ADVANCED SEARCH" styleClass="h3"/>
+            <JFXToggleButton fx:id="revealAdvancedSearchButton" mnemonicParsing="false"/>
+            <padding>
+                <Insets bottom="-20.0"/>
+            </padding>
+        </HBox>
+        <VBox fx:id="basicSearchPane">
+            <VBox fx:id="basicSearchPaneMaps" spacing="20.0" visible="false">
+                <HBox spacing="10" alignment="CENTER_LEFT">
+                    <Label text="Name:" />
+                    <JFXTextField fx:id="MapNameTextField" maxWidth="250"/>
                 </HBox>
-            </children>
+                <HBox spacing="10" alignment="CENTER_LEFT">
+                    <Label text="Author:" />
+                    <JFXTextField fx:id="mapAuthorTextField" maxWidth="250"/>
+                </HBox>
+                <HBox spacing="10" alignment="CENTER_LEFT">
+                    <Label text="Size (km):" />
+                    <JFXTextField fx:id="mapSizeTextField" maxWidth="100"/>
+                </HBox>
+            </VBox>
+            <VBox fx:id="basicSearchPaneMods" spacing="20.0" visible="false">
+                <HBox spacing="10" alignment="CENTER_LEFT">
+                    <Label text="Name:" />
+                    <JFXTextField fx:id="modNameTextField" maxWidth="250"/>
+                </HBox>
+                <HBox spacing="10" alignment="CENTER_LEFT">
+                    <Label text="Author:" />
+                    <JFXTextField fx:id="modAuthorTextField" maxWidth="250"/>
+                </HBox>
+                <HBox spacing="40">
+                    <JFXCheckBox fx:id="simMods" mnemonicParsing="false" selected="true" text="SIM" />
+                    <JFXCheckBox fx:id="UIMods" mnemonicParsing="false" selected="true" text="UI" />
+                </HBox>
+            </VBox>
+            <VBox fx:id="basicSearchPaneReplays" spacing="20.0" visible="false">
+                <HBox spacing="10" alignment="CENTER_LEFT">
+                    <Label text="Player:" />
+                    <JFXTextField fx:id="playerTextField" maxWidth="250"/>
+                </HBox>
+                <HBox spacing="10" alignment="CENTER_LEFT">
+                    <Label text="Min. Rating:" />
+                    <JFXTextField fx:id="ratingTextField" prefWidth="110"/>
+                </HBox>
+                <HBox spacing="10" alignment="CENTER_LEFT">
+                    <Label text="Map:" />
+                    <JFXTextField fx:id="replayMapTextField" maxWidth="250"/>
+                </HBox>
+                <HBox spacing="10" alignment="CENTER_LEFT">
+                    <Label text="Game Type:" />
+                    <JFXComboBox />
+                </HBox>
+                <JFXCheckBox fx:id="timeRange" mnemonicParsing="false" selected="true" text="only past year" />
+            </VBox>
         </VBox>
-        <HBox alignment="CENTER_LEFT" spacing="10.0">
+        <VBox fx:id="advancedSearchPane" spacing="10">
+            <VBox fx:id="criteriaPane" spacing="10">
+                <children>
+                    <HBox alignment="CENTER_LEFT" spacing="10.0">
+                        <children>
+                            <fx:include fx:id="initialLogicalNode" source="logical_node.fxml" />
+                        </children>
+                    </HBox>
+                </children>
+            </VBox>
+            <HBox alignment="CENTER_LEFT" spacing="10.0">
+                <children>
+                    <JFXButton maxHeight="1.7976931348623157E308" mnemonicParsing="false" onAction="#onAddCriteriaButtonClicked" text="%query.addCriteria" />
+                    <JFXButton layoutX="10.0" layoutY="10.0" maxHeight="1.7976931348623157E308" mnemonicParsing="false" onAction="#onResetButtonClicked" text="%reset" />
+                </children>
+            </HBox>
+            <JFXCheckBox fx:id="displayQueryCheckBox" mnemonicParsing="false" text="%vault.replays.displayQuery">
+            </JFXCheckBox>
+            <JFXTextField fx:id="queryTextField" maxWidth="1.7976931348623157E308" onAction="#onSearchButtonClicked" promptText="%vault.replays.queryPrompt" />
+        </VBox>
+        <HBox fx:id="sortBox" alignment="CENTER_LEFT" spacing="5">
             <children>
-                <JFXButton maxHeight="1.7976931348623157E308" mnemonicParsing="false"
-                           onAction="#onAddCriteriaButtonClicked" text="%query.addCriteria"/>
-                <JFXButton layoutX="10.0" layoutY="10.0" maxHeight="1.7976931348623157E308" mnemonicParsing="false"
-                        onAction="#onResetButtonClicked" text="%reset"/>
-                <HBox fx:id="sortBox" alignment="CENTER_LEFT" spacing="5">
-                    <padding>
-                        <Insets>
-                            <left>
-                                20
-                            </left>
-                            <right>
-                                20
-                            </right>
-                        </Insets>
-                    </padding>
-                    <children>
-                        <Label text="%search.sort"/>
-                        <JFXComboBox fx:id="sortPropertyComboBox"/>
-                        <JFXComboBox fx:id="sortOrderChoiceBox"/>
-                    </children>
-                </HBox>
-
-                <JFXButton fx:id="searchButton" defaultButton="true" mnemonicParsing="false"
-                           onAction="#onSearchButtonClicked" styleClass="button-raised" text="%search">
-                    <graphic>
-                        <Label styleClass="icon" text=""/>
-                    </graphic>
-                </JFXButton>
-                <JFXCheckBox fx:id="displayQueryCheckBox" mnemonicParsing="false" text="%vault.replays.displayQuery"/>
-
+                <Label text="%search.sort" />
+                <JFXComboBox fx:id="sortPropertyComboBox" />
+                <JFXComboBox fx:id="sortOrderChoiceBox" />
             </children>
         </HBox>
-        <JFXTextField fx:id="queryTextField" onAction="#onSearchButtonClicked" maxWidth="1.7976931348623157E308"
-                   promptText="%vault.replays.queryPrompt"/>
-    </children>
+        <JFXButton fx:id="searchButton" defaultButton="true" mnemonicParsing="false" onAction="#onSearchButtonClicked" styleClass="button-raised" text="%search">
+            <graphic>
+                <Label styleClass="icon" text="" />
+            </graphic>
+        </JFXButton>
+        <padding>
+            <Insets bottom="20.0" left="20.0" right="20.0" top="0.0" />
+        </padding>
+    </VBox>
+    <padding>
+        <Insets bottom="20.0" left="20.0" top="20.0" right="10.0"/>
+    </padding>
 </VBox>

--- a/src/main/resources/theme/vault/search/specification.fxml
+++ b/src/main/resources/theme/vault/search/specification.fxml
@@ -3,12 +3,17 @@
 <?import com.jfoenix.controls.JFXComboBox?>
 <?import com.jfoenix.controls.JFXDatePicker?>
 <?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.VBox?>
 <HBox xmlns:fx="http://javafx.com/fxml/1" fx:id="specificationRoot" maxHeight="-Infinity" maxWidth="-Infinity"
       minHeight="-Infinity" minWidth="-Infinity" spacing="10" xmlns="http://javafx.com/javafx/8.0.111"
       fx:controller="com.faforever.client.query.SpecificationController">
-    <JFXComboBox fx:id="propertyField" maxHeight="1.7976931348623157E308"/>
-    <JFXComboBox fx:id="operationField" maxHeight="1.7976931348623157E308" prefWidth="150.0"/>
-    <JFXComboBox fx:id="valueField" editable="true" maxHeight="1.7976931348623157E308" prefWidth="300.0"
-                 promptText="%query.valueHint"/>
-    <JFXDatePicker fx:id="datePicker" maxHeight="1.7976931348623157E308" prefWidth="300.0"/>
+    <VBox spacing="5">
+        <JFXComboBox fx:id="propertyField" maxHeight="1.7976931348623157E308"/>
+        <HBox spacing="10">
+            <JFXComboBox fx:id="operationField" maxHeight="1.7976931348623157E308"/>
+            <JFXComboBox fx:id="valueField" editable="true" maxHeight="1.7976931348623157E308"
+                         promptText="%query.valueHint" maxWidth="250"/>
+            <JFXDatePicker fx:id="datePicker" maxHeight="1.7976931348623157E308" prefWidth="150"/>
+        </HBox>
+    </VBox>
 </HBox>


### PR DESCRIPTION
I created UI elements to provide basic search fields for the vault. The only things left to do are:
- Make the text fields construct the appropriate api query string.
- Give the user the ability to leave the fields blank while triggering the sort order with the search button.

However, I do not know how to do that properly. The code for the vault search is incredibly abstract to accomodate for changes in the api, which is good, but I have no idea where I would inject the more or less hardcoded string for the basic search fields.

This will eventually fix #1231 

![grafik](https://user-images.githubusercontent.com/52536103/86038830-d5278900-ba41-11ea-8b71-b01b2f60c415.png)
![grafik](https://user-images.githubusercontent.com/52536103/86038876-e96b8600-ba41-11ea-9973-4130fb717a17.png)
