### PR TITLE
#1651 Improve Chat readability

### DIFF
--- a/src/main/resources/theme/chat/compact/chat_section.html
+++ b/src/main/resources/theme/chat/compact/chat_section.html
@@ -1,9 +1,11 @@
 <table class="chat-section compact chat-section-{username}">
   <tr>
-    <td class="author">
-      <span class="author" style="{inline-style}">
+    <td class="decoration">
         <img class="avatar" src="{avatar}"/>
         <img class="country-flag" src="{country-flag}"/>
+    </td>
+    <td class="author">
+      <span class="author" style="{inline-style}">
         <span class="clan-tag {css-classes}"
               onmouseover="showClanInfo('{clan-tag}')"
               onmouseout="hideClanInfo()"

--- a/src/main/resources/theme/style-webview.css
+++ b/src/main/resources/theme/style-webview.css
@@ -45,6 +45,7 @@ a {
 
 img.avatar,
 img.country-flag {
+  margin-left: 1px;
   margin-right: 0.2em;
 }
 
@@ -130,14 +131,18 @@ img.country-flag {
 }
 
 .chat-section.compact td.decoration {
+  white-space: nowrap;
   vertical-align: top;
-  min-width: 75px;
 }
 
 .chat-section.compact td.author {
   vertical-align: top;
-  text-align: right;
-  min-width: 120px;
+  text-align: left;
+  min-width: 130px;
+  max-width: 130px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .chat-section.compact td.decoration * {

--- a/src/main/resources/theme/style-webview.css
+++ b/src/main/resources/theme/style-webview.css
@@ -89,7 +89,6 @@ img.country-flag {
   /* Use same as -fx-light-text-color */
   color: #DCDCDC;
   cursor: pointer;
-  font-weight: bold;
 }
 
 .chat-section .clan-tag:hover {
@@ -122,6 +121,7 @@ img.country-flag {
 .chat-section.compact,
 .chat-section.compact .messages-wrapper {
   width: 100%;
+  vertical-align: top;
 }
 
 .chat-section.compact img.avatar[src=""],
@@ -129,12 +129,18 @@ img.country-flag {
   visibility: hidden;
 }
 
-.chat-section.compact td.author {
+.chat-section.compact td.decoration {
   vertical-align: top;
-  min-width: 200px;
+  min-width: 75px;
 }
 
-.chat-section.compact td.author * {
+.chat-section.compact td.author {
+  vertical-align: top;
+  text-align: right;
+  min-width: 120px;
+}
+
+.chat-section.compact td.decoration * {
   vertical-align: middle;
   line-height: 1em;
 }


### PR DESCRIPTION
Fixes #1651 

Makes names right aligned and reduces font weight on clan tag to normal. I didn't implement the colon, because it is controversial and more of a preference thing than objectively better.
Long names disturbing the layout is still an issue, but that seems rather difficult to fix.
![grafik](https://user-images.githubusercontent.com/52536103/97812779-11832400-1c84-11eb-91f5-05619b3fbd4d.png)
