### PR TITLE
Fix coop replay parsing

### DIFF
--- a/src/main/java/com/faforever/client/patch/GameUpdaterImpl.java
+++ b/src/main/java/com/faforever/client/patch/GameUpdaterImpl.java
@@ -73,7 +73,7 @@ public class GameUpdaterImpl implements GameUpdater {
 
     if (!NAMES_OF_FEATURED_BASE_MODS.contains(featuredMod.getTechnicalName())) {
       future = future.thenCompose(aVoid -> modService.getFeaturedMod(FAF.getTechnicalName()))
-          .thenCompose(baseMod -> updateFeaturedMod(baseMod, null))
+          .thenCompose(baseMod -> updateFeaturedMod(baseMod, version))
           .thenAccept(patchResults::add);
     }
 

--- a/src/main/java/com/faforever/client/replay/ReplayService.java
+++ b/src/main/java/com/faforever/client/replay/ReplayService.java
@@ -42,7 +42,6 @@ import com.google.common.primitives.Bytes;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
-import org.eclipse.jgit.util.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationContext;
@@ -509,22 +508,7 @@ public class ReplayService {
     String gameType = replayInfo.getFeaturedMod();
     Integer replayId = replayInfo.getUid();
     Map<String, Integer> modVersions = replayInfo.getFeaturedModVersions();
-    String mapName = replayInfo.getMapname();
-
-    // For some reason in the coop replay the map name is null in the metadata
-    // So we just take it directly from the replay data.
-    if (gameType.equals("coop")) {
-      mapName = parseMapFolderName(rawReplayBytes);
-    }
-
-    // For map generator games the map name is "None" because replay server gets map name by from DB based on filename
-    // from replay data, and DB does not contain generated maps.
-    if (StringUtils.equalsIgnoreCase(mapName, "None")) {
-      String maybeMapGen = parseMapFolderName(rawReplayBytes);
-      if (mapGeneratorService.isGeneratedMap(maybeMapGen)) {
-        mapName = maybeMapGen;
-      }
-    }
+    String mapName = parseMapFolderName(rawReplayBytes);
 
     Set<String> simMods = replayInfo.getSimMods() != null ? replayInfo.getSimMods().keySet() : emptySet();
 

--- a/src/main/java/com/faforever/client/replay/ReplayService.java
+++ b/src/main/java/com/faforever/client/replay/ReplayService.java
@@ -513,14 +513,14 @@ public class ReplayService {
 
     // For some reason in the coop replay the map name is null in the metadata
     // So we just take it directly from the replay data.
-    if (StringUtils.isEmptyOrNull(mapName)) {
+    if (gameType.equals("coop")) {
       mapName = parseMapFolderName(rawReplayBytes);
     }
 
     // For map generator games the map name is "None" because replay server gets map name by from DB based on filename
     // from replay data, and DB does not contain generated maps.
     if (StringUtils.equalsIgnoreCase(mapName, "None")) {
-      String maybeMapGen = parseMapName(rawReplayBytes).replaceAll(".scmap", "");
+      String maybeMapGen = parseMapFolderName(rawReplayBytes);
       if (mapGeneratorService.isGeneratedMap(maybeMapGen)) {
         mapName = maybeMapGen;
       }


### PR DESCRIPTION
Reads in map name from replay bytes if game type is coop.
Updates FAF to correct version for replay.

Fixes #1676


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#1676: Clientside workaround for coop replays](https://issuehunt.io/repos/32919066/issues/1676)
---
</details>
<!-- /Issuehunt content-->