### PR TITLE
Fix bug in handling of navigation events

### DIFF
--- a/src/main/java/com/faforever/client/leaderboard/LeaderboardsController.java
+++ b/src/main/java/com/faforever/client/leaderboard/LeaderboardsController.java
@@ -68,8 +68,7 @@ public class LeaderboardsController extends AbstractViewController<Node> {
       if (navigateEvent instanceof OpenLadder1v1LeaderboardEvent) {
         lastTab = ladder1v1LeaderboardTab;
         lastTabController = ladder1v1LeaderboardController;
-      }
-      else if (navigateEvent instanceof OpenGlobalLeaderboardEvent) {
+      } else if (navigateEvent instanceof OpenGlobalLeaderboardEvent) {
         lastTab = globalLeaderboardTab;
         lastTabController = globalLeaderboardController;
       }

--- a/src/main/java/com/faforever/client/leaderboard/LeaderboardsController.java
+++ b/src/main/java/com/faforever/client/leaderboard/LeaderboardsController.java
@@ -27,6 +27,8 @@ public class LeaderboardsController extends AbstractViewController<Node> {
   public Tab globalLeaderboardTab;
 
   private boolean isHandlingEvent;
+  private AbstractViewController<?> lastTabController;
+  private Tab lastTab;
 
   public LeaderboardsController(EventBus eventBus) {
     this.eventBus = eventBus;
@@ -39,7 +41,8 @@ public class LeaderboardsController extends AbstractViewController<Node> {
 
   @Override
   public void initialize() {
-    eventBus.post(new OpenLadder1v1LeaderboardEvent());
+    lastTab = ladder1v1LeaderboardTab;
+    lastTabController = ladder1v1LeaderboardController;
     ladder1v1LeaderboardController.setRatingType(KnownFeaturedMod.LADDER_1V1);
     globalLeaderboardController.setRatingType(KnownFeaturedMod.FAF);
 
@@ -63,13 +66,15 @@ public class LeaderboardsController extends AbstractViewController<Node> {
 
     try {
       if (navigateEvent instanceof OpenLadder1v1LeaderboardEvent) {
-        leaderboardRoot.getSelectionModel().select(ladder1v1LeaderboardTab);
-        ladder1v1LeaderboardController.display(navigateEvent);
+        lastTab = ladder1v1LeaderboardTab;
+        lastTabController = ladder1v1LeaderboardController;
       }
-      if (navigateEvent instanceof OpenGlobalLeaderboardEvent) {
-        leaderboardRoot.getSelectionModel().select(globalLeaderboardTab);
-        globalLeaderboardController.display(navigateEvent);
+      else if (navigateEvent instanceof OpenGlobalLeaderboardEvent) {
+        lastTab = globalLeaderboardTab;
+        lastTabController = globalLeaderboardController;
       }
+      leaderboardRoot.getSelectionModel().select(lastTab);
+      lastTabController.display(navigateEvent);
     } finally {
       isHandlingEvent = false;
     }

--- a/src/main/java/com/faforever/client/play/PlayController.java
+++ b/src/main/java/com/faforever/client/play/PlayController.java
@@ -65,12 +65,10 @@ public class PlayController extends AbstractViewController<Node> {
       if (navigateEvent instanceof OpenCustomGamesEvent) {
         lastTab = customGamesTab;
         lastTabController = customGamesController;
-      }
-      else if (navigateEvent instanceof Open1v1Event) {
+      } else if (navigateEvent instanceof Open1v1Event) {
         lastTab = ladderTab;
         lastTabController = ladderController;
-      }
-      else if (navigateEvent instanceof OpenCoopEvent) {
+      } else if (navigateEvent instanceof OpenCoopEvent) {
         lastTab = coopTab;
         lastTabController = coopController;
       }

--- a/src/main/java/com/faforever/client/play/PlayController.java
+++ b/src/main/java/com/faforever/client/play/PlayController.java
@@ -31,8 +31,8 @@ public class PlayController extends AbstractViewController<Node> {
   public Ladder1v1Controller ladderController;
   public CoopController coopController;
   private boolean isHandlingEvent;
-  private AbstractViewController<?> lastTab;
-
+  private AbstractViewController<?> lastTabController;
+  private Tab lastTab;
 
   public PlayController(EventBus eventBus) {
     this.eventBus = eventBus;
@@ -40,8 +40,8 @@ public class PlayController extends AbstractViewController<Node> {
 
   @Override
   public void initialize() {
-    eventBus.post(new OpenCustomGamesEvent());
-    lastTab = customGamesController;
+    lastTab = customGamesTab;
+    lastTabController = customGamesController;
     playRootTabPane.getSelectionModel().selectedItemProperty().addListener((observable, oldValue, newValue) -> {
       if (isHandlingEvent) {
         return;
@@ -63,22 +63,19 @@ public class PlayController extends AbstractViewController<Node> {
 
     try {
       if (navigateEvent instanceof OpenCustomGamesEvent) {
-        playRootTabPane.getSelectionModel().select(customGamesTab);
-        customGamesController.display(navigateEvent);
-        lastTab = customGamesController;
+        lastTab = customGamesTab;
+        lastTabController = customGamesController;
       }
       else if (navigateEvent instanceof Open1v1Event) {
-        playRootTabPane.getSelectionModel().select(ladderTab);
-        ladderController.display(navigateEvent);
-        lastTab = ladderController;
+        lastTab = ladderTab;
+        lastTabController = ladderController;
       }
       else if (navigateEvent instanceof OpenCoopEvent) {
-        playRootTabPane.getSelectionModel().select(coopTab);
-        coopController.display(navigateEvent);
-        lastTab = coopController;
-      } else if (Objects.equals(navigateEvent.getClass(), NavigateEvent.class)) {
-        lastTab.display(navigateEvent);
+        lastTab = coopTab;
+        lastTabController = coopController;
       }
+      playRootTabPane.getSelectionModel().select(lastTab);
+      lastTabController.display(navigateEvent);
     } finally {
       isHandlingEvent = false;
     }

--- a/src/main/java/com/faforever/client/vault/VaultController.java
+++ b/src/main/java/com/faforever/client/vault/VaultController.java
@@ -77,16 +77,13 @@ public class VaultController extends AbstractViewController<Node> {
       if (navigateEvent instanceof OpenMapVaultEvent) {
         lastTab = mapVaultTab;
         lastTabController = mapVaultController;
-      }
-      else if (navigateEvent instanceof OpenModVaultEvent) {
+      } else if (navigateEvent instanceof OpenModVaultEvent) {
         lastTab = modVaultTab;
             lastTabController = modVaultController;
-      }
-      else if (navigateEvent instanceof OpenOnlineReplayVaultEvent) {
+      } else if (navigateEvent instanceof OpenOnlineReplayVaultEvent) {
         lastTab = onlineReplayVaultTab;
         lastTabController = onlineReplayVaultController;
-      }
-      else if (navigateEvent instanceof OpenReplayVaultEvent) {
+      } else if (navigateEvent instanceof OpenReplayVaultEvent) {
         lastTab = localReplayVaultTab;
         lastTabController = localReplayVaultController;
       }

--- a/src/main/java/com/faforever/client/vault/VaultController.java
+++ b/src/main/java/com/faforever/client/vault/VaultController.java
@@ -35,6 +35,8 @@ public class VaultController extends AbstractViewController<Node> {
   public Tab onlineReplayVaultTab;
   public Tab localReplayVaultTab;
   private boolean isHandlingEvent;
+  private AbstractViewController<?> lastTabController;
+  private Tab lastTab;
 
   public VaultController(EventBus eventBus) {
     this.eventBus = eventBus;
@@ -47,7 +49,8 @@ public class VaultController extends AbstractViewController<Node> {
 
   @Override
   public void initialize() {
-    eventBus.post(new OpenMapVaultEvent());
+    lastTab = onlineReplayVaultTab;
+    lastTabController = onlineReplayVaultController;
     vaultRoot.getSelectionModel().selectedItemProperty().addListener((observable, oldValue, newValue) -> {
       if (isHandlingEvent) {
         return;
@@ -72,21 +75,23 @@ public class VaultController extends AbstractViewController<Node> {
 
     try {
       if (navigateEvent instanceof OpenMapVaultEvent) {
-        vaultRoot.getSelectionModel().select(mapVaultTab);
-        mapVaultController.display(navigateEvent);
+        lastTab = mapVaultTab;
+        lastTabController = mapVaultController;
       }
-      if (navigateEvent instanceof OpenModVaultEvent) {
-        vaultRoot.getSelectionModel().select(modVaultTab);
-        modVaultController.display(navigateEvent);
+      else if (navigateEvent instanceof OpenModVaultEvent) {
+        lastTab = modVaultTab;
+            lastTabController = modVaultController;
       }
-      if (navigateEvent instanceof OpenOnlineReplayVaultEvent) {
-        vaultRoot.getSelectionModel().select(onlineReplayVaultTab);
-        onlineReplayVaultController.display(navigateEvent);
+      else if (navigateEvent instanceof OpenOnlineReplayVaultEvent) {
+        lastTab = onlineReplayVaultTab;
+        lastTabController = onlineReplayVaultController;
       }
-      if (navigateEvent instanceof OpenReplayVaultEvent) {
-        vaultRoot.getSelectionModel().select(localReplayVaultTab);
-        localReplayVaultController.display(navigateEvent);
+      else if (navigateEvent instanceof OpenReplayVaultEvent) {
+        lastTab = localReplayVaultTab;
+        lastTabController = localReplayVaultController;
       }
+      vaultRoot.getSelectionModel().select(lastTab);
+      lastTabController.display(navigateEvent);
     } finally {
       isHandlingEvent = false;
     }


### PR DESCRIPTION
Fixes #1807 
Posting a navigation event when initializing a tab had side effects when a navigate event (e.g. clicking on the show ladder maps button) took you to a previously uninitialized tab, because that would also trigger the event in initialize().
If we want that, the new behaviour could be improved even further by writing the lastTab information to the preferences, so the client can remember which tabs you had open even over a restart.