### PR TITLE
Issue/#1849 Remove unused fields from GameInfoMessage

### DIFF
--- a/src/main/java/com/faforever/client/game/GameService.java
+++ b/src/main/java/com/faforever/client/game/GameService.java
@@ -800,7 +800,6 @@ public class GameService implements InitializingBean {
     game.setFeaturedMod(gameInfoMessage.getFeaturedMod());
     game.setNumPlayers(gameInfoMessage.getNumPlayers());
     game.setMaxPlayers(gameInfoMessage.getMaxPlayers());
-    game.setVictoryCondition(gameInfoMessage.getGameType());
     Optional.ofNullable(gameInfoMessage.getLaunchedAt()).ifPresent(aDouble -> game.setStartTime(
         TimeUtil.fromPythonTime(aDouble.longValue()).toInstant()
     ));
@@ -820,13 +819,6 @@ public class GameService implements InitializingBean {
       game.getTeams().clear();
       if (gameInfoMessage.getTeams() != null) {
         game.getTeams().putAll(gameInfoMessage.getTeams());
-      }
-    }
-
-    synchronized (game.getFeaturedModVersions()) {
-      game.getFeaturedModVersions().clear();
-      if (gameInfoMessage.getFeaturedModVersions() != null) {
-        game.getFeaturedModVersions().putAll(gameInfoMessage.getFeaturedModVersions());
       }
     }
 

--- a/src/main/java/com/faforever/client/remote/MockFafServerAccessor.java
+++ b/src/main/java/com/faforever/client/remote/MockFafServerAccessor.java
@@ -331,7 +331,6 @@ public class MockFafServerAccessor implements FafServerAccessor {
     gameInfoMessage.setState(GameStatus.OPEN);
     gameInfoMessage.setSimMods(Collections.emptyMap());
     gameInfoMessage.setTeams(Collections.emptyMap());
-    gameInfoMessage.setFeaturedModVersions(Collections.emptyMap());
     gameInfoMessage.setPasswordProtected(access == GameAccess.PASSWORD);
 
     return gameInfoMessage;

--- a/src/main/java/com/faforever/client/remote/domain/GameInfoMessage.java
+++ b/src/main/java/com/faforever/client/remote/domain/GameInfoMessage.java
@@ -19,13 +19,10 @@ public class GameInfoMessage extends FafServerMessage {
   private GameStatus state;
   private Integer numPlayers;
   private Map<String, List<String>> teams;
-  private Map<String, Integer> featuredModVersions;
   private String featuredMod;
   private Integer uid;
   private Integer maxPlayers;
   private String title;
-  // FAF calls this "game_type" but it's actually the victory condition.
-  private VictoryCondition gameType;
   private Map<String, String> simMods;
   private String mapname;
   private Double launchedAt;

--- a/src/test/java/com/faforever/client/game/GameInfoMessageBuilder.java
+++ b/src/test/java/com/faforever/client/game/GameInfoMessageBuilder.java
@@ -75,11 +75,6 @@ public class GameInfoMessageBuilder {
     return this;
   }
 
-  public GameInfoMessageBuilder gameType(VictoryCondition gameType) {
-    gameInfoMessage.setGameType(gameType);
-    return this;
-  }
-
   public GameInfoMessageBuilder state(GameStatus state) {
     gameInfoMessage.setState(state);
     return this;


### PR DESCRIPTION
Removed `gameType` and `featuredModVersions` both of which have not been included in the `game_info` message for a long time.

Fixes #1849 