### PR TITLE
Change default database from rackover to spooky

### DIFF
--- a/src/main/java/com/faforever/client/preferences/Preferences.java
+++ b/src/main/java/com/faforever/client/preferences/Preferences.java
@@ -71,7 +71,7 @@ public class Preferences {
     developer = new DeveloperPrefs();
     gameListSorting = new SimpleListProperty<>(observableArrayList());
     vaultPrefs = new VaultPrefs();
-    unitDataBaseType = new SimpleObjectProperty<>(UnitDataBaseType.RACKOVER);
+    unitDataBaseType = new SimpleObjectProperty<>(UnitDataBaseType.SPOOKY);
     storedCookies = new SimpleMapProperty<>(FXCollections.observableHashMap());
     showPasswordProtectedGames = new SimpleBooleanProperty(true);
     showModdedGames = new SimpleBooleanProperty(true);


### PR DESCRIPTION
First off, i have no idea what im doing, and so if this doesnt work i wouldnt be surprised in the slightest. (forgive me)

Also, this is kinda an issue / feature request but i thought it would go along easier if i tried to do it myself first

Anyway, the brick i want to sell is this: the spooky db is good and beautiful while the rackover db is bad and ugly.
the rack one is also without a maintainer while the spooky one does have a maintainer.

I also think that the spooky one should be integrated into faf completely while the rackover one retired, but thats a separate thing. for now i would like for the spooky one to be made default, Check out this comparison:
![](https://i.imgur.com/OmtAYWd.png)
![](https://i.imgur.com/uuJMKIZ.jpg)

also, later there will be a version 2 of the database which is even better:
![](https://i.imgur.com/jkAE8BN.jpg)
This one however isnt done yet so half its features are missing at the moment.