### PR TITLE
Remove clanMenu from ChatUserItemController and use clanLabel instead

### DIFF
--- a/src/main/java/com/faforever/client/chat/ChatChannelUser.java
+++ b/src/main/java/com/faforever/client/chat/ChatChannelUser.java
@@ -1,6 +1,5 @@
 package com.faforever.client.chat;
 
-import com.faforever.client.clan.Clan;
 import com.faforever.client.game.PlayerStatus;
 import com.faforever.client.player.Player;
 import javafx.beans.property.BooleanProperty;
@@ -31,7 +30,6 @@ public class ChatChannelUser {
   private final ObjectProperty<Instant> lastActive;
   private final ObjectProperty<PlayerStatus> status;
   private final ObjectProperty<Image> avatar;
-  private final ObjectProperty<Clan> clan;
   private final StringProperty clanTag;
   private final ObjectProperty<Image> countryFlag;
   private final StringProperty countryName;
@@ -52,7 +50,6 @@ public class ChatChannelUser {
     this.lastActive = new SimpleObjectProperty<>();
     this.status = new SimpleObjectProperty<>();
     this.avatar = new SimpleObjectProperty<>();
-    this.clan = new SimpleObjectProperty<>();
     this.clanTag = new SimpleStringProperty();
     this.countryFlag = new SimpleObjectProperty<>();
     this.countryName = new SimpleStringProperty();
@@ -145,18 +142,6 @@ public class ChatChannelUser {
 
   public ObjectProperty<Image> avatarProperty() {
     return avatar;
-  }
-
-  public Optional<Clan> getClan() {
-    return Optional.ofNullable(clan.get());
-  }
-
-  public void setClan(Clan clan) {
-    this.clan.set(clan);
-  }
-
-  public ObjectProperty<Clan> clanProperty() {
-    return clan;
   }
 
   public Optional<String> getClanTag() {

--- a/src/main/java/com/faforever/client/chat/ChatUserItemController.java
+++ b/src/main/java/com/faforever/client/chat/ChatUserItemController.java
@@ -1,7 +1,6 @@
 package com.faforever.client.chat;
 
 import com.faforever.client.chat.event.ChatUserPopulateEvent;
-import com.faforever.client.clan.Clan;
 import com.faforever.client.fx.Controller;
 import com.faforever.client.fx.JavaFxUtil;
 import com.faforever.client.fx.PlatformService;
@@ -20,8 +19,6 @@ import javafx.beans.binding.Bindings;
 import javafx.css.PseudoClass;
 import javafx.scene.Node;
 import javafx.scene.control.Label;
-import javafx.scene.control.MenuButton;
-import javafx.scene.control.MenuItem;
 import javafx.scene.control.Tooltip;
 import javafx.scene.image.ImageView;
 import javafx.scene.input.ContextMenuEvent;
@@ -75,7 +72,7 @@ public class ChatUserItemController implements Controller<Node> {
   public ImageView countryImageView;
   public ImageView avatarImageView;
   public Label usernameLabel;
-  public MenuButton clanMenu;
+  public Label clanLabel;
   public ImageView playerMapImage;
 
   private ChatChannelUser chatUser;
@@ -141,11 +138,11 @@ public class ChatUserItemController implements Controller<Node> {
     weakColorInvalidationListener.invalidated(chatPrefs.chatColorModeProperty());
     weakFormatInvalidationListener.invalidated(chatPrefs.chatFormatProperty());
 
-    JavaFxUtil.bindManagedToVisible(countryImageView, clanMenu, playerStatusIndicator, playerMapImage);
+    JavaFxUtil.bindManagedToVisible(countryImageView, clanLabel, playerStatusIndicator, playerMapImage);
 
     JavaFxUtil.bind(avatarImageView.visibleProperty(), Bindings.isNotNull(avatarImageView.imageProperty()));
     JavaFxUtil.bind(countryImageView.visibleProperty(), Bindings.isNotNull(countryImageView.imageProperty()));
-    JavaFxUtil.bind(clanMenu.visibleProperty(), Bindings.isNotEmpty(clanMenu.textProperty()));
+    JavaFxUtil.bind(clanLabel.visibleProperty(), Bindings.isNotEmpty(clanLabel.textProperty()));
     JavaFxUtil.bind(playerStatusIndicator.visibleProperty(), Bindings.isNotNull(playerStatusIndicator.imageProperty()));
     JavaFxUtil.bind(playerMapImage.visibleProperty(), Bindings.isNotNull(playerMapImage.imageProperty()));
 
@@ -185,7 +182,7 @@ public class ChatUserItemController implements Controller<Node> {
     chatUser.getPlayer().ifPresent(player -> {
       if (player.getSocialStatus() == SELF) {
         usernameLabel.getStyleClass().add(SELF.getCssClass());
-        clanMenu.getStyleClass().add(SELF.getCssClass());
+        clanLabel.getStyleClass().add(SELF.getCssClass());
       }
     });
 
@@ -207,10 +204,10 @@ public class ChatUserItemController implements Controller<Node> {
   private void assignColor(Color color) {
     if (color != null) {
       usernameLabel.setStyle(String.format("-fx-text-fill: %s", JavaFxUtil.toRgbCode(color)));
-      clanMenu.setStyle(String.format("-fx-text-fill: %s", JavaFxUtil.toRgbCode(color)));
+      clanLabel.setStyle(String.format("-fx-text-fill: %s", JavaFxUtil.toRgbCode(color)));
     } else {
       usernameLabel.setStyle("");
-      clanMenu.setStyle("");
+      clanLabel.setStyle("");
     }
   }
 
@@ -229,7 +226,7 @@ public class ChatUserItemController implements Controller<Node> {
 
     JavaFxUtil.unbind(usernameLabel.textProperty());
     JavaFxUtil.unbind(avatarImageView.imageProperty());
-    JavaFxUtil.unbind(clanMenu.textProperty());
+    JavaFxUtil.unbind(clanLabel.textProperty());
     JavaFxUtil.unbind(countryImageView.imageProperty());
     JavaFxUtil.unbind(playerMapImage.imageProperty());
     JavaFxUtil.unbind(playerStatusIndicator.imageProperty());
@@ -246,7 +243,7 @@ public class ChatUserItemController implements Controller<Node> {
       this.chatUser.setDisplayed(true);
       JavaFxUtil.bind(usernameLabel.textProperty(), this.chatUser.usernameProperty());
       JavaFxUtil.bind(avatarImageView.imageProperty(), this.chatUser.avatarProperty());
-      JavaFxUtil.bind(clanMenu.textProperty(), this.chatUser.clanTagProperty());
+      JavaFxUtil.bind(clanLabel.textProperty(), this.chatUser.clanTagProperty());
       JavaFxUtil.bind(countryImageView.imageProperty(), this.chatUser.countryFlagProperty());
       JavaFxUtil.bind(countryTooltip.textProperty(), this.chatUser.countryNameProperty());
       JavaFxUtil.bind(playerMapImage.imageProperty(), this.chatUser.mapImageProperty());
@@ -275,35 +272,5 @@ public class ChatUserItemController implements Controller<Node> {
 
   public void onMouseEnteredUserNameLabel() {
     chatUser.getPlayer().ifPresent(this::updateNameLabelText);
-  }
-
-  /**
-   * Memory analysis suggest this menu uses tons of memory while it stays unclear why exactly (something java fx
-   * internal). We just load the menu on click. Also we destroy it over and over again.
-   */
-  public void onClanMenuRequested() {
-    clanMenu.getItems().clear();
-    clanMenu.hide();
-    if (chatUser.getClan().isEmpty()) {
-      return;
-    }
-
-    Clan clan = chatUser.getClan().get();
-
-    Player currentPlayer = playerService.getCurrentPlayer()
-        .orElseThrow(() -> new IllegalStateException("Player has to be set"));
-
-    if (currentPlayer.getId() != clan.getLeader().getId()
-        && playerService.isOnline(clan.getLeader().getId())) {
-      MenuItem messageLeaderItem = new MenuItem(i18n.get("clan.messageLeader"));
-      messageLeaderItem.setOnAction(event -> eventBus.post(new InitiatePrivateChatEvent(clan.getLeader().getUsername())));
-      clanMenu.getItems().add(messageLeaderItem);
-    }
-
-    MenuItem visitClanPageAction = new MenuItem(i18n.get("clan.visitPage"));
-    visitClanPageAction.setOnAction(event -> platformService.showDocument(clan.getWebsiteUrl()));
-    clanMenu.getItems().add(visitClanPageAction);
-
-    clanMenu.show();
   }
 }

--- a/src/main/java/com/faforever/client/chat/ChatUserService.java
+++ b/src/main/java/com/faforever/client/chat/ChatUserService.java
@@ -3,7 +3,6 @@ package com.faforever.client.chat;
 import com.faforever.client.chat.avatar.AvatarService;
 import com.faforever.client.chat.event.ChatUserGameChangeEvent;
 import com.faforever.client.chat.event.ChatUserPopulateEvent;
-import com.faforever.client.clan.ClanService;
 import com.faforever.client.game.PlayerStatus;
 import com.faforever.client.i18n.I18n;
 import com.faforever.client.map.MapService;
@@ -27,7 +26,6 @@ public class ChatUserService implements InitializingBean {
   private final UiService uiService;
   private final MapService mapService;
   private final AvatarService avatarService;
-  private final ClanService clanService;
   private final CountryFlagService countryFlagService;
   private final I18n i18n;
   private final EventBus eventBus;
@@ -38,22 +36,11 @@ public class ChatUserService implements InitializingBean {
   }
 
   public void populateClan(ChatChannelUser chatChannelUser) {
-    if (chatChannelUser.getClan().isEmpty()) {
+    if (chatChannelUser.getClanTag().isEmpty()) {
       chatChannelUser.getPlayer().ifPresent(player -> {
         if (player.getClan() != null) {
-          clanService.getClanByTag(player.getClan())
-              .thenAccept(optionalClan -> Platform.runLater(() -> {
-                    if (optionalClan.isPresent()) {
-                      chatChannelUser.setClan(optionalClan.get());
-                      chatChannelUser.setClanTag(String.format("[%s]", optionalClan.get().getTag()));
-                    } else {
-                      chatChannelUser.setClan(null);
-                      chatChannelUser.setClanTag(null);
-                    }
-                  })
-              );
+          chatChannelUser.setClanTag(String.format("[%s]", player.getClan()));
         } else {
-          chatChannelUser.setClan(null);
           chatChannelUser.setClanTag(null);
         }
       });
@@ -119,7 +106,6 @@ public class ChatUserService implements InitializingBean {
       populateCountry(chatChannelUser);
       populateGameStatus(chatChannelUser);
     } else if (!chatChannelUser.isDisplayed()) {
-      chatChannelUser.setClan(null);
       chatChannelUser.setClanTag(null);
       chatChannelUser.setAvatar(null);
       chatChannelUser.setCountryFlag(null);

--- a/src/main/resources/theme/chat/chat_user_item.fxml
+++ b/src/main/resources/theme/chat/chat_user_item.fxml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <?import javafx.scene.control.Label?>
-<?import javafx.scene.control.MenuButton?>
 <?import javafx.scene.image.ImageView?>
 <?import javafx.scene.layout.HBox?>
 <HBox fx:id="chatUserItemRoot" alignment="CENTER_LEFT" spacing="3.0" xmlns="http://javafx.com/javafx/11.0.1"
@@ -10,9 +9,7 @@
     <children>
         <ImageView fx:id="avatarImageView" fitHeight="20.0" fitWidth="40.0" pickOnBounds="true" preserveRatio="true"/>
         <ImageView fx:id="countryImageView" fitHeight="16.0" fitWidth="16.0" pickOnBounds="true" preserveRatio="true"/>
-        <MenuButton fx:id="clanMenu" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308"
-                    onMouseClicked="#onClanMenuRequested"
-                    styleClass="chat-user-control-clan" text="[CLAN]"/>
+        <Label fx:id="clanLabel" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" text="[CLAN]"/>
         <Label fx:id="usernameLabel" maxWidth="1.7976931348623157E308" minWidth="0.0" onMouseClicked="#onItemClicked"
                onMouseEntered="#onMouseEnteredUserNameLabel" styleClass="chat-user-item-username"
                text="&lt;Username&gt;" HBox.hgrow="ALWAYS"/>

--- a/src/test/java/com/faforever/client/chat/ChatChannelUserBuilder.java
+++ b/src/test/java/com/faforever/client/chat/ChatChannelUserBuilder.java
@@ -1,6 +1,5 @@
 package com.faforever.client.chat;
 
-import com.faforever.client.clan.Clan;
 import com.faforever.client.game.PlayerStatus;
 import com.faforever.client.player.Player;
 import javafx.scene.image.Image;
@@ -55,11 +54,6 @@ public final class ChatChannelUserBuilder {
 
   public ChatChannelUserBuilder avatar(Image avatar) {
     chatChannelUser.setAvatar(avatar);
-    return this;
-  }
-
-  public ChatChannelUserBuilder clan(Clan clan) {
-    chatChannelUser.setClan(clan);
     return this;
   }
 

--- a/src/test/java/com/faforever/client/chat/ChatChannelUserItemControllerTest.java
+++ b/src/test/java/com/faforever/client/chat/ChatChannelUserItemControllerTest.java
@@ -1,7 +1,5 @@
 package com.faforever.client.chat;
 
-import com.faforever.client.chat.avatar.AvatarBean;
-import com.faforever.client.clan.Clan;
 import com.faforever.client.fx.MouseEvents;
 import com.faforever.client.fx.PlatformService;
 import com.faforever.client.i18n.I18n;
@@ -14,9 +12,7 @@ import com.faforever.client.test.AbstractPlainJavaFxTest;
 import com.faforever.client.theme.UiService;
 import com.faforever.client.util.TimeService;
 import com.google.common.eventbus.EventBus;
-import javafx.collections.ObservableList;
 import javafx.scene.control.ContextMenu;
-import javafx.scene.control.MenuItem;
 import javafx.scene.image.Image;
 import javafx.scene.input.ContextMenuEvent;
 import javafx.scene.input.MouseButton;
@@ -28,9 +24,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.testfx.util.WaitForAsyncUtils;
 
-import java.net.URL;
-import java.util.Optional;
-
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertFalse;
@@ -38,7 +31,6 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyDouble;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -63,20 +55,10 @@ public class ChatChannelUserItemControllerTest extends AbstractPlainJavaFxTest {
   @Mock
   private TimeService timeService;
 
-  private Clan testClan;
-
   @Before
   public void setUp() throws Exception {
     Preferences preferences = new Preferences();
     when(preferencesService.getPreferences()).thenReturn(preferences);
-
-    when(i18n.get(eq("clan.messageLeader"))).thenReturn("Message clan leader");
-    when(i18n.get(eq("clan.visitPage"))).thenReturn("Visit clan website");
-    testClan = new Clan();
-    testClan.setTag("e");
-    testClan.setLeader(PlayerBuilder.create("test_player").defaultValues().id(2).get());
-    when(playerService.isOnline(eq(2))).thenReturn(true);
-    when(playerService.getCurrentPlayer()).thenReturn(Optional.of(new Player("junit")));
 
     instance = new ChatUserItemController(
         preferencesService,
@@ -179,73 +161,6 @@ public class ChatChannelUserItemControllerTest extends AbstractPlainJavaFxTest {
     verify(uiService).loadFxml("theme/chat/chat_user_context_menu.fxml");
     verify(contextMenuController).setChatUser(chatUser);
     verify(contextMenu).show(any(Window.class), anyDouble(), anyDouble());
-  }
-
-  @Test
-  public void testContactClanLeaderNotShowing() throws Exception {
-    Player player = PlayerBuilder.create("junit")
-        .defaultValues()
-        .id(2)
-        .clan("e")
-        .avatar(new AvatarBean(new URL("http://example.com/avatar.png"), "dog"))
-        .get();
-    when(playerService.getCurrentPlayer()).thenReturn(Optional.of(player));
-    instance.setChatUser(ChatChannelUserBuilder.create("junit").defaultValues().player(player).clan(testClan).get());
-    WaitForAsyncUtils.waitForFxEvents();
-
-    instance.clanMenu.getOnMouseClicked().handle(null);
-
-    ObservableList<MenuItem> items = instance.clanMenu.getItems();
-    assertThat(items.size(), is(1));
-    boolean containsMessageItem = items.stream().anyMatch((item) -> "Message clan leader".equals(item.getText()));
-    assertThat(containsMessageItem, is(false));
-  }
-
-  @Test
-  public void testContactClanLeaderShowingSameClan() throws Exception {
-    Player player = PlayerBuilder.create("junit")
-        .defaultValues()
-        .clan("e")
-        .avatar(new AvatarBean(new URL("http://example.com/avatar.png"), "dog"))
-        .get();
-    Player otherClanLeader = PlayerBuilder.create("test_player")
-        .id(2)
-        .defaultValues()
-        .clan("e")
-        .avatar(new AvatarBean(new URL("http://example.com/avatar.png"), "dog"))
-        .get();
-    when(playerService.getCurrentPlayer()).thenReturn(Optional.of(otherClanLeader));
-    instance.setChatUser(ChatChannelUserBuilder.create("junit").defaultValues().player(player).clan(testClan).get());
-    WaitForAsyncUtils.waitForFxEvents();
-
-    instance.clanMenu.getOnMouseClicked().handle(null);
-
-    ObservableList<MenuItem> items = instance.clanMenu.getItems();
-    assertThat(items.size(), is(2));
-    boolean containsMessageItem = items.stream().anyMatch((item) -> "Message clan leader".equals(item.getText()));
-    assertThat(containsMessageItem, is(true));
-  }
-
-  @Test
-  public void testContactClanLeaderShowingOtherClan() throws Exception {
-    Player player = PlayerBuilder.create("junit")
-        .defaultValues()
-        .clan("e")
-        .get();
-    Player otherClanLeader = PlayerBuilder.create("test_player")
-        .defaultValues()
-        .clan("not")
-        .get();
-    when(playerService.getCurrentPlayer()).thenReturn(Optional.of(otherClanLeader));
-    instance.setChatUser(ChatChannelUserBuilder.create("junit").defaultValues().player(player).clan(testClan).get());
-    WaitForAsyncUtils.waitForFxEvents();
-
-    instance.clanMenu.getOnMouseClicked().handle(null);
-
-    ObservableList<MenuItem> items = instance.clanMenu.getItems();
-    assertThat(items.size(), is(2));
-    boolean containsMessageItem = items.stream().anyMatch((item) -> "Message clan leader".equals(item.getText()));
-    assertThat(containsMessageItem, is(true));
   }
 
 

--- a/src/test/java/com/faforever/client/chat/ChatUserServiceTest.java
+++ b/src/test/java/com/faforever/client/chat/ChatUserServiceTest.java
@@ -5,7 +5,6 @@ import com.faforever.client.chat.avatar.AvatarService;
 import com.faforever.client.chat.event.ChatUserGameChangeEvent;
 import com.faforever.client.chat.event.ChatUserPopulateEvent;
 import com.faforever.client.clan.Clan;
-import com.faforever.client.clan.ClanService;
 import com.faforever.client.game.Game;
 import com.faforever.client.game.GameBuilder;
 import com.faforever.client.game.PlayerStatus;
@@ -26,7 +25,6 @@ import org.testfx.util.WaitForAsyncUtils;
 
 import java.net.URL;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -52,8 +50,6 @@ public class ChatUserServiceTest extends AbstractPlainJavaFxTest {
   @Mock
   private EventBus eventBus;
   @Mock
-  private ClanService clanService;
-  @Mock
   private MapService mapService;
   @Mock
   private AvatarBean avatar;
@@ -66,7 +62,6 @@ public class ChatUserServiceTest extends AbstractPlainJavaFxTest {
     avatarURL = new URL("http://avatar.png");
     testClan = new Clan();
     testClan.setTag("testClan");
-    when(clanService.getClanByTag(anyString())).thenReturn(CompletableFuture.completedFuture(Optional.of(testClan)));
     when(countryFlagService.loadCountryFlag(anyString())).thenReturn(Optional.of(mock(Image.class)));
     when(uiService.getThemeImage(anyString())).thenReturn(mock(Image.class));
     when(mapService.loadPreview(anyString(), any(PreviewSize.class))).thenReturn(mock(Image.class));
@@ -79,7 +74,6 @@ public class ChatUserServiceTest extends AbstractPlainJavaFxTest {
         uiService,
         mapService,
         avatarService,
-        clanService,
         countryFlagService,
         i18n,
         eventBus
@@ -94,7 +88,6 @@ public class ChatUserServiceTest extends AbstractPlainJavaFxTest {
     instance.onChatUserPopulate(new ChatUserPopulateEvent(chatUser));
     WaitForAsyncUtils.waitForFxEvents();
 
-    verify(clanService, never()).getClanByTag(anyString());
     verify(countryFlagService, never()).loadCountryFlag(anyString());
     verify(avatarService, never()).loadAvatar(anyString());
     verify(mapService, never()).loadPreview(anyString(), any(PreviewSize.class));
@@ -111,7 +104,6 @@ public class ChatUserServiceTest extends AbstractPlainJavaFxTest {
     instance.onChatUserGameChange(new ChatUserGameChangeEvent(chatUser));
     WaitForAsyncUtils.waitForFxEvents();
 
-    verify(clanService, never()).getClanByTag(anyString());
     verify(countryFlagService, never()).loadCountryFlag(anyString());
     verify(avatarService, never()).loadAvatar(anyString());
     verify(mapService, never()).loadPreview(anyString(), any(PreviewSize.class));
@@ -127,7 +119,6 @@ public class ChatUserServiceTest extends AbstractPlainJavaFxTest {
     instance.onChatUserPopulate(new ChatUserPopulateEvent(chatUser));
     WaitForAsyncUtils.waitForFxEvents();
 
-    verify(clanService, never()).getClanByTag(anyString());
     verify(countryFlagService, never()).loadCountryFlag(anyString());
     verify(avatarService, never()).loadAvatar(anyString());
     verify(mapService, never()).loadPreview(anyString(), any(PreviewSize.class));
@@ -144,8 +135,6 @@ public class ChatUserServiceTest extends AbstractPlainJavaFxTest {
     instance.onChatUserPopulate(new ChatUserPopulateEvent(chatUser));
     WaitForAsyncUtils.waitForFxEvents();
 
-    verify(clanService).getClanByTag(testClan.getTag());
-    assertEquals(chatUser.getClan().orElse(null), testClan);
     assertEquals(chatUser.getClanTag().orElse(null), String.format("[%s]", testClan.getTag()));
   }
 
@@ -159,8 +148,6 @@ public class ChatUserServiceTest extends AbstractPlainJavaFxTest {
     instance.onChatUserPopulate(new ChatUserPopulateEvent(chatUser));
     WaitForAsyncUtils.waitForFxEvents();
 
-    verify(clanService, never()).getClanByTag(anyString());
-    assertTrue(chatUser.getClan().isEmpty());
     assertTrue(chatUser.getClanTag().isEmpty());
   }
 


### PR DESCRIPTION
Fixes #2020

The removal of the clan menu would cut down significantly on a blocking api call which is part of the issue with the cpu usage.
If it is worth the slowdown then we could keep it.