### PR TITLE
Limit garage collecter and use g1gc

### DIFF
--- a/.idea/runConfigurations/Main.xml
+++ b/.idea/runConfigurations/Main.xml
@@ -5,7 +5,7 @@
     </envs>
     <option name="MAIN_CLASS_NAME" value="com.faforever.client.Main" />
     <module name="downlords-faf-client.main" />
-    <option name="VM_PARAMETERS" value="-DnativeDir=build/resources/native -Dprism.dirtyopts=false -Xms128m -Xmx712m -XX:MinHeapFreeRatio=15 -XX:MaxHeapFreeRatio=33 -XX:+HeapDumpOnOutOfMemoryError -XX:+UseStringDeduplication -javaagent:webview-patch/build/libs/webview-patch.jar -Djava.net.preferIPv4Stack=true -XX:TieredStopAtLevel=1 -noverify" />
+    <option name="VM_PARAMETERS" value="-DnativeDir=build/resources/native -Dprism.dirtyopts=false -Xms128m -Xmx712m -XX:MinHeapFreeRatio=15 -XX:MaxHeapFreeRatio=33 -XX:+HeapDumpOnOutOfMemoryError -XX:+UseStringDeduplication -XX:ConcGCThreads=1 -XX:ParallelGCThreads=1 -XX:+UseG1GC -javaagent:webview-patch/build/libs/webview-patch.jar -Djava.net.preferIPv4Stack=true -XX:TieredStopAtLevel=1 -noverify" />
     <RunnerSettings RunnerId="Profile ">
       <option name="myExternalizedOptions" value="additional-options2=onexit\=snapshot,_no_java_version_check" />
     </RunnerSettings>

--- a/.idea/runConfigurations/Main_with_Reload.xml
+++ b/.idea/runConfigurations/Main_with_Reload.xml
@@ -5,7 +5,7 @@
     </envs>
     <option name="MAIN_CLASS_NAME" value="com.faforever.client.Main" />
     <module name="downlords-faf-client.main" />
-    <option name="VM_PARAMETERS" value="-DnativeDir=build/resources/native -Dprism.dirtyopts=false -Xms128m -Xmx712m -XX:MinHeapFreeRatio=15 -XX:MaxHeapFreeRatio=33 -XX:+HeapDumpOnOutOfMemoryError -XX:+UseStringDeduplication -javaagent:webview-patch/build/libs/webview-patch.jar -Djava.net.preferIPv4Stack=true -XX:TieredStopAtLevel=1 -noverify" />
+    <option name="VM_PARAMETERS" value="-DnativeDir=build/resources/native -Dprism.dirtyopts=false -Xms128m -Xmx712m -XX:MinHeapFreeRatio=15 -XX:MaxHeapFreeRatio=33 -XX:+HeapDumpOnOutOfMemoryError -XX:+UseStringDeduplication -XX:ConcGCThreads=1 -XX:ParallelGCThreads=1 -XX:+UseG1GC -javaagent:webview-patch/build/libs/webview-patch.jar -Djava.net.preferIPv4Stack=true -XX:TieredStopAtLevel=1 -noverify" />
     <method v="2">
       <option name="Make" enabled="true" />
     </method>

--- a/downlords-faf-client.install4j
+++ b/downlords-faf-client.install4j
@@ -46,6 +46,9 @@
 
 # Adjust maximum memory usage to 712MiB
 -Xmx712m
+-XX:ConcGCThreads=1
+-XX:ParallelGCThreads=1
+-XX:+UseG1GC
 -Djava.library.path=.</content>
       </vmOptionsFile>
       <iconImageFiles>


### PR DESCRIPTION
Fixes #1806 

Limits the garbage collector to 1 thread and specifies usage of g1gc. This seemed to improve client responsiveness on my machine as well.