### PR TITLE
Feature/#2006 chat changes

### DIFF
--- a/src/main/java/com/faforever/client/chat/ChannelTabController.java
+++ b/src/main/java/com/faforever/client/chat/ChannelTabController.java
@@ -296,8 +296,8 @@ public class ChannelTabController extends AbstractChatTabController {
     JavaFxUtil.addListener(preferencesService.getPreferences().getChat().chatColorModeProperty(), chatColorModeChangeListener);
     addUserFilterPopup();
 
-    chatUserListView.setItems(filteredChatUserList);
     chatUserListView.setCellFactory(param -> new ChatUserListCell(uiService));
+    chatUserListView.setItems(filteredChatUserList);
 
     autoCompletionHelper.bindTo(messageTextField());
 
@@ -330,8 +330,8 @@ public class ChannelTabController extends AbstractChatTabController {
 
   private void setAllMessageColors() {
     Map<String, String> userToColor = new HashMap<>();
-    channel.getUsers().stream().filter(chatUser -> chatUser.getColor() != null).forEach(chatUser
-        -> userToColor.put(chatUser.getUsername(), JavaFxUtil.toRgbCode(chatUser.getColor())));
+    channel.getUsers().stream().filter(chatUser -> chatUser.getColor().isPresent()).forEach(chatUser
+        -> userToColor.put(chatUser.getUsername(), JavaFxUtil.toRgbCode(chatUser.getColor().get())));
     getJsObject().call("setAllMessageColors", new Gson().toJson(userToColor));
   }
 
@@ -404,8 +404,8 @@ public class ChannelTabController extends AbstractChatTabController {
 
   private void updateUserMessageColor(ChatChannelUser chatUser) {
     String color = "";
-    if (chatUser.getColor() != null) {
-      color = JavaFxUtil.toRgbCode(chatUser.getColor());
+    if (chatUser.getColor().isPresent()) {
+      color = JavaFxUtil.toRgbCode(chatUser.getColor().get());
     }
     getJsObject().call("updateUserMessageColor", chatUser.getUsername(), color);
   }
@@ -461,7 +461,7 @@ public class ChannelTabController extends AbstractChatTabController {
     JavaFxUtil.addListener(chatPrefs.hideFoeMessagesProperty(), weakHideFoeMessagesListener);
 
     Platform.runLater(() -> {
-      weakColorPropertyListener.changed(chatUser.colorProperty(), null, chatUser.getColor());
+      weakColorPropertyListener.changed(chatUser.colorProperty(), null, chatUser.getColor().orElse(null));
       weakHideFoeMessagesListener.changed(chatPrefs.hideFoeMessagesProperty(), null, chatPrefs.getHideFoeMessages());
     });
   }
@@ -641,8 +641,8 @@ public class ChannelTabController extends AbstractChatTabController {
     } else {
       ChatColorMode chatColorMode = chatPrefs.getChatColorMode();
       if ((chatColorMode == ChatColorMode.CUSTOM || chatColorMode == ChatColorMode.RANDOM)
-          && chatUser.getColor() != null) {
-        color = createInlineStyleFromColor(chatUser.getColor());
+          && chatUser.getColor().isPresent()) {
+        color = createInlineStyleFromColor(chatUser.getColor().get());
       }
     }
 

--- a/src/main/java/com/faforever/client/chat/ChatChannelUser.java
+++ b/src/main/java/com/faforever/client/chat/ChatChannelUser.java
@@ -1,5 +1,7 @@
 package com.faforever.client.chat;
 
+import com.faforever.client.clan.Clan;
+import com.faforever.client.game.PlayerStatus;
 import com.faforever.client.player.Player;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.ObjectProperty;
@@ -7,6 +9,7 @@ import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
+import javafx.scene.image.Image;
 import javafx.scene.paint.Color;
 import lombok.ToString;
 
@@ -14,7 +17,6 @@ import java.time.Instant;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
-
 /**
  * Represents a chat user within a channel. If a user is in multiple channels, one instance per channel needs to be
  * created since e.g. the {@code isModerator} flag is specific to the channel.
@@ -27,6 +29,15 @@ public class ChatChannelUser {
   private final ObjectProperty<Color> color;
   private final ObjectProperty<Player> player;
   private final ObjectProperty<Instant> lastActive;
+  private final ObjectProperty<PlayerStatus> status;
+  private final ObjectProperty<Image> avatar;
+  private final ObjectProperty<Clan> clan;
+  private final StringProperty clanTag;
+  private final ObjectProperty<Image> countryFlag;
+  private final StringProperty countryName;
+  private final ObjectProperty<Image> mapImage;
+  private final ObjectProperty<Image> statusImage;
+  private final BooleanProperty displayed;
 
   ChatChannelUser(String username, Color color, boolean moderator) {
     this(username, color, moderator, null);
@@ -38,6 +49,15 @@ public class ChatChannelUser {
     this.color = new SimpleObjectProperty<>(color);
     this.player = new SimpleObjectProperty<>(player);
     this.lastActive = new SimpleObjectProperty<>();
+    this.status = new SimpleObjectProperty<>();
+    this.avatar = new SimpleObjectProperty<>();
+    this.clan = new SimpleObjectProperty<>();
+    this.clanTag = new SimpleStringProperty();
+    this.countryFlag = new SimpleObjectProperty<>();
+    this.countryName = new SimpleStringProperty();
+    this.mapImage = new SimpleObjectProperty<>();
+    this.statusImage = new SimpleObjectProperty<>();
+    this.displayed = new SimpleBooleanProperty(false);
   }
 
   public Optional<Player> getPlayer() {
@@ -52,8 +72,8 @@ public class ChatChannelUser {
     return player;
   }
 
-  public Color getColor() {
-    return color.get();
+  public Optional<Color> getColor() {
+    return Optional.ofNullable(color.get());
   }
 
   public void setColor(Color color) {
@@ -99,6 +119,114 @@ public class ChatChannelUser {
 
   public ObjectProperty<Instant> lastActiveProperty() {
     return lastActive;
+  }
+
+  public Optional<PlayerStatus> getStatus() {
+    return Optional.ofNullable(status.get());
+  }
+
+  public void setStatus(PlayerStatus status) {
+    this.status.set(status);
+  }
+
+  public ObjectProperty<PlayerStatus> statusProperty() {
+    return status;
+  }
+
+  public Optional<Image> getAvatar() {
+    return Optional.ofNullable(avatar.get());
+  }
+
+  public void setAvatar(Image avatar) {
+    this.avatar.set(avatar);
+  }
+
+  public ObjectProperty<Image> avatarProperty() {
+    return avatar;
+  }
+
+  public Optional<Clan> getClan() {
+    return Optional.ofNullable(clan.get());
+  }
+
+  public void setClan(Clan clan) {
+    this.clan.set(clan);
+  }
+
+  public ObjectProperty<Clan> clanProperty() {
+    return clan;
+  }
+
+  public Optional<String> getClanTag() {
+    return Optional.ofNullable(clanTag.get());
+  }
+
+  public void setClanTag(String clanTag) {
+    this.clanTag.set(clanTag);
+  }
+
+  public StringProperty clanTagProperty() {
+    return clanTag;
+  }
+
+  public Optional<Image> getCountryFlag() {
+    return Optional.ofNullable(countryFlag.get());
+  }
+
+  public void setCountryFlag(Image countryFlag) {
+    this.countryFlag.set(countryFlag);
+  }
+
+  public ObjectProperty<Image> countryFlagProperty() {
+    return countryFlag;
+  }
+
+  public Optional<String> getCountryName() {
+    return Optional.ofNullable(countryName.get());
+  }
+
+  public void setCountryName(String countryName) {
+    this.countryName.set(countryName);
+  }
+
+  public StringProperty countryNameProperty() {
+    return countryName;
+  }
+
+  public Optional<Image> getMapImage() {
+    return Optional.ofNullable(mapImage.get());
+  }
+
+  public void setMapImage(Image mapImage) {
+    this.mapImage.set(mapImage);
+  }
+
+  public ObjectProperty<Image> mapImageProperty() {
+    return mapImage;
+  }
+
+  public Optional<Image> getStatusImage() {
+    return Optional.ofNullable(statusImage.get());
+  }
+
+  public void setStatusImage(Image statusImage) {
+    this.statusImage.set(statusImage);
+  }
+
+  public ObjectProperty<Image> statusImageProperty() {
+    return statusImage;
+  }
+
+  public boolean isDisplayed() {
+    return displayed.get();
+  }
+
+  public void setDisplayed(boolean displayed) {
+    this.displayed.set(displayed);
+  }
+
+  public BooleanProperty displayedProperty() {
+    return displayed;
   }
 
   @Override

--- a/src/main/java/com/faforever/client/chat/ChatController.java
+++ b/src/main/java/com/faforever/client/chat/ChatController.java
@@ -61,7 +61,7 @@ public class ChatController extends AbstractViewController<Node> {
     String channelName = channel.getName();
     chatService.addUsersListener(channelName, change -> {
       if (change.wasRemoved()) {
-        onChatUserLeftChannel(channelName, change.getValueRemoved().getUsername());
+        onChatUserLeftChannel(change.getValueRemoved(), channelName);
       }
       if (change.wasAdded()) {
         onUserJoinedChannel(change.getValueAdded(), channelName);
@@ -228,19 +228,18 @@ public class ChatController extends AbstractViewController<Node> {
     chatService.joinChannel(channelName);
   }
 
-  private void onChatUserLeftChannel(String channelName, String username) {
-    if (!username.equalsIgnoreCase(userService.getUsername())) {
-      return;
-    }
-    AbstractChatTabController chatTab = nameToChatTabController.get(channelName);
-    if (chatTab != null) {
-      Platform.runLater(() -> tabPane.getTabs().remove(chatTab.getRoot()));
+  private void onChatUserLeftChannel(ChatChannelUser chatUser, String channelName) {
+    if (isCurrentUser(chatUser)) {
+      AbstractChatTabController chatTab = nameToChatTabController.get(channelName);
+      if (chatTab != null) {
+        Platform.runLater(() -> tabPane.getTabs().remove(chatTab.getRoot()));
+      }
     }
   }
 
   private void onUserJoinedChannel(ChatChannelUser chatUser, String channelName) {
-    Platform.runLater(() -> {
-      if (isCurrentUser(chatUser)) {
+    if (isCurrentUser(chatUser)) {
+      Platform.runLater(() -> {
         AbstractChatTabController tabController = getOrCreateChannelTab(channelName);
         onConnected();
         if (channelName.equals(chatService.getDefaultChannelName())) {
@@ -248,8 +247,8 @@ public class ChatController extends AbstractViewController<Node> {
           tabPane.getSelectionModel().select(tab);
           nameToChatTabController.get(tab.getId()).onDisplay();
         }
-      }
-    });
+      });
+    }
   }
 
   private boolean isCurrentUser(ChatChannelUser chatUser) {

--- a/src/main/java/com/faforever/client/chat/ChatUserService.java
+++ b/src/main/java/com/faforever/client/chat/ChatUserService.java
@@ -1,0 +1,133 @@
+package com.faforever.client.chat;
+
+import com.faforever.client.chat.avatar.AvatarService;
+import com.faforever.client.chat.event.ChatUserGameChangeEvent;
+import com.faforever.client.chat.event.ChatUserPopulateEvent;
+import com.faforever.client.clan.ClanService;
+import com.faforever.client.game.PlayerStatus;
+import com.faforever.client.i18n.I18n;
+import com.faforever.client.map.MapService;
+import com.faforever.client.map.MapService.PreviewSize;
+import com.faforever.client.theme.UiService;
+import com.google.common.base.Strings;
+import com.google.common.eventbus.EventBus;
+import com.google.common.eventbus.Subscribe;
+import javafx.application.Platform;
+import javafx.scene.image.Image;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class ChatUserService implements InitializingBean {
+
+  private final UiService uiService;
+  private final MapService mapService;
+  private final AvatarService avatarService;
+  private final ClanService clanService;
+  private final CountryFlagService countryFlagService;
+  private final I18n i18n;
+  private final EventBus eventBus;
+
+  @Override
+  public void afterPropertiesSet() {
+    eventBus.register(this);
+  }
+
+  public void populateClan(ChatChannelUser chatChannelUser) {
+    if (chatChannelUser.getClan().isEmpty()) {
+      chatChannelUser.getPlayer().ifPresent(player -> clanService.getClanByTag(player.getClan())
+          .thenAccept(optionalClan -> Platform.runLater(() -> {
+            if (optionalClan.isPresent()) {
+              chatChannelUser.setClan(optionalClan.get());
+              chatChannelUser.setClanTag(String.format("[%s]", optionalClan.get().getTag()));
+            } else {
+              chatChannelUser.setClan(null);
+              chatChannelUser.setClanTag(null);
+            }
+          })));
+    }
+  }
+
+  public void populateAvatar(ChatChannelUser chatChannelUser) {
+    if (chatChannelUser.getAvatar().isEmpty()) {
+      chatChannelUser.getPlayer()
+          .ifPresent(player -> Platform.runLater(() -> {
+            if (!Strings.isNullOrEmpty(player.getAvatarUrl())) {
+              chatChannelUser.setAvatar(avatarService.loadAvatar(player.getAvatarUrl()));
+            } else {
+              chatChannelUser.setAvatar(null);
+            }
+          }));
+    }
+  }
+
+  public void populateCountry(ChatChannelUser chatChannelUser) {
+    if (chatChannelUser.getCountryFlag().isEmpty()) {
+      chatChannelUser.getPlayer()
+          .ifPresent(player -> Platform.runLater(() -> {
+            Optional<Image> countryFlag = countryFlagService.loadCountryFlag(player.getCountry());
+            if (countryFlag.isPresent()) {
+              chatChannelUser.setCountryFlag(countryFlag.get());
+            } else {
+              chatChannelUser.setCountryFlag(null);
+            }
+            chatChannelUser.setCountryName(i18n.getCountryNameLocalized(player.getCountry()));
+          }));
+    }
+  }
+
+  public void populateGameStatus(ChatChannelUser chatChannelUser) {
+    chatChannelUser.getPlayer()
+        .ifPresent(player -> Platform.runLater(() -> {
+          Image playerStatusImage = switch (player.getStatus()) {
+            case HOSTING -> uiService.getThemeImage(UiService.CHAT_LIST_STATUS_HOSTING);
+            case LOBBYING -> uiService.getThemeImage(UiService.CHAT_LIST_STATUS_LOBBYING);
+            case PLAYING -> uiService.getThemeImage(UiService.CHAT_LIST_STATUS_PLAYING);
+            default -> null;
+          };
+          chatChannelUser.setStatusImage(playerStatusImage);
+
+          if (player.getStatus() != PlayerStatus.IDLE) {
+            chatChannelUser.setMapImage(mapService.loadPreview(player.getGame().getMapFolderName(), PreviewSize.SMALL));
+          } else {
+            chatChannelUser.setMapImage(null);
+          }
+
+          chatChannelUser.setStatus(player.getStatus());
+        }));
+  }
+
+  @Subscribe
+  public void onChatUserPopulate(ChatUserPopulateEvent event) {
+    ChatChannelUser chatChannelUser = event.getChatChannelUser();
+    if (chatChannelUser.isDisplayed()) {
+      populateAvatar(chatChannelUser);
+      populateClan(chatChannelUser);
+      populateCountry(chatChannelUser);
+    } else if (!chatChannelUser.isDisplayed()) {
+      chatChannelUser.setClan(null);
+      chatChannelUser.setClanTag(null);
+      chatChannelUser.setAvatar(null);
+      chatChannelUser.setCountryFlag(null);
+      chatChannelUser.setCountryName(null);
+    }
+  }
+
+  @Subscribe
+  public void onChatUserGameChange(ChatUserGameChangeEvent event) {
+    ChatChannelUser chatChannelUser = event.getChatChannelUser();
+    if (chatChannelUser.isDisplayed()) {
+      populateGameStatus(chatChannelUser);
+    } else if (!chatChannelUser.isDisplayed()) {
+      chatChannelUser.setStatus(null);
+      chatChannelUser.setMapImage(null);
+      chatChannelUser.setStatusImage(null);
+    }
+  }
+}
+
+

--- a/src/main/java/com/faforever/client/chat/CountryFlagService.java
+++ b/src/main/java/com/faforever/client/chat/CountryFlagService.java
@@ -13,7 +13,6 @@ import org.springframework.stereotype.Service;
 
 import java.lang.invoke.MethodHandles;
 import java.net.URL;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;

--- a/src/main/java/com/faforever/client/chat/PrivateUserInfoController.java
+++ b/src/main/java/com/faforever/client/chat/PrivateUserInfoController.java
@@ -84,6 +84,7 @@ public class PrivateUserInfoController implements Controller<Node> {
   }
 
   public void setChatUser(@NotNull ChatChannelUser chatUser) {
+    chatUser.setDisplayed(true);
     chatUser.getPlayer().ifPresentOrElse(this::displayPlayerInfo, () -> {
       chatUser.playerProperty().addListener((observable, oldValue, newValue) -> {
         if (newValue != null) {
@@ -93,11 +94,13 @@ public class PrivateUserInfoController implements Controller<Node> {
         }
       });
       displayChatUserInfo(chatUser);
+      JavaFxUtil.bind(usernameLabel.textProperty(), chatUser.usernameProperty());
+      JavaFxUtil.bind(countryImageView.imageProperty(), chatUser.countryFlagProperty());
+      JavaFxUtil.bind(countryLabel.textProperty(), chatUser.countryNameProperty());
     });
   }
 
   private void displayChatUserInfo(ChatChannelUser chatUser) {
-    usernameLabel.textProperty().bind(chatUser.usernameProperty());
     onPlayerGameChanged(null);
     setPlayerInfoVisible(false);
   }
@@ -118,14 +121,8 @@ public class PrivateUserInfoController implements Controller<Node> {
   private void displayPlayerInfo(Player player) {
     setPlayerInfoVisible(true);
 
-    usernameLabel.textProperty().bind(player.usernameProperty());
-
     userImageView.setImage(IdenticonUtil.createIdenticon(player.getId()));
     userImageView.setVisible(true);
-
-    countryFlagService.loadCountryFlag(player.getCountry()).ifPresent(image -> countryImageView.setImage(image));
-    countryLabel.setText(i18n.getCountryNameLocalized(player.getCountry()));
-    countryLabel.setVisible(true);
 
     globalRatingInvalidationListener = (observable) -> loadReceiverGlobalRatingInformation(player);
     JavaFxUtil.addListener(player.globalRatingMeanProperty(), new WeakInvalidationListener(globalRatingInvalidationListener));

--- a/src/main/java/com/faforever/client/chat/event/ChatUserGameChangeEvent.java
+++ b/src/main/java/com/faforever/client/chat/event/ChatUserGameChangeEvent.java
@@ -1,0 +1,9 @@
+package com.faforever.client.chat.event;
+
+import com.faforever.client.chat.ChatChannelUser;
+import lombok.Value;
+
+@Value
+public class ChatUserGameChangeEvent {
+  private final ChatChannelUser chatChannelUser;
+}

--- a/src/main/java/com/faforever/client/chat/event/ChatUserPopulateEvent.java
+++ b/src/main/java/com/faforever/client/chat/event/ChatUserPopulateEvent.java
@@ -1,0 +1,9 @@
+package com.faforever.client.chat.event;
+
+import com.faforever.client.chat.ChatChannelUser;
+import lombok.Value;
+
+@Value
+public class ChatUserPopulateEvent {
+  private final ChatChannelUser chatChannelUser;
+}

--- a/src/main/java/com/faforever/client/fx/JavaFxUtil.java
+++ b/src/main/java/com/faforever/client/fx/JavaFxUtil.java
@@ -349,6 +349,16 @@ public final class JavaFxUtil {
   }
 
   /**
+   * Since the JavaFX properties API is not thread safe, unbinding a property must be synchronized on the property -
+   * which is what this method does.
+   */
+  public static <T> void unbind(Property<T> property) {
+    synchronized (property) {
+      property.unbind();
+    }
+  }
+
+  /**
    * Since the JavaFX properties API is not thread safe, binding properties must be synchronized on the properties -
    * which is what this method does. Since synchronization happens on both property in order {@code property1,
    * property2}, this is prone to deadlocks. To avoid this, pass the property with the lower visibility (e.g. method- or

--- a/src/main/resources/theme/chat/chat_user_item.fxml
+++ b/src/main/resources/theme/chat/chat_user_item.fxml
@@ -4,7 +4,6 @@
 <?import javafx.scene.control.MenuButton?>
 <?import javafx.scene.image.ImageView?>
 <?import javafx.scene.layout.HBox?>
-
 <HBox fx:id="chatUserItemRoot" alignment="CENTER_LEFT" spacing="3.0" xmlns="http://javafx.com/javafx/11.0.1"
       onContextMenuRequested="#onContextMenuRequested" onMouseClicked="#onItemClicked" styleClass="chat-user-item"
       xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.faforever.client.chat.ChatUserItemController">
@@ -12,7 +11,7 @@
         <ImageView fx:id="avatarImageView" fitHeight="20.0" fitWidth="40.0" pickOnBounds="true" preserveRatio="true"/>
         <ImageView fx:id="countryImageView" fitHeight="16.0" fitWidth="16.0" pickOnBounds="true" preserveRatio="true"/>
         <MenuButton fx:id="clanMenu" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308"
-                    onMouseClicked="#onClanMenuRequested" onMouseEntered="#updateClanData"
+                    onMouseClicked="#onClanMenuRequested"
                     styleClass="chat-user-control-clan" text="[CLAN]"/>
         <Label fx:id="usernameLabel" maxWidth="1.7976931348623157E308" minWidth="0.0" onMouseClicked="#onItemClicked"
                onMouseEntered="#onMouseEnteredUserNameLabel" styleClass="chat-user-item-username"

--- a/src/test/java/com/faforever/client/chat/ChatChannelUserBuilder.java
+++ b/src/test/java/com/faforever/client/chat/ChatChannelUserBuilder.java
@@ -1,7 +1,12 @@
 package com.faforever.client.chat;
 
+import com.faforever.client.clan.Clan;
+import com.faforever.client.game.PlayerStatus;
 import com.faforever.client.player.Player;
+import javafx.scene.image.Image;
 import javafx.scene.paint.Color;
+
+import java.time.Instant;
 
 public final class ChatChannelUserBuilder {
   private final ChatChannelUser chatChannelUser;
@@ -15,6 +20,7 @@ public final class ChatChannelUserBuilder {
   }
 
   public ChatChannelUserBuilder defaultValues() {
+    chatChannelUser.setDisplayed(true);
     return this;
   }
 
@@ -22,13 +28,68 @@ public final class ChatChannelUserBuilder {
     return chatChannelUser;
   }
 
-  public ChatChannelUserBuilder setPlayer(Player player) {
+  public ChatChannelUserBuilder player(Player player) {
     chatChannelUser.setPlayer(player);
     return this;
   }
 
   public ChatChannelUserBuilder moderator(boolean isModerator) {
     chatChannelUser.setModerator(isModerator);
+    return this;
+  }
+
+  public ChatChannelUserBuilder color(Color color) {
+    chatChannelUser.setColor(color);
+    return this;
+  }
+
+  public ChatChannelUserBuilder lastActive(Instant lastActive) {
+    chatChannelUser.setLastActive(lastActive);
+    return this;
+  }
+
+  public ChatChannelUserBuilder status(PlayerStatus status) {
+    chatChannelUser.setStatus(status);
+    return this;
+  }
+
+  public ChatChannelUserBuilder avatar(Image avatar) {
+    chatChannelUser.setAvatar(avatar);
+    return this;
+  }
+
+  public ChatChannelUserBuilder clan(Clan clan) {
+    chatChannelUser.setClan(clan);
+    return this;
+  }
+
+  public ChatChannelUserBuilder clanTag(String clanTag) {
+    chatChannelUser.setClanTag(clanTag);
+    return this;
+  }
+
+  public ChatChannelUserBuilder countryFlag(Image countryFlag) {
+    chatChannelUser.setCountryFlag(countryFlag);
+    return this;
+  }
+
+  public ChatChannelUserBuilder countryName(String countryName) {
+    chatChannelUser.setCountryName(countryName);
+    return this;
+  }
+
+  public ChatChannelUserBuilder mapImage(Image mapImage) {
+    chatChannelUser.setMapImage(mapImage);
+    return this;
+  }
+
+  public ChatChannelUserBuilder statusImage(Image statusImage) {
+    chatChannelUser.setStatusImage(statusImage);
+    return this;
+  }
+
+  public ChatChannelUserBuilder displayed(boolean displayed) {
+    chatChannelUser.setDisplayed(displayed);
     return this;
   }
 }

--- a/src/test/java/com/faforever/client/chat/ChatChannelUserContextMenuControllerTest.java
+++ b/src/test/java/com/faforever/client/chat/ChatChannelUserContextMenuControllerTest.java
@@ -116,7 +116,7 @@ public class ChatChannelUserContextMenuControllerTest extends AbstractPlainJavaF
     loadFxml("theme/chat/chat_user_context_menu.fxml", clazz -> instance);
 
     player = PlayerBuilder.create(TEST_USER_NAME).socialStatus(SELF).avatar(null).game(new Game()).get();
-    chatUser = ChatChannelUserBuilder.create(TEST_USER_NAME).defaultValues().setPlayer(player).get();
+    chatUser = ChatChannelUserBuilder.create(TEST_USER_NAME).defaultValues().player(player).get();
   }
 
   @Test

--- a/src/test/java/com/faforever/client/chat/ChatChannelUserItemControllerTest.java
+++ b/src/test/java/com/faforever/client/chat/ChatChannelUserItemControllerTest.java
@@ -1,22 +1,15 @@
 package com.faforever.client.chat;
 
 import com.faforever.client.chat.avatar.AvatarBean;
-import com.faforever.client.chat.avatar.AvatarService;
 import com.faforever.client.clan.Clan;
-import com.faforever.client.clan.ClanService;
-import com.faforever.client.clan.ClanTooltipController;
 import com.faforever.client.fx.MouseEvents;
 import com.faforever.client.fx.PlatformService;
-import com.faforever.client.game.GameBuilder;
 import com.faforever.client.i18n.I18n;
-import com.faforever.client.map.MapService;
-import com.faforever.client.map.MapService.PreviewSize;
 import com.faforever.client.player.Player;
 import com.faforever.client.player.PlayerBuilder;
 import com.faforever.client.player.PlayerService;
 import com.faforever.client.preferences.Preferences;
 import com.faforever.client.preferences.PreferencesService;
-import com.faforever.client.remote.domain.GameStatus;
 import com.faforever.client.test.AbstractPlainJavaFxTest;
 import com.faforever.client.theme.UiService;
 import com.faforever.client.util.TimeService;
@@ -27,7 +20,6 @@ import javafx.scene.control.MenuItem;
 import javafx.scene.image.Image;
 import javafx.scene.input.ContextMenuEvent;
 import javafx.scene.input.MouseButton;
-import javafx.scene.layout.Pane;
 import javafx.stage.Window;
 import org.hamcrest.CoreMatchers;
 import org.junit.Before;
@@ -37,11 +29,8 @@ import org.mockito.Mock;
 import org.testfx.util.WaitForAsyncUtils;
 
 import java.net.URL;
-import java.nio.file.Paths;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 
-import static org.hamcrest.CoreMatchers.endsWith;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertFalse;
@@ -49,20 +38,16 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyDouble;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class ChatChannelUserItemControllerTest extends AbstractPlainJavaFxTest {
 
   private ChatUserItemController instance;
-  @Mock
-  private AvatarService avatarService;
-  @Mock
-  private CountryFlagService countryFlagService;
   @Mock
   private PreferencesService preferencesService;
   @Mock
@@ -72,17 +57,12 @@ public class ChatChannelUserItemControllerTest extends AbstractPlainJavaFxTest {
   @Mock
   private EventBus eventBus;
   @Mock
-  private ClanService clanService;
-  @Mock
   private PlayerService playerService;
   @Mock
   private PlatformService platformService;
   @Mock
   private TimeService timeService;
-  @Mock
-  private MapService mapService;
 
-  private ClanTooltipController clanTooltipControllerMock;
   private Clan testClan;
 
   @Before
@@ -95,30 +75,17 @@ public class ChatChannelUserItemControllerTest extends AbstractPlainJavaFxTest {
     testClan = new Clan();
     testClan.setTag("e");
     testClan.setLeader(PlayerBuilder.create("test_player").defaultValues().id(2).get());
-    when(clanService.getClanByTag(anyString())).thenReturn(CompletableFuture.completedFuture(Optional.of(testClan)));
-    when(countryFlagService.loadCountryFlag("US")).thenReturn(Optional.of(mock(Image.class)));
     when(playerService.isOnline(eq(2))).thenReturn(true);
     when(playerService.getCurrentPlayer()).thenReturn(Optional.of(new Player("junit")));
-    clanTooltipControllerMock = mock(ClanTooltipController.class);
-    when(uiService.loadFxml("theme/chat/clan_tooltip.fxml")).thenReturn(clanTooltipControllerMock);
-    when(clanTooltipControllerMock.getRoot()).thenReturn(new Pane());
-    when(uiService.getThemeImage(UiService.CHAT_LIST_STATUS_HOSTING)).thenReturn(new Image(UiService.CHAT_LIST_STATUS_HOSTING));
-    when(uiService.getThemeImage(UiService.CHAT_LIST_STATUS_LOBBYING)).thenReturn(new Image(UiService.CHAT_LIST_STATUS_LOBBYING));
-    when(uiService.getThemeImage(UiService.CHAT_LIST_STATUS_PLAYING)).thenReturn(new Image(UiService.CHAT_LIST_STATUS_PLAYING));
-    when(mapService.loadPreview("mapName", PreviewSize.SMALL)).thenReturn(new Image(UiService.UNKNOWN_MAP_IMAGE));
 
     instance = new ChatUserItemController(
         preferencesService,
-        avatarService,
-        countryFlagService,
         i18n,
         uiService,
         eventBus,
-        clanService,
         playerService,
         platformService,
-        timeService,
-        mapService
+        timeService
     );
     loadFxml("theme/chat/chat_user_item.fxml", param -> instance);
   }
@@ -130,28 +97,6 @@ public class ChatChannelUserItemControllerTest extends AbstractPlainJavaFxTest {
   }
 
   @Test
-  public void testSetChatUser() throws Exception {
-    Player player = PlayerBuilder.create("junit")
-        .defaultValues()
-        .clan("e")
-        .avatar(new AvatarBean(new URL("http://example.com/avatar.png"), "dog"))
-        .get();
-    when(playerService.getCurrentPlayer()).thenReturn(Optional.of(player));
-    instance.setChatUser(ChatChannelUserBuilder.create("junit").defaultValues().setPlayer(player).get());
-    WaitForAsyncUtils.waitForFxEvents();
-    instance.clanMenu.getOnMouseClicked().handle(null);
-
-    assertThat(instance.clanMenu.getText(), is("[e]"));
-    assertThat(instance.clanMenu.isVisible(), is(true));
-    verify(countryFlagService).loadCountryFlag("US");
-    assertThat(instance.countryTooltip, CoreMatchers.notNullValue());
-    assertThat(instance.avatarTooltip, CoreMatchers.notNullValue());
-    assertThat(instance.userTooltip, CoreMatchers.notNullValue());
-    instance.clanMenu.getOnMouseEntered().handle(null);
-    verify(clanTooltipControllerMock).setClan(testClan);
-  }
-
-  @Test
   public void testGetPlayer() {
     ChatChannelUser chatUser = ChatChannelUserBuilder.create("junit").defaultValues().get();
     instance.setChatUser(chatUser);
@@ -160,92 +105,39 @@ public class ChatChannelUserItemControllerTest extends AbstractPlainJavaFxTest {
   }
 
   @Test
-  public void testOpenGameSetsStatusToWaiting() {
+  public void testNullValuesHidesNodes() {
     Player player = PlayerBuilder.create("junit").defaultValues().get();
     ChatChannelUser chatUser = ChatChannelUserBuilder.create("junit")
         .defaultValues()
-        .setPlayer(player)
+        .player(player)
         .get();
     instance.setChatUser(chatUser);
     WaitForAsyncUtils.waitForFxEvents();
 
+    assertFalse(instance.avatarImageView.isVisible());
     assertFalse(instance.playerStatusIndicator.isVisible());
     assertFalse(instance.playerMapImage.isVisible());
-
-    player.setGame(GameBuilder.create().defaultValues().get());
-    WaitForAsyncUtils.waitForFxEvents();
-
-    assertTrue(instance.playerStatusIndicator.isVisible());
-    assertThat(instance.playerStatusIndicator.getImage().getUrl(), endsWith(Paths.get(UiService.CHAT_LIST_STATUS_LOBBYING).getFileName().toString()));
-    assertTrue(instance.playerMapImage.isVisible());
-    assertThat(instance.playerMapImage.getImage().getUrl(), endsWith(UiService.UNKNOWN_MAP_IMAGE));
+    assertFalse(instance.countryImageView.isVisible());
   }
 
   @Test
-  public void testHostedGameSetsStatusToHosting() {
+  public void testNotNullValuesShowsNodes() {
     Player player = PlayerBuilder.create("junit").defaultValues().get();
     ChatChannelUser chatUser = ChatChannelUserBuilder.create("junit")
         .defaultValues()
-        .setPlayer(player)
-        .get();
-
-    instance.setChatUser(chatUser);
-    WaitForAsyncUtils.waitForFxEvents();
-
-    assertFalse(instance.playerStatusIndicator.isVisible());
-    assertFalse(instance.playerMapImage.isVisible());
-
-    player.setGame(GameBuilder.create().defaultValues().host("junit").state(GameStatus.OPEN).get());
-    WaitForAsyncUtils.waitForFxEvents();
-
-    assertTrue(instance.playerStatusIndicator.isVisible());
-    assertThat(instance.playerStatusIndicator.getImage().getUrl(), endsWith(Paths.get(UiService.CHAT_LIST_STATUS_HOSTING).getFileName().toString()));
-    assertTrue(instance.playerMapImage.isVisible());
-    assertThat(instance.playerMapImage.getImage().getUrl(), endsWith(UiService.UNKNOWN_MAP_IMAGE));
-  }
-
-  @Test
-  public void testActiveGameSetsStatusToPlaying() {
-    Player player = PlayerBuilder.create("junit").defaultValues().get();
-    ChatChannelUser chatUser = ChatChannelUserBuilder.create("junit")
-        .defaultValues()
-        .setPlayer(player)
+        .player(player)
+        .avatar(new Image(UiService.UNKNOWN_MAP_IMAGE))
+        .countryFlag(new Image(UiService.UNKNOWN_MAP_IMAGE))
+        .mapImage(new Image(UiService.UNKNOWN_MAP_IMAGE))
+        .statusImage(new Image(UiService.UNKNOWN_MAP_IMAGE))
         .get();
     instance.setChatUser(chatUser);
     WaitForAsyncUtils.waitForFxEvents();
 
-    assertFalse(instance.playerStatusIndicator.isVisible());
-    assertFalse(instance.playerMapImage.isVisible());
-
-    player.setGame(GameBuilder.create().defaultValues().host("junit").state(GameStatus.PLAYING).get());
-    WaitForAsyncUtils.waitForFxEvents();
-
+    assertTrue(instance.avatarImageView.isVisible());
     assertTrue(instance.playerStatusIndicator.isVisible());
-    assertThat(instance.playerStatusIndicator.getImage().getUrl(), endsWith(Paths.get(UiService.CHAT_LIST_STATUS_PLAYING).getFileName().toString()));
     assertTrue(instance.playerMapImage.isVisible());
-    assertThat(instance.playerMapImage.getImage().getUrl(), endsWith(UiService.UNKNOWN_MAP_IMAGE));
-  }
-
-  @Test
-  public void testNullGameSetsStatusToNothing() {
-    Player player = PlayerBuilder.create("junit").defaultValues().get();
-    ChatChannelUser chatUser = ChatChannelUserBuilder.create("junit")
-        .defaultValues()
-        .setPlayer(player)
-        .get();
-    instance.setChatUser(chatUser);
-    player.setGame(GameBuilder.create().defaultValues().host("junit").state(GameStatus.PLAYING).get());
-    WaitForAsyncUtils.waitForFxEvents();
-
-    assertTrue(instance.playerStatusIndicator.isVisible());
-    assertThat(instance.playerStatusIndicator.getImage().getUrl(), endsWith(Paths.get(UiService.CHAT_LIST_STATUS_PLAYING).getFileName().toString()));
-    assertTrue(instance.playerMapImage.isVisible());
-    assertThat(instance.playerMapImage.getImage().getUrl(), endsWith(UiService.UNKNOWN_MAP_IMAGE));
-    player.setGame(null);
-    WaitForAsyncUtils.waitForFxEvents();
-
-    assertFalse(instance.playerStatusIndicator.isVisible());
-    assertFalse(instance.playerMapImage.isVisible());
+    assertTrue(instance.countryImageView.isVisible());
   }
 
   @Test
@@ -263,7 +155,7 @@ public class ChatChannelUserItemControllerTest extends AbstractPlainJavaFxTest {
     instance.onItemClicked(MouseEvents.generateClick(MouseButton.PRIMARY, 2));
 
     ArgumentCaptor<InitiatePrivateChatEvent> captor = ArgumentCaptor.forClass(InitiatePrivateChatEvent.class);
-    verify(eventBus).post(captor.capture());
+    verify(eventBus, times(3)).post(captor.capture());
 
     assertThat(captor.getValue().getUsername(), is("junit"));
   }
@@ -298,7 +190,7 @@ public class ChatChannelUserItemControllerTest extends AbstractPlainJavaFxTest {
         .avatar(new AvatarBean(new URL("http://example.com/avatar.png"), "dog"))
         .get();
     when(playerService.getCurrentPlayer()).thenReturn(Optional.of(player));
-    instance.setChatUser(ChatChannelUserBuilder.create("junit").defaultValues().setPlayer(player).get());
+    instance.setChatUser(ChatChannelUserBuilder.create("junit").defaultValues().player(player).clan(testClan).get());
     WaitForAsyncUtils.waitForFxEvents();
 
     instance.clanMenu.getOnMouseClicked().handle(null);
@@ -323,7 +215,7 @@ public class ChatChannelUserItemControllerTest extends AbstractPlainJavaFxTest {
         .avatar(new AvatarBean(new URL("http://example.com/avatar.png"), "dog"))
         .get();
     when(playerService.getCurrentPlayer()).thenReturn(Optional.of(otherClanLeader));
-    instance.setChatUser(ChatChannelUserBuilder.create("junit").defaultValues().setPlayer(player).get());
+    instance.setChatUser(ChatChannelUserBuilder.create("junit").defaultValues().player(player).clan(testClan).get());
     WaitForAsyncUtils.waitForFxEvents();
 
     instance.clanMenu.getOnMouseClicked().handle(null);
@@ -339,15 +231,13 @@ public class ChatChannelUserItemControllerTest extends AbstractPlainJavaFxTest {
     Player player = PlayerBuilder.create("junit")
         .defaultValues()
         .clan("e")
-        .avatar(new AvatarBean(new URL("http://example.com/avatar.png"), "dog"))
         .get();
     Player otherClanLeader = PlayerBuilder.create("test_player")
         .defaultValues()
         .clan("not")
-        .avatar(new AvatarBean(new URL("http://example.com/avatar.png"), "dog"))
         .get();
     when(playerService.getCurrentPlayer()).thenReturn(Optional.of(otherClanLeader));
-    instance.setChatUser(ChatChannelUserBuilder.create("junit").defaultValues().setPlayer(player).get());
+    instance.setChatUser(ChatChannelUserBuilder.create("junit").defaultValues().player(player).clan(testClan).get());
     WaitForAsyncUtils.waitForFxEvents();
 
     instance.clanMenu.getOnMouseClicked().handle(null);

--- a/src/test/java/com/faforever/client/chat/ChatControllerTest.java
+++ b/src/test/java/com/faforever/client/chat/ChatControllerTest.java
@@ -30,7 +30,6 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -153,7 +152,6 @@ public class ChatControllerTest extends AbstractPlainJavaFxTest {
     tab.setId(TEST_CHANNEL_NAME);
 
     when(channelTabController.getRoot()).thenReturn(tab);
-    when(userService.getUsername()).thenReturn(TEST_USER_NAME);
     doAnswer(invocation -> {
       MapChangeListener.Change<? extends String, ? extends Channel> change = mock(MapChangeListener.Change.class);
       when(change.wasAdded()).thenReturn(true);
@@ -166,12 +164,8 @@ public class ChatControllerTest extends AbstractPlainJavaFxTest {
     instance.onJoinChannelButtonClicked();
 
     verify(chatService).joinChannel(TEST_CHANNEL_NAME);
-    verify(chatService).addUsersListener(eq(TEST_CHANNEL_NAME), onUsersListenerCaptor.capture());
 
     MapChangeListener.Change<? extends String, ? extends ChatChannelUser> change = mock(MapChangeListener.Change.class);
-    when(change.wasAdded()).thenReturn(true);
-    doReturn(new ChatChannelUser(TEST_USER_NAME, null, false)).when(change).getValueAdded();
-    onUsersListenerCaptor.getValue().onChanged(change);
 
     CountDownLatch tabAddedLatch = new CountDownLatch(1);
     instance.tabPane.getTabs().addListener((InvalidationListener) observable -> tabAddedLatch.countDown());

--- a/src/test/java/com/faforever/client/chat/ChatControllerTest.java
+++ b/src/test/java/com/faforever/client/chat/ChatControllerTest.java
@@ -30,6 +30,7 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -152,6 +153,7 @@ public class ChatControllerTest extends AbstractPlainJavaFxTest {
     tab.setId(TEST_CHANNEL_NAME);
 
     when(channelTabController.getRoot()).thenReturn(tab);
+    when(userService.getUsername()).thenReturn(TEST_USER_NAME);
     doAnswer(invocation -> {
       MapChangeListener.Change<? extends String, ? extends Channel> change = mock(MapChangeListener.Change.class);
       when(change.wasAdded()).thenReturn(true);
@@ -164,8 +166,12 @@ public class ChatControllerTest extends AbstractPlainJavaFxTest {
     instance.onJoinChannelButtonClicked();
 
     verify(chatService).joinChannel(TEST_CHANNEL_NAME);
+    verify(chatService).addUsersListener(eq(TEST_CHANNEL_NAME), onUsersListenerCaptor.capture());
 
     MapChangeListener.Change<? extends String, ? extends ChatChannelUser> change = mock(MapChangeListener.Change.class);
+    when(change.wasAdded()).thenReturn(true);
+    doReturn(new ChatChannelUser(TEST_USER_NAME, null, false)).when(change).getValueAdded();
+    onUsersListenerCaptor.getValue().onChanged(change);
 
     CountDownLatch tabAddedLatch = new CountDownLatch(1);
     instance.tabPane.getTabs().addListener((InvalidationListener) observable -> tabAddedLatch.countDown());

--- a/src/test/java/com/faforever/client/chat/ChatUserServiceTest.java
+++ b/src/test/java/com/faforever/client/chat/ChatUserServiceTest.java
@@ -1,0 +1,255 @@
+package com.faforever.client.chat;
+
+import com.faforever.client.chat.avatar.AvatarBean;
+import com.faforever.client.chat.avatar.AvatarService;
+import com.faforever.client.chat.event.ChatUserGameChangeEvent;
+import com.faforever.client.chat.event.ChatUserPopulateEvent;
+import com.faforever.client.clan.Clan;
+import com.faforever.client.clan.ClanService;
+import com.faforever.client.game.Game;
+import com.faforever.client.game.GameBuilder;
+import com.faforever.client.game.PlayerStatus;
+import com.faforever.client.i18n.I18n;
+import com.faforever.client.map.MapService;
+import com.faforever.client.map.MapService.PreviewSize;
+import com.faforever.client.player.Player;
+import com.faforever.client.player.PlayerBuilder;
+import com.faforever.client.remote.domain.GameStatus;
+import com.faforever.client.test.AbstractPlainJavaFxTest;
+import com.faforever.client.theme.UiService;
+import com.google.common.eventbus.EventBus;
+import javafx.scene.image.Image;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.testfx.util.WaitForAsyncUtils;
+
+import java.net.URL;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class ChatUserServiceTest extends AbstractPlainJavaFxTest {
+
+  private ChatUserService instance;
+  @Mock
+  private AvatarService avatarService;
+  @Mock
+  private CountryFlagService countryFlagService;
+  @Mock
+  private I18n i18n;
+  @Mock
+  private UiService uiService;
+  @Mock
+  private EventBus eventBus;
+  @Mock
+  private ClanService clanService;
+  @Mock
+  private MapService mapService;
+  @Mock
+  private AvatarBean avatar;
+  private URL avatarURL;
+
+  private Clan testClan;
+
+  @Before
+  public void setUp() throws Exception {
+    avatarURL = new URL("http://avatar.png");
+    testClan = new Clan();
+    testClan.setTag("testClan");
+    when(clanService.getClanByTag(null)).thenReturn(CompletableFuture.completedFuture(Optional.empty()));
+    when(clanService.getClanByTag(anyString())).thenReturn(CompletableFuture.completedFuture(Optional.of(testClan)));
+    when(countryFlagService.loadCountryFlag(anyString())).thenReturn(Optional.of(mock(Image.class)));
+    when(uiService.getThemeImage(anyString())).thenReturn(mock(Image.class));
+    when(mapService.loadPreview(anyString(), any(PreviewSize.class))).thenReturn(mock(Image.class));
+    when(avatarService.loadAvatar(anyString())).thenReturn(mock(Image.class));
+    when(avatar.getUrl()).thenReturn(avatarURL);
+    when(avatar.getDescription()).thenReturn("fancy");
+    when(i18n.getCountryNameLocalized("US")).thenReturn("United States");
+
+    instance = new ChatUserService(
+        uiService,
+        mapService,
+        avatarService,
+        clanService,
+        countryFlagService,
+        i18n,
+        eventBus
+    );
+  }
+
+  @Test
+  public void testPlayerIsNull() {
+    ChatChannelUser chatUser = ChatChannelUserBuilder.create("junit")
+        .defaultValues()
+        .get();
+    instance.onChatUserGameChange(new ChatUserGameChangeEvent(chatUser));
+    instance.onChatUserPopulate(new ChatUserPopulateEvent(chatUser));
+    WaitForAsyncUtils.waitForFxEvents();
+
+    verify(clanService, never()).getClanByTag(anyString());
+    verify(avatarService, never()).loadAvatar(anyString());
+    verify(mapService, never()).loadPreview(anyString(), any(PreviewSize.class));
+    verify(uiService, never()).getThemeImage(anyString());
+  }
+
+  @Test
+  public void testClanNotNull() {
+    Player player = PlayerBuilder.create("junit").defaultValues().clan(testClan.getTag()).get();
+    ChatChannelUser chatUser = ChatChannelUserBuilder.create("junit")
+        .defaultValues()
+        .player(player)
+        .get();
+    instance.onChatUserPopulate(new ChatUserPopulateEvent(chatUser));
+    WaitForAsyncUtils.waitForFxEvents();
+
+    verify(clanService).getClanByTag(testClan.getTag());
+    assertEquals(chatUser.getClan().orElse(null), testClan);
+    assertEquals(chatUser.getClanTag().orElse(null), String.format("[%s]", testClan.getTag()));
+  }
+
+  @Test
+  public void testClanNull() {
+    Player player = PlayerBuilder.create("junit").defaultValues().clan(null).get();
+    ChatChannelUser chatUser = ChatChannelUserBuilder.create("junit")
+        .defaultValues()
+        .player(player)
+        .get();
+    instance.onChatUserPopulate(new ChatUserPopulateEvent(chatUser));
+    WaitForAsyncUtils.waitForFxEvents();
+
+    verify(clanService).getClanByTag(null);
+    assertTrue(chatUser.getClan().isEmpty());
+    assertTrue(chatUser.getClanTag().isEmpty());
+  }
+
+  @Test
+  public void testAvatarNotNull() {
+    Player player = PlayerBuilder.create("junit").defaultValues().avatar(avatar).get();
+    ChatChannelUser chatUser = ChatChannelUserBuilder.create("junit")
+        .defaultValues()
+        .player(player)
+        .get();
+    instance.onChatUserPopulate(new ChatUserPopulateEvent(chatUser));
+    WaitForAsyncUtils.waitForFxEvents();
+
+    verify(avatarService).loadAvatar(avatarURL.toExternalForm());
+    assertTrue(chatUser.getAvatar().isPresent());
+  }
+
+  @Test
+  public void testAvatarNull() {
+    Player player = PlayerBuilder.create("junit").defaultValues().get();
+    ChatChannelUser chatUser = ChatChannelUserBuilder.create("junit")
+        .defaultValues()
+        .player(player)
+        .get();
+    instance.onChatUserPopulate(new ChatUserPopulateEvent(chatUser));
+    WaitForAsyncUtils.waitForFxEvents();
+
+    verify(avatarService, never()).loadAvatar(anyString());
+    assertTrue(chatUser.getAvatar().isEmpty());
+  }
+
+  @Test
+  public void testCountryNotNull() {
+    Player player = PlayerBuilder.create("junit").defaultValues().country("US").get();
+    ChatChannelUser chatUser = ChatChannelUserBuilder.create("junit")
+        .defaultValues()
+        .player(player)
+        .get();
+    instance.onChatUserPopulate(new ChatUserPopulateEvent(chatUser));
+    WaitForAsyncUtils.waitForFxEvents();
+
+    verify(countryFlagService).loadCountryFlag("US");
+    assertTrue(chatUser.getCountryFlag().isPresent());
+    assertEquals("United States", chatUser.getCountryName().orElse(null));
+  }
+
+  @Test
+  public void testCountryNull() {
+    Player player = PlayerBuilder.create("junit").defaultValues().country(null).get();
+    ChatChannelUser chatUser = ChatChannelUserBuilder.create("junit")
+        .defaultValues()
+        .player(player)
+        .get();
+    instance.onChatUserPopulate(new ChatUserPopulateEvent(chatUser));
+    WaitForAsyncUtils.waitForFxEvents();
+
+    verify(countryFlagService).loadCountryFlag(null);
+    assertTrue(chatUser.getCountryFlag().isEmpty());
+    assertTrue(chatUser.getCountryName().isEmpty());
+  }
+
+  @Test
+  public void testStatusToIdle() {
+    Player player = PlayerBuilder.create("junit").defaultValues().game(null).get();
+    ChatChannelUser chatUser = ChatChannelUserBuilder.create("junit")
+        .defaultValues()
+        .player(player)
+        .get();
+    instance.onChatUserGameChange(new ChatUserGameChangeEvent(chatUser));
+    WaitForAsyncUtils.waitForFxEvents();
+
+    verify(uiService, never()).getThemeImage(anyString());
+    assertFalse(chatUser.getMapImage().isPresent());
+    assertEquals(PlayerStatus.IDLE, chatUser.getStatus().orElse(null));
+  }
+
+  @Test
+  public void testStatusToPlaying() {
+    Game game = GameBuilder.create().defaultValues().state(GameStatus.PLAYING).get();
+    Player player = PlayerBuilder.create("junit").defaultValues().game(game).get();
+    ChatChannelUser chatUser = ChatChannelUserBuilder.create("junit")
+        .defaultValues()
+        .player(player)
+        .get();
+    instance.onChatUserGameChange(new ChatUserGameChangeEvent(chatUser));
+    WaitForAsyncUtils.waitForFxEvents();
+
+    verify(uiService).getThemeImage(UiService.CHAT_LIST_STATUS_PLAYING);
+    assertTrue(chatUser.getMapImage().isPresent());
+    assertEquals(PlayerStatus.PLAYING, chatUser.getStatus().orElse(null));
+  }
+
+  @Test
+  public void testStatusToHosting() {
+    Game game = GameBuilder.create().defaultValues().state(GameStatus.OPEN).host("junit").get();
+    Player player = PlayerBuilder.create("junit").defaultValues().game(game).get();
+    ChatChannelUser chatUser = ChatChannelUserBuilder.create("junit")
+        .defaultValues()
+        .player(player)
+        .get();
+    instance.onChatUserGameChange(new ChatUserGameChangeEvent(chatUser));
+    WaitForAsyncUtils.waitForFxEvents();
+
+    verify(uiService).getThemeImage(UiService.CHAT_LIST_STATUS_HOSTING);
+    assertTrue(chatUser.getMapImage().isPresent());
+    assertEquals(PlayerStatus.HOSTING, chatUser.getStatus().orElse(null));
+  }
+
+  @Test
+  public void testStatusToLobbying() {
+    Game game = GameBuilder.create().defaultValues().state(GameStatus.OPEN).get();
+    Player player = PlayerBuilder.create("junit").defaultValues().game(game).get();
+    ChatChannelUser chatUser = ChatChannelUserBuilder.create("junit")
+        .defaultValues()
+        .player(player)
+        .get();
+    instance.onChatUserGameChange(new ChatUserGameChangeEvent(chatUser));
+    WaitForAsyncUtils.waitForFxEvents();
+
+    verify(uiService).getThemeImage(UiService.CHAT_LIST_STATUS_LOBBYING);
+    assertTrue(chatUser.getMapImage().isPresent());
+    assertEquals(PlayerStatus.LOBBYING, chatUser.getStatus().orElse(null));
+  }
+}

--- a/src/test/java/com/faforever/client/chat/UserFilterControllerTest.java
+++ b/src/test/java/com/faforever/client/chat/UserFilterControllerTest.java
@@ -41,7 +41,7 @@ public class UserFilterControllerTest extends AbstractPlainJavaFxTest {
     player = PlayerBuilder.create("junit").defaultValues().get();
     chatChannelUser = ChatChannelUserBuilder.create("junit")
         .defaultValues()
-        .setPlayer(player)
+        .player(player)
         .get();
 
     loadFxml("theme/chat/user_filter.fxml", clazz -> instance);


### PR DESCRIPTION
This pull request is in response to #2006.

It is trying to use the event bus to modify elements of the chatUserItem and remove calls to the various services from chatUserItemController.
This will hopefully reduce the cpu usage as currently all the services are called for all users whenever the chat user list changes and with this they will not be associated with the specific cell but rather the chat user.