### PR TITLE
Create game title text field changes border to red if not filled out

### DIFF
--- a/src/main/java/com/faforever/client/game/CreateGameController.java
+++ b/src/main/java/com/faforever/client/game/CreateGameController.java
@@ -31,6 +31,7 @@ import javafx.beans.binding.Bindings;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
+import javafx.css.PseudoClass;
 import javafx.scene.control.Button;
 import javafx.scene.control.CheckBox;
 import javafx.scene.control.Label;
@@ -223,11 +224,11 @@ public class CreateGameController implements Controller<Pane> {
   }
 
   private void adjustCreateGameButtonBackgroundColor(String newValue) {
+    PseudoClass invalidClass = PseudoClass.getPseudoClass("invalid");
     if (Strings.isNullOrEmpty(newValue)) {
-      // titleTextField.setBackground(new Background(new BackgroundFill(Paint.valueOf("FF0000"), CornerRadii.EMPTY, Insets.EMPTY)));
-      titleTextField.setStyle("-fx-background-color: -bad;");
+      titleTextField.pseudoClassStateChanged(invalidClass, true);
     } else {
-      titleTextField.setStyle("-fx-background-color: transparent;");
+      titleTextField.pseudoClassStateChanged(invalidClass, false);
     }
   }
 

--- a/src/main/java/com/faforever/client/game/CreateGameController.java
+++ b/src/main/java/com/faforever/client/game/CreateGameController.java
@@ -195,7 +195,9 @@ public class CreateGameController implements Controller<Pane> {
     titleTextField.textProperty().addListener((observable, oldValue, newValue) -> {
       preferencesService.getPreferences().getLastGamePrefs().setLastGameTitle(newValue);
       preferencesService.storeInBackground();
+      adjustCreateGameButtonBackgroundColor(newValue);
     });
+    adjustCreateGameButtonBackgroundColor(titleTextField.getText());
 
     createGameButton.textProperty().bind(Bindings.createStringBinding(() -> {
       switch (fafService.connectionStateProperty().get()) {
@@ -218,6 +220,15 @@ public class CreateGameController implements Controller<Pane> {
         titleTextField.textProperty().isEmpty()
             .or(featuredModListView.getSelectionModel().selectedItemProperty().isNull().or(fafService.connectionStateProperty().isNotEqualTo(CONNECTED)))
     );
+  }
+
+  private void adjustCreateGameButtonBackgroundColor(String newValue) {
+    if (Strings.isNullOrEmpty(newValue)) {
+      // titleTextField.setBackground(new Background(new BackgroundFill(Paint.valueOf("FF0000"), CornerRadii.EMPTY, Insets.EMPTY)));
+      titleTextField.setStyle("-fx-background-color: -bad;");
+    } else {
+      titleTextField.setStyle("-fx-background-color: transparent;");
+    }
   }
 
   private void initPassword() {

--- a/src/main/resources/theme/style.css
+++ b/src/main/resources/theme/style.css
@@ -959,6 +959,7 @@
 
 .game-title-input {
   -fx-font-size: 0.8cm;
+  -fx-prompt-text-fill: -fx-light-text-color;
 }
 .game-generate-map {
   -fx-background-color: -dimmed-accent;

--- a/src/main/resources/theme/style.css
+++ b/src/main/resources/theme/style.css
@@ -959,8 +959,12 @@
 
 .game-title-input {
   -fx-font-size: 0.8cm;
-  -fx-prompt-text-fill: -fx-light-text-color;
 }
+
+.game-title-input:invalid {
+  -fx-border-color: -bad;
+}
+
 .game-generate-map {
   -fx-background-color: -dimmed-accent;
   -fx-graphic-text-gap: 0.7em;

--- a/src/test/java/com/faforever/client/game/CreateGameControllerTest.java
+++ b/src/test/java/com/faforever/client/game/CreateGameControllerTest.java
@@ -19,6 +19,7 @@ import com.faforever.client.theme.UiService;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import javafx.css.PseudoClass;
 import javafx.scene.image.Image;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyEvent;
@@ -323,4 +324,14 @@ public class CreateGameControllerTest extends AbstractPlainJavaFxTest {
     assertEquals(preferences.getLastGamePrefs().getLastGamePassword(), "1234");
     verify(preferencesService).storeInBackground();
   }
+
+  @Test
+  public void testCreateGameTitleTextBorderColor() {
+    PseudoClass invalidClass = PseudoClass.getPseudoClass("invalid");
+    instance.titleTextField.setText("Test");
+    assertThat(instance.titleTextField.getPseudoClassStates().contains(invalidClass), is(false));
+    instance.titleTextField.setText("");
+    assertThat(instance.titleTextField.getPseudoClassStates().contains(invalidClass), is(true));
+  }
+
 }


### PR DESCRIPTION
Fixes #1813 

I'm new in FAF development, so I hope the implementation is ok. It changes the background color of the title text-field of the create game page to red to attract more attention if it's empty.