### PR TITLE
Maintain chat user categories when filtering

### DIFF
--- a/src/main/java/com/faforever/client/chat/ChannelTabController.java
+++ b/src/main/java/com/faforever/client/chat/ChannelTabController.java
@@ -288,7 +288,7 @@ public class ChannelTabController extends AbstractChatTabController {
   public void initialize() {
     super.initialize();
 
-    userSearchTextField.textProperty().addListener((observable, oldValue, newValue) -> filterChatUsers(newValue));
+    userSearchTextField.textProperty().addListener((observable, oldValue, newValue) -> userFilterController.filterUsers());
 
     channelTabScrollPaneVBox.setMinWidth(preferencesService.getPreferences().getChat().getChannelTabScrollPaneWidth());
     channelTabScrollPaneVBox.setPrefWidth(preferencesService.getPreferences().getChat().getChannelTabScrollPaneWidth());
@@ -418,20 +418,6 @@ public class ChannelTabController extends AbstractChatTabController {
 
   private void updateUserMessageDisplay(ChatChannelUser chatUser, String display) {
     Platform.runLater(() -> getJsObject().call("updateUserMessageDisplay", chatUser.getUsername(), display));
-  }
-
-  /** Filters by username "contains" case insensitive. */
-  @SuppressWarnings("unchecked")
-  private void filterChatUsers(String searchString) {
-    setUserFilter(listItem -> {
-      if (Strings.isNullOrEmpty(searchString)) {
-        return true;
-      }
-
-      ChatChannelUser user = listItem.getUser();
-
-      return listItem.getCategory() != null || user.getUsername().toLowerCase(US).contains(searchString.toLowerCase(US));
-    });
   }
 
   private void associateChatUserWithPlayer(Player player, ChatChannelUser chatUser) {

--- a/src/main/java/com/faforever/client/chat/UserFilterController.java
+++ b/src/main/java/com/faforever/client/chat/UserFilterController.java
@@ -57,7 +57,7 @@ public class UserFilterController implements Controller<Node> {
     maxRatingFilterField.textProperty().addListener((observable, oldValue, newValue) -> filterUsers());
   }
 
-  private void filterUsers() {
+  public void filterUsers() {
     channelTabController.setUserFilter(this::filterUser);
     filterApplied.set(
         !maxRatingFilterField.getText().isEmpty()
@@ -68,14 +68,12 @@ public class UserFilterController implements Controller<Node> {
   }
 
   private boolean filterUser(CategoryOrChatUserListItem userListItem) {
-    if (userListItem.getUser() == null) {
-      return false;
-    }
     ChatChannelUser user = userListItem.getUser();
-    return channelTabController.isUsernameMatch(user)
+    return userListItem.getCategory() != null
+        || (channelTabController.isUsernameMatch(user)
         && isInClan(user)
         && isBoundByRating(user)
-        && isGameStatusMatch(user);
+        && isGameStatusMatch(user));
   }
 
   public BooleanProperty filterAppliedProperty() {


### PR DESCRIPTION
Fixes #1618

Use a single filter function for all filters and maintain categories during filtering