### PR TITLE
Renamed shortcut name from "DownlordsFafClient" to "FAF Client"

### DIFF
--- a/downlords-faf-client.install4j
+++ b/downlords-faf-client.install4j
@@ -24,7 +24,7 @@
     </entries>
   </files>
   <launchers>
-    <launcher name="DownlordsFafClient" id="25">
+    <launcher name="FAF Client" id="25">
       <executable name="downlords-faf-client" iconSet="true" executableMode="gui" changeWorkingDirectory="false" workingDirectory="bin" singleInstance="true" checkConsoleParameter="true" dpiAware="true" />
       <splashScreen show="true" width="640" height="400" bitmapFile="./src/media/splash/splash.png" textOverlay="true">
         <text>


### PR DESCRIPTION
Renamed the default shortcut from "DownlordsFafClient" to "FAF Client".
I created the installer locally using install4j and verified the name of the shortcut.
![image](https://user-images.githubusercontent.com/7738847/95870065-5c3c0b00-0d6c-11eb-9841-7cedf209b10f.png)
