### PR TITLE
Use Flowless over listview for chat user list

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -14,15 +14,6 @@
       <option name="JD_ALIGN_EXCEPTION_COMMENTS" value="false" />
       <option name="JD_DO_NOT_WRAP_ONE_LINE_COMMENTS" value="true" />
     </JavaCodeStyleSettings>
-    <JetCodeStyleSettings>
-      <option name="PACKAGES_TO_USE_STAR_IMPORTS">
-        <value>
-          <package name="java.util" withSubpackages="false" static="false" />
-          <package name="kotlinx.android.synthetic" withSubpackages="true" static="false" />
-          <package name="io.ktor" withSubpackages="true" static="false" />
-        </value>
-      </option>
-    </JetCodeStyleSettings>
     <XML>
       <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
     </XML>

--- a/build.gradle
+++ b/build.gradle
@@ -253,6 +253,7 @@ dependencies {
   compile("org.openjfx:javafx-media:${javafxVersion}:${javafxPlatform}")
   compile ("com.github.axel1200:discord-rpc:${discordRpcVersion}")
   compile("org.controlsfx:controlsfx:${controlsfxVersion}")
+  compile("org.fxmisc.flowless:flowless:${flowlessVersion}")
 
   compile project(":webview-patch")
   compile("org.javassist:javassist:${project.ext['javassist.version']}")

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,3 +16,4 @@ coverallsGradlePluginVersion=2.10.1
 jnaVersion=5.6.0
 discordRpcVersion=1.6.2-jna
 controlsfxVersion=11.0.3
+flowlessVersion=0.6.2

--- a/src/main/java/com/faforever/client/chat/ChatChannelUser.java
+++ b/src/main/java/com/faforever/client/chat/ChatChannelUser.java
@@ -5,7 +5,6 @@ import com.faforever.client.fx.JavaFxUtil;
 import com.faforever.client.game.PlayerStatus;
 import com.faforever.client.player.Player;
 import com.faforever.client.player.SocialStatus;
-import javafx.beans.InvalidationListener;
 import javafx.beans.binding.Bindings;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.ObjectProperty;
@@ -13,6 +12,7 @@ import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
+import javafx.beans.value.ChangeListener;
 import javafx.scene.image.Image;
 import javafx.scene.paint.Color;
 import lombok.ToString;
@@ -45,13 +45,12 @@ public class ChatChannelUser {
   private final ObjectProperty<Image> gameStatusImage;
   private final StringProperty statusTooltipText;
   private final BooleanProperty displayed;
-  private final BooleanProperty populated;
-  private InvalidationListener socialStatusInvalidationListener;
-  private InvalidationListener gameStatusInvalidationListener;
-  private InvalidationListener clanTagInvalidationListener;
-  private InvalidationListener avatarInvalidationListener;
-  private InvalidationListener countryInvalidationListener;
-  private InvalidationListener populatedInvalidationListener;
+  private ChangeListener<SocialStatus> socialStatusChangeListener;
+  private ChangeListener<PlayerStatus> gameStatusChangeListener;
+  private ChangeListener<String> clanTagChangeListener;
+  private ChangeListener<String> avatarChangeListener;
+  private ChangeListener<String> countryInvalidationListener;
+  private ChangeListener<Boolean> displayedChangeListener;
 
   ChatChannelUser(String username, boolean moderator) {
     this(username, moderator, null);
@@ -74,7 +73,6 @@ public class ChatChannelUser {
     this.gameStatusImage = new SimpleObjectProperty<>();
     this.statusTooltipText = new SimpleStringProperty();
     this.displayed = new SimpleBooleanProperty(false);
-    this.populated = new SimpleBooleanProperty(false);
     if (player != null) {
       player.getChatChannelUsers().add(this);
       socialStatus.setValue(player.getSocialStatus());
@@ -287,85 +285,69 @@ public class ChatChannelUser {
     this.displayed.set(displayed);
   }
 
-  public BooleanProperty displayedProperty() {
-    return displayed;
+  public ChangeListener<Boolean> getDisplayedChangeListener() {
+    return displayedChangeListener;
   }
 
-  public boolean isPopulated() {
-    return populated.get();
-  }
-
-  public void setPopulated(boolean populated) {
-    this.populated.set(populated);
-  }
-
-  public BooleanProperty populatedProperty() {
-    return populated;
-  }
-
-  public InvalidationListener getPopulatedInvalidationListener() {
-    return populatedInvalidationListener;
-  }
-
-  public void setPopulatedInvalidationListener(InvalidationListener listener) {
+  public void setDisplayedChangeListener(ChangeListener<Boolean> listener) {
     if (player.get() != null) {
-      if (populatedInvalidationListener != null) {
-        JavaFxUtil.removeListener(populatedProperty(), populatedInvalidationListener);
+      if (displayedChangeListener != null) {
+        JavaFxUtil.removeListener(displayed, displayedChangeListener);
       }
-      populatedInvalidationListener = listener;
-      if (populatedInvalidationListener != null) {
-        JavaFxUtil.addListener(populatedProperty(), populatedInvalidationListener);
+      displayedChangeListener = listener;
+      if (displayedChangeListener != null) {
+        JavaFxUtil.addListener(displayed, displayedChangeListener);
       }
     }
   }
 
-  public InvalidationListener getSocialStatusInvalidationListener() {
-    return socialStatusInvalidationListener;
+  public ChangeListener<SocialStatus> getSocialStatusChangeListener() {
+    return socialStatusChangeListener;
   }
 
-  public void setSocialStatusInvalidationListener(InvalidationListener listener) {
-    if (socialStatusInvalidationListener != null) {
-      JavaFxUtil.removeListener(socialStatus, socialStatusInvalidationListener);
+  public void setSocialStatusChangeListener(ChangeListener<SocialStatus> listener) {
+    if (socialStatusChangeListener != null) {
+      JavaFxUtil.removeListener(socialStatus, socialStatusChangeListener);
     }
-    socialStatusInvalidationListener = listener;
-    if (socialStatusInvalidationListener != null) {
-      JavaFxUtil.addListener(socialStatus, socialStatusInvalidationListener);
-    }
-  }
-
-  public InvalidationListener getGameStatusInvalidationListener() {
-    return gameStatusInvalidationListener;
-  }
-
-  public void setGameStatusInvalidationListener(InvalidationListener listener) {
-    if (gameStatusInvalidationListener != null) {
-      JavaFxUtil.removeListener(gameStatus, gameStatusInvalidationListener);
-    }
-    gameStatusInvalidationListener = listener;
-    if (gameStatusInvalidationListener != null) {
-      JavaFxUtil.addListener(gameStatus, gameStatusInvalidationListener);
+    socialStatusChangeListener = listener;
+    if (socialStatusChangeListener != null) {
+      JavaFxUtil.addListener(socialStatus, socialStatusChangeListener);
     }
   }
 
-  public InvalidationListener getClanTagInvalidationListener() {
-    return clanTagInvalidationListener;
+  public ChangeListener<PlayerStatus> getGameStatusChangeListener() {
+    return gameStatusChangeListener;
   }
 
-  public void setClanTagInvalidationListener(InvalidationListener listener) {
-    if (clanTagInvalidationListener != null) {
-      JavaFxUtil.removeListener(clanTag, clanTagInvalidationListener);
+  public void setGameStatusChangeListener(ChangeListener<PlayerStatus> listener) {
+    if (gameStatusChangeListener != null) {
+      JavaFxUtil.removeListener(gameStatus, gameStatusChangeListener);
     }
-    clanTagInvalidationListener = listener;
-    if (clanTagInvalidationListener != null) {
-      JavaFxUtil.addListener(clanTag, clanTagInvalidationListener);
+    gameStatusChangeListener = listener;
+    if (gameStatusChangeListener != null) {
+      JavaFxUtil.addListener(gameStatus, gameStatusChangeListener);
     }
   }
 
-  public InvalidationListener getCountryInvalidationListener() {
+  public ChangeListener<String> getClanTagChangeListener() {
+    return clanTagChangeListener;
+  }
+
+  public void setClanTagChangeListener(ChangeListener<String> listener) {
+    if (clanTagChangeListener != null) {
+      JavaFxUtil.removeListener(clanTag, clanTagChangeListener);
+    }
+    clanTagChangeListener = listener;
+    if (clanTagChangeListener != null) {
+      JavaFxUtil.addListener(clanTag, clanTagChangeListener);
+    }
+  }
+
+  public ChangeListener<String> getCountryInvalidationListener() {
     return countryInvalidationListener;
   }
 
-  public void setCountryInvalidationListener(InvalidationListener listener) {
+  public void setCountryChangeListener(ChangeListener<String> listener) {
     if (player.get() != null) {
       if (countryInvalidationListener != null) {
         JavaFxUtil.removeListener(player.get().countryProperty(), countryInvalidationListener);
@@ -377,46 +359,46 @@ public class ChatChannelUser {
     }
   }
 
-  public InvalidationListener getAvatarInvalidationListener() {
-    return avatarInvalidationListener;
+  public ChangeListener<String> getAvatarChangeListener() {
+    return avatarChangeListener;
   }
 
-  public void setAvatarInvalidationListener(InvalidationListener listener) {
+  public void setAvatarChangeListener(ChangeListener<String> listener) {
     if (player.get() != null) {
-      if (avatarInvalidationListener != null) {
-        JavaFxUtil.removeListener(player.get().avatarUrlProperty(), avatarInvalidationListener);
+      if (avatarChangeListener != null) {
+        JavaFxUtil.removeListener(player.get().avatarUrlProperty(), avatarChangeListener);
       }
-      avatarInvalidationListener = listener;
-      if (avatarInvalidationListener != null) {
-        JavaFxUtil.addListener(player.get().avatarUrlProperty(), avatarInvalidationListener);
+      avatarChangeListener = listener;
+      if (avatarChangeListener != null) {
+        JavaFxUtil.addListener(player.get().avatarUrlProperty(), avatarChangeListener);
       }
     }
   }
 
   public void removeListeners() {
-    if (avatarInvalidationListener != null) {
-      JavaFxUtil.removeListener(player.get().avatarUrlProperty(), avatarInvalidationListener);
-      avatarInvalidationListener = null;
+    if (avatarChangeListener != null) {
+      JavaFxUtil.removeListener(player.get().avatarUrlProperty(), avatarChangeListener);
+      avatarChangeListener = null;
     }
     if (countryInvalidationListener != null) {
       JavaFxUtil.removeListener(player.get().countryProperty(), countryInvalidationListener);
       countryInvalidationListener = null;
     }
-    if (clanTagInvalidationListener != null) {
-      JavaFxUtil.removeListener(clanTag, clanTagInvalidationListener);
-      clanTagInvalidationListener = null;
+    if (clanTagChangeListener != null) {
+      JavaFxUtil.removeListener(clanTag, clanTagChangeListener);
+      clanTagChangeListener = null;
     }
-    if (gameStatusInvalidationListener != null) {
-      JavaFxUtil.removeListener(gameStatus, gameStatusInvalidationListener);
-      gameStatusInvalidationListener = null;
+    if (gameStatusChangeListener != null) {
+      JavaFxUtil.removeListener(gameStatus, gameStatusChangeListener);
+      gameStatusChangeListener = null;
     }
-    if (socialStatusInvalidationListener != null) {
-      JavaFxUtil.removeListener(socialStatus, socialStatusInvalidationListener);
-      socialStatusInvalidationListener = null;
+    if (socialStatusChangeListener != null) {
+      JavaFxUtil.removeListener(socialStatus, socialStatusChangeListener);
+      socialStatusChangeListener = null;
     }
-    if (populatedInvalidationListener != null) {
-      JavaFxUtil.addListener(populatedProperty(), populatedInvalidationListener);
-      populatedInvalidationListener = null;
+    if (displayedChangeListener != null) {
+      JavaFxUtil.addListener(displayed, displayedChangeListener);
+      displayedChangeListener = null;
     }
   }
 

--- a/src/main/java/com/faforever/client/chat/ChatUserItemController.java
+++ b/src/main/java/com/faforever/client/chat/ChatUserItemController.java
@@ -12,7 +12,6 @@ import com.faforever.client.player.PlayerService;
 import com.faforever.client.preferences.ChatPrefs;
 import com.faforever.client.preferences.PreferencesService;
 import com.faforever.client.theme.UiService;
-import com.faforever.client.util.TimeService;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.eventbus.EventBus;
 import javafx.beans.InvalidationListener;
@@ -54,7 +53,6 @@ public class ChatUserItemController implements Controller<Node> {
   private final EventBus eventBus;
   private final PlayerService playerService;
   private final PlatformService platformService;
-  private final TimeService timeService;
   private final ChatPrefs chatPrefs;
 
   private final InvalidationListener formatChangeListener;
@@ -75,20 +73,17 @@ public class ChatUserItemController implements Controller<Node> {
   protected Tooltip avatarTooltip;
   private GameTooltipController gameInfoController;
   private ChatChannelUser chatUser;
-  private ChatChannelUser oldChatUser;
   private WeakReference<ChatUserContextMenuController> contextMenuController = null;
 
-  // TODO reduce dependencies, rely on eventBus instead
   public ChatUserItemController(PreferencesService preferencesService,
                                 I18n i18n, UiService uiService, EventBus eventBus, PlayerService playerService,
-                                PlatformService platformService, TimeService timeService) {
+                                PlatformService platformService) {
     this.platformService = platformService;
     this.preferencesService = preferencesService;
     this.playerService = playerService;
     this.i18n = i18n;
     this.uiService = uiService;
     this.eventBus = eventBus;
-    this.timeService = timeService;
     this.chatPrefs = preferencesService.getPreferences().getChat();
 
     formatChangeListener = observable -> updateFormat();
@@ -229,26 +224,14 @@ public class ChatUserItemController implements Controller<Node> {
     JavaFxUtil.unbind(countryTooltip.textProperty());
     JavaFxUtil.unbind(statusGameTooltip.textProperty());
 
-    if (oldChatUser != null && !oldChatUser.equals(chatUser)
-        && !oldChatUser.isDisplayed() && chatUser != null) {
-      oldChatUser.setPopulated(false);
-    }
-
     if (this.chatUser != null) {
       this.chatUser.setDisplayed(false);
-      this.chatUser.setPopulated(false);
     }
 
     this.chatUser = chatUser;
 
     if (this.chatUser != null) {
       this.chatUser.setDisplayed(true);
-      this.chatUser.setPopulated(true);
-      InvalidationListener populatedListener = this.chatUser.getPopulatedInvalidationListener();
-      if (populatedListener != null) {
-        populatedListener.invalidated(null);
-      }
-      oldChatUser = this.chatUser;
       JavaFxUtil.bind(usernameLabel.textProperty(), this.chatUser.usernameProperty());
       JavaFxUtil.bind(usernameLabel.styleProperty(), Bindings.createStringBinding(() ->
               chatUser.getColor().map(color -> String.format("-fx-text-fill: %s", JavaFxUtil.toRgbCode(color))).orElse(""),

--- a/src/main/java/com/faforever/client/chat/ChatUserListCell.java
+++ b/src/main/java/com/faforever/client/chat/ChatUserListCell.java
@@ -1,47 +1,39 @@
 package com.faforever.client.chat;
 
 import com.faforever.client.theme.UiService;
-import javafx.scene.control.ListCell;
+import javafx.scene.Node;
+import org.fxmisc.flowless.Cell;
 
-import java.util.Objects;
+public class ChatUserListCell implements Cell<CategoryOrChatUserListItem, Node> {
 
-public class ChatUserListCell extends ListCell<CategoryOrChatUserListItem> {
+  private final Node node;
+  private ChatUserItemController chatUserItemController;
+  private ChatCategoryItemController chatUserCategoryController;
 
-  private final ChatUserItemController chatUserItemController;
-  private final ChatCategoryItemController chatUserCategoryController;
-  private Object oldItem;
-
-  public ChatUserListCell(UiService uiService) {
-    chatUserItemController = uiService.loadFxml("theme/chat/chat_user_item.fxml");
-    chatUserCategoryController = uiService.loadFxml("theme/chat/chat_user_category.fxml");
-
-    setText(null);
+  public ChatUserListCell(CategoryOrChatUserListItem chatUserListItem, UiService uiService) {
+    if (chatUserListItem.getUser() != null) {
+      chatUserItemController = uiService.loadFxml("theme/chat/chat_user_item.fxml");
+      chatUserItemController.setChatUser(chatUserListItem.getUser());
+      node = chatUserItemController.getRoot();
+    } else {
+      chatUserCategoryController = uiService.loadFxml("theme/chat/chat_user_category.fxml");
+      chatUserCategoryController.setChatUserCategory(chatUserListItem.getCategory());
+      node = chatUserCategoryController.getRoot();
+    }
   }
 
   @Override
-  protected void updateItem(CategoryOrChatUserListItem item, boolean empty) {
-    if (Objects.equals(item, oldItem)) {
-      return;
+  public void dispose() {
+    if (chatUserItemController != null) {
+      chatUserItemController.getChatUser().setDisplayed(false);
     }
-    oldItem = item;
-
-    super.updateItem(item, empty);
-
-    if (item == null || empty) {
-      chatUserItemController.setChatUser(null);
+    if (chatUserCategoryController != null) {
       chatUserCategoryController.setChatUserCategory(null);
-      setGraphic(null);
-      return;
     }
+  }
 
-    if (item.getUser() != null) {
-      chatUserCategoryController.setChatUserCategory(null);
-      chatUserItemController.setChatUser(item.getUser());
-      setGraphic(chatUserItemController.getRoot());
-    } else {
-      chatUserItemController.setChatUser(null);
-      chatUserCategoryController.setChatUserCategory(item.getCategory());
-      setGraphic(chatUserCategoryController.getRoot());
-    }
+  @Override
+  public Node getNode() {
+    return node;
   }
 }

--- a/src/main/java/com/faforever/client/chat/ChatUserListCell.java
+++ b/src/main/java/com/faforever/client/chat/ChatUserListCell.java
@@ -24,7 +24,7 @@ public class ChatUserListCell implements Cell<CategoryOrChatUserListItem, Node> 
 
   @Override
   public void dispose() {
-    if (chatUserItemController != null) {
+    if (chatUserItemController != null && chatUserItemController.getChatUser() != null) {
       chatUserItemController.getChatUser().setDisplayed(false);
     }
     if (chatUserCategoryController != null) {

--- a/src/main/java/com/faforever/client/chat/ChatUserService.java
+++ b/src/main/java/com/faforever/client/chat/ChatUserService.java
@@ -49,9 +49,6 @@ public class ChatUserService implements InitializingBean {
 
   public void populateClan(ChatChannelUser chatChannelUser) {
     if (chatChannelUser.isDisplayed()) {
-      if (chatChannelUser.getClan().isPresent()) {
-        return;
-      }
       chatChannelUser.getPlayer().ifPresent(player -> {
         if (player.getClan() != null) {
           clanService.getClanByTag(player.getClan())
@@ -71,9 +68,6 @@ public class ChatUserService implements InitializingBean {
 
   public void populateAvatar(ChatChannelUser chatChannelUser) {
     if (chatChannelUser.isDisplayed()) {
-      if (chatChannelUser.getAvatar().isPresent()) {
-        return;
-      }
       chatChannelUser.getPlayer()
           .ifPresent(player -> {
             Image avatar;
@@ -91,9 +85,6 @@ public class ChatUserService implements InitializingBean {
 
   public void populateCountry(ChatChannelUser chatChannelUser) {
     if (chatChannelUser.isDisplayed()) {
-      if (chatChannelUser.getCountryFlag().isPresent()) {
-        return;
-      }
       chatChannelUser.getPlayer()
           .ifPresent(player -> {
             Optional<Image> countryFlag = countryFlagService.loadCountryFlag(player.getCountry());

--- a/src/main/java/com/faforever/client/chat/ChatUserService.java
+++ b/src/main/java/com/faforever/client/chat/ChatUserService.java
@@ -21,6 +21,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.stereotype.Service;
 
+import java.util.Objects;
 import java.util.Optional;
 
 import static com.faforever.client.chat.ChatColorMode.DEFAULT;
@@ -168,27 +169,27 @@ public class ChatUserService implements InitializingBean {
       populateAvatar(chatChannelUser);
       populateColor(chatChannelUser);
       chatChannelUser.setAvatarChangeListener((observable, oldValue, newValue) -> {
-        if (!oldValue.equals(newValue)) {
+        if (!Objects.equals(oldValue, newValue)) {
           populateAvatar(chatChannelUser);
         }
       });
       chatChannelUser.setClanTagChangeListener((observable, oldValue, newValue) -> {
-        if (!oldValue.equals(newValue)) {
+        if (!Objects.equals(oldValue, newValue)) {
           populateClan(chatChannelUser);
         }
       });
       chatChannelUser.setCountryChangeListener((observable, oldValue, newValue) -> {
-        if (!oldValue.equals(newValue)) {
+        if (!Objects.equals(oldValue, newValue)) {
           populateCountry(chatChannelUser);
         }
       });
       chatChannelUser.setSocialStatusChangeListener((observable, oldValue, newValue) -> {
-        if (!oldValue.equals(newValue)) {
+        if (!Objects.equals(oldValue, newValue)) {
           populateColor(chatChannelUser);
         }
       });
       chatChannelUser.setGameStatusChangeListener((observable, oldValue, newValue) -> {
-        if (!oldValue.equals(newValue)) {
+        if (!Objects.equals(oldValue, newValue)) {
           populateGameImages(chatChannelUser);
         }
       });

--- a/src/main/java/com/faforever/client/chat/ChatUserService.java
+++ b/src/main/java/com/faforever/client/chat/ChatUserService.java
@@ -17,6 +17,7 @@ import com.google.common.eventbus.EventBus;
 import javafx.scene.image.Image;
 import javafx.scene.paint.Color;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.stereotype.Service;
 
@@ -27,6 +28,7 @@ import static com.faforever.client.chat.ChatColorMode.RANDOM;
 import static com.faforever.client.chat.ChatUserCategory.MODERATOR;
 import static java.util.Locale.US;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ChatUserService implements InitializingBean {
@@ -174,30 +176,60 @@ public class ChatUserService implements InitializingBean {
       populateCountry(chatChannelUser);
       populateAvatar(chatChannelUser);
       populateColor(chatChannelUser);
-      chatChannelUser.setAvatarInvalidationListener((observable) -> populateAvatar(chatChannelUser));
-      chatChannelUser.setClanTagInvalidationListener((observable) -> populateClan(chatChannelUser));
-      chatChannelUser.setCountryInvalidationListener((observable) -> populateCountry(chatChannelUser));
-      chatChannelUser.setSocialStatusInvalidationListener((observable) -> populateColor(chatChannelUser));
-      chatChannelUser.setGameStatusInvalidationListener((observable) -> populateGameImages(chatChannelUser));
-      chatChannelUser.setPopulatedInvalidationListener((observable -> {
-        populateGameImages(chatChannelUser);
-        populateClan(chatChannelUser);
-        populateCountry(chatChannelUser);
-        populateAvatar(chatChannelUser);
-        populateColor(chatChannelUser);
-      }));
+      chatChannelUser.setAvatarChangeListener((observable, oldValue, newValue) -> {
+        if (!oldValue.equals(newValue)) {
+          populateAvatar(chatChannelUser);
+        }
+      });
+      chatChannelUser.setClanTagChangeListener((observable, oldValue, newValue) -> {
+        if (!oldValue.equals(newValue)) {
+          populateClan(chatChannelUser);
+        }
+      });
+      chatChannelUser.setCountryChangeListener((observable, oldValue, newValue) -> {
+        if (!oldValue.equals(newValue)) {
+          populateCountry(chatChannelUser);
+        }
+      });
+      chatChannelUser.setSocialStatusChangeListener((observable, oldValue, newValue) -> {
+        if (!oldValue.equals(newValue)) {
+          populateColor(chatChannelUser);
+        }
+      });
+      chatChannelUser.setGameStatusChangeListener((observable, oldValue, newValue) -> {
+        if (!oldValue.equals(newValue)) {
+          populateGameImages(chatChannelUser);
+        }
+      });
+      chatChannelUser.setDisplayedChangeListener((observable, oldValue, newValue) -> {
+        if (oldValue != newValue) {
+          if (newValue) {
+            populateGameImages(chatChannelUser);
+            populateClan(chatChannelUser);
+            populateCountry(chatChannelUser);
+            populateAvatar(chatChannelUser);
+            populateColor(chatChannelUser);
+          } else {
+            chatChannelUser.setStatusTooltipText(null);
+            chatChannelUser.setGameStatusImage(null);
+            chatChannelUser.setMapImage(null);
+            chatChannelUser.setCountryFlag(null);
+            chatChannelUser.setCountryName(null);
+            chatChannelUser.setClan(null);
+            chatChannelUser.setAvatar(null);
+          }
+        }
+      });
     } else {
       chatChannelUser.removeListeners();
       chatChannelUser.setPlayer(null);
-      JavaFxUtil.runLater(() -> {
-        chatChannelUser.setStatusTooltipText(null);
-        chatChannelUser.setGameStatusImage(null);
-        chatChannelUser.setMapImage(null);
-        chatChannelUser.setCountryFlag(null);
-        chatChannelUser.setCountryName(null);
-        chatChannelUser.setClan(null);
-        chatChannelUser.setAvatar(null);
-      });
+      chatChannelUser.setStatusTooltipText(null);
+      chatChannelUser.setGameStatusImage(null);
+      chatChannelUser.setMapImage(null);
+      chatChannelUser.setCountryFlag(null);
+      chatChannelUser.setCountryName(null);
+      chatChannelUser.setClan(null);
+      chatChannelUser.setAvatar(null);
     }
   }
 }

--- a/src/main/java/com/faforever/client/fa/OnGameFullNotifier.java
+++ b/src/main/java/com/faforever/client/fa/OnGameFullNotifier.java
@@ -37,8 +37,7 @@ public class OnGameFullNotifier implements InitializingBean {
   private final MapService mapService;
   private final EventBus eventBus;
   private final GameService gameService;
-  private final ClientProperties clientProperties;
-  private String faWindowTitle;
+  private final String faWindowTitle;
 
   @Inject
   public OnGameFullNotifier(PlatformService platformService, ExecutorService executorService,
@@ -54,7 +53,6 @@ public class OnGameFullNotifier implements InitializingBean {
     this.mapService = mapService;
     this.eventBus = eventBus;
     this.gameService = gameService;
-    this.clientProperties = clientProperties;
     this.faWindowTitle = clientProperties.getForgedAlliance().getWindowTitle();
   }
 

--- a/src/main/java/com/faforever/client/player/Player.java
+++ b/src/main/java/com/faforever/client/player/Player.java
@@ -1,6 +1,7 @@
 package com.faforever.client.player;
 
 import com.faforever.client.chat.ChatChannelUser;
+import com.faforever.client.chat.avatar.AvatarBean;
 import com.faforever.client.game.Game;
 import com.faforever.client.game.PlayerStatus;
 import com.faforever.client.leaderboard.LeaderboardRating;
@@ -18,6 +19,7 @@ import javafx.beans.property.StringProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.collections.ObservableSet;
+import lombok.SneakyThrows;
 
 import java.time.Instant;
 import java.util.HashMap;
@@ -179,6 +181,21 @@ public class Player {
 
   public StringProperty countryProperty() {
     return country;
+  }
+
+  @SneakyThrows
+  public void setAvatar(AvatarBean avatar) {
+    if (avatar != null) {
+      if (avatar.getUrl() != null) {
+        setAvatarUrl(avatar.getUrl().toExternalForm());
+      } else {
+        setAvatarUrl(null);
+      }
+      setAvatarTooltip(avatar.getDescription());
+    } else {
+      setAvatarUrl(null);
+      setAvatarTooltip(null);
+    }
   }
 
   public String getAvatarUrl() {

--- a/src/main/resources/theme/chat/channel_tab.fxml
+++ b/src/main/resources/theme/chat/channel_tab.fxml
@@ -2,7 +2,6 @@
 
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.control.Button?>
-<?import javafx.scene.control.ListView?>
 <?import javafx.scene.control.Separator?>
 <?import javafx.scene.control.SplitPane?>
 <?import javafx.scene.control.Tab?>
@@ -78,16 +77,9 @@
                             <Insets left="10.0" right="10.0"/>
                         </VBox.margin>
                     </HBox>
-                    <AnchorPane maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308"
-                                VBox.vgrow="ALWAYS">
-                        <children>
-                            <ListView fx:id="chatUserListView" maxHeight="1.7976931348623157E308"
-                                      maxWidth="1.7976931348623157E308" styleClass="chat-user-list-view"
-                                      AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0"
-                                      AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
-                            </ListView>
-                        </children>
-                    </AnchorPane>
+                    <VBox fx:id="chatUserListViewBox" maxHeight="1.7976931348623157E308"
+                          maxWidth="1.7976931348623157E308"
+                          VBox.vgrow="ALWAYS"/>
                 </children>
           </VBox>
         </SplitPane>

--- a/src/main/resources/theme/chat/chat_user_item.fxml
+++ b/src/main/resources/theme/chat/chat_user_item.fxml
@@ -14,8 +14,7 @@
                     onMouseClicked="#onClanMenuRequested"
                     styleClass="chat-user-control-clan" text="[CLAN]"/>
         <Label fx:id="usernameLabel" maxWidth="1.7976931348623157E308" minWidth="0.0" onMouseClicked="#onItemClicked"
-               styleClass="chat-user-item-username"
-               text="&lt;Username&gt;" HBox.hgrow="ALWAYS"/>
+               styleClass="chat-user-item-username" text="&lt;Username&gt;" HBox.hgrow="ALWAYS"/>
         <ImageView fx:id="playerStatusIndicator"/>
         <ImageView fx:id="playerMapImage" fitHeight="16.0" fitWidth="16.0"/>
     </children>

--- a/src/main/resources/theme/style.css
+++ b/src/main/resources/theme/style.css
@@ -276,6 +276,10 @@
   -fx-padding: 0;
 }
 
+.chat-user-item-username {
+  -fx-text-fill: -fx-text-color;
+}
+
 .chat-user-list-view .list-cell {
   -fx-background-color: transparent;
   -fx-padding: 1px 8px 1px 8px;
@@ -284,6 +288,7 @@
 .chat-user-list-category {
   -fx-padding: 20px 0px 10px 0px;
   -fx-font-weight: bold;
+  -fx-text-fill: -fx-text-color;
 }
 
 /***************** Chat User Control *****************/

--- a/src/test/java/com/faforever/client/chat/ChannelTabControllerTest.java
+++ b/src/test/java/com/faforever/client/chat/ChannelTabControllerTest.java
@@ -25,7 +25,6 @@ import javafx.collections.ObservableMap;
 import javafx.scene.control.TabPane;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyEvent;
-import javafx.scene.layout.Pane;
 import javafx.scene.paint.Color;
 import org.junit.Before;
 import org.junit.Test;
@@ -86,8 +85,6 @@ public class ChannelTabControllerTest extends AbstractPlainJavaFxTest {
   @Mock
   private UiService uiService;
   @Mock
-  private ChatUserItemController chatUserItemController;
-  @Mock
   private ChatCategoryItemController chatCategoryItemController;
   @Mock
   private WebViewConfigurer webViewConfigurer;
@@ -122,9 +119,7 @@ public class ChannelTabControllerTest extends AbstractPlainJavaFxTest {
     when(preferencesService.getPreferences()).thenReturn(preferences);
     when(userService.getUsername()).thenReturn(USER_NAME);
     when(uiService.loadFxml("theme/chat/user_filter.fxml")).thenReturn(userFilterController);
-    when(uiService.loadFxml("theme/chat/chat_user_item.fxml")).thenReturn(chatUserItemController);
     when(uiService.loadFxml("theme/chat/chat_user_category.fxml")).thenReturn(chatCategoryItemController);
-    when(chatUserItemController.getRoot()).thenReturn(new Pane());
     when(uiService.getThemeFileUrl(CHAT_CONTAINER)).thenReturn(getClass().getResource("/theme/chat/chat_container.html"));
 
     loadFxml("theme/chat/user_filter.fxml", clazz -> userFilterController);

--- a/src/test/java/com/faforever/client/chat/ChatChannelUserBuilder.java
+++ b/src/test/java/com/faforever/client/chat/ChatChannelUserBuilder.java
@@ -98,9 +98,4 @@ public final class ChatChannelUserBuilder {
     chatChannelUser.setDisplayed(displayed);
     return this;
   }
-
-  public ChatChannelUserBuilder populated(boolean populated) {
-    chatChannelUser.setPopulated(populated);
-    return this;
-  }
 }

--- a/src/test/java/com/faforever/client/chat/ChatChannelUserItemControllerTest.java
+++ b/src/test/java/com/faforever/client/chat/ChatChannelUserItemControllerTest.java
@@ -85,8 +85,7 @@ public class ChatChannelUserItemControllerTest extends AbstractPlainJavaFxTest {
         uiService,
         eventBus,
         playerService,
-        platformService,
-        timeService
+        platformService
     );
     loadFxml("theme/chat/chat_user_item.fxml", param -> instance);
   }

--- a/src/test/java/com/faforever/client/chat/ChatUserServiceTest.java
+++ b/src/test/java/com/faforever/client/chat/ChatUserServiceTest.java
@@ -20,7 +20,7 @@ import com.faforever.client.remote.domain.GameStatus;
 import com.faforever.client.test.AbstractPlainJavaFxTest;
 import com.faforever.client.theme.UiService;
 import com.google.common.eventbus.EventBus;
-import javafx.beans.InvalidationListener;
+import javafx.beans.value.ChangeListener;
 import javafx.collections.FXCollections;
 import javafx.scene.image.Image;
 import javafx.scene.paint.Color;
@@ -117,12 +117,12 @@ public class ChatUserServiceTest extends AbstractPlainJavaFxTest {
     verify(avatarService, never()).loadAvatar(anyString());
     verify(mapService, never()).loadPreview(anyString(), any(PreviewSize.class));
     verify(uiService, never()).getThemeImage(anyString());
-    assertNull(chatUser.getAvatarInvalidationListener());
-    assertNull(chatUser.getSocialStatusInvalidationListener());
-    assertNull(chatUser.getClanTagInvalidationListener());
+    assertNull(chatUser.getAvatarChangeListener());
+    assertNull(chatUser.getSocialStatusChangeListener());
+    assertNull(chatUser.getClanTagChangeListener());
     assertNull(chatUser.getCountryInvalidationListener());
-    assertNull(chatUser.getGameStatusInvalidationListener());
-    assertNull(chatUser.getPopulatedInvalidationListener());
+    assertNull(chatUser.getGameStatusChangeListener());
+    assertNull(chatUser.getDisplayedChangeListener());
   }
 
   @Test
@@ -137,12 +137,12 @@ public class ChatUserServiceTest extends AbstractPlainJavaFxTest {
     verify(avatarService, never()).loadAvatar(anyString());
     verify(mapService, never()).loadPreview(anyString(), any(PreviewSize.class));
     verify(uiService, never()).getThemeImage(anyString());
-    assertNotNull(chatUser.getAvatarInvalidationListener());
+    assertNotNull(chatUser.getAvatarChangeListener());
     assertNotNull(chatUser.getSocialStatus());
-    assertNotNull(chatUser.getClanTagInvalidationListener());
+    assertNotNull(chatUser.getClanTagChangeListener());
     assertNotNull(chatUser.getCountryInvalidationListener());
-    assertNotNull(chatUser.getGameStatusInvalidationListener());
-    assertNotNull(chatUser.getPopulatedInvalidationListener());
+    assertNotNull(chatUser.getGameStatusChangeListener());
+    assertNotNull(chatUser.getDisplayedChangeListener());
   }
 
   @Test
@@ -151,23 +151,23 @@ public class ChatUserServiceTest extends AbstractPlainJavaFxTest {
     instance.associatePlayerToChatUser(chatUser, player1);
     WaitForAsyncUtils.waitForFxEvents();
 
-    InvalidationListener gameStatusListener = chatUser.getGameStatusInvalidationListener();
-    InvalidationListener socialStatusListener = chatUser.getSocialStatusInvalidationListener();
-    InvalidationListener clanTagListener = chatUser.getClanTagInvalidationListener();
-    InvalidationListener avatarListener = chatUser.getAvatarInvalidationListener();
-    InvalidationListener countryListener = chatUser.getCountryInvalidationListener();
-    InvalidationListener populatedListener = chatUser.getPopulatedInvalidationListener();
+    ChangeListener<PlayerStatus> gameStatusListener = chatUser.getGameStatusChangeListener();
+    ChangeListener<SocialStatus> socialStatusListener = chatUser.getSocialStatusChangeListener();
+    ChangeListener<String> clanTagListener = chatUser.getClanTagChangeListener();
+    ChangeListener<String> avatarListener = chatUser.getAvatarChangeListener();
+    ChangeListener<String> countryListener = chatUser.getCountryInvalidationListener();
+    ChangeListener<Boolean> displayedListener = chatUser.getDisplayedChangeListener();
 
     Player player2 = PlayerBuilder.create("junit2").defaultValues().clan(testClan.getTag()).get();
     instance.associatePlayerToChatUser(chatUser, player2);
     WaitForAsyncUtils.waitForFxEvents();
 
-    assertNotEquals(gameStatusListener, chatUser.getGameStatusInvalidationListener());
-    assertNotEquals(socialStatusListener, chatUser.getSocialStatusInvalidationListener());
-    assertNotEquals(clanTagListener, chatUser.getClanTagInvalidationListener());
-    assertNotEquals(avatarListener, chatUser.getAvatarInvalidationListener());
+    assertNotEquals(gameStatusListener, chatUser.getGameStatusChangeListener());
+    assertNotEquals(socialStatusListener, chatUser.getSocialStatusChangeListener());
+    assertNotEquals(clanTagListener, chatUser.getClanTagChangeListener());
+    assertNotEquals(avatarListener, chatUser.getAvatarChangeListener());
     assertNotEquals(countryListener, chatUser.getCountryInvalidationListener());
-    assertNotEquals(populatedListener, chatUser.getPopulatedInvalidationListener());
+    assertNotEquals(displayedListener, chatUser.getDisplayedChangeListener());
   }
 
   @Test
@@ -176,22 +176,22 @@ public class ChatUserServiceTest extends AbstractPlainJavaFxTest {
     instance.associatePlayerToChatUser(chatUser, player1);
     WaitForAsyncUtils.waitForFxEvents();
 
-    assertNotNull(chatUser.getGameStatusInvalidationListener());
-    assertNotNull(chatUser.getSocialStatusInvalidationListener());
-    assertNotNull(chatUser.getClanTagInvalidationListener());
-    assertNotNull(chatUser.getAvatarInvalidationListener());
+    assertNotNull(chatUser.getGameStatusChangeListener());
+    assertNotNull(chatUser.getSocialStatusChangeListener());
+    assertNotNull(chatUser.getClanTagChangeListener());
+    assertNotNull(chatUser.getAvatarChangeListener());
     assertNotNull(chatUser.getCountryInvalidationListener());
-    assertNotNull(chatUser.getPopulatedInvalidationListener());
+    assertNotNull(chatUser.getDisplayedChangeListener());
 
     instance.associatePlayerToChatUser(chatUser, null);
     WaitForAsyncUtils.waitForFxEvents();
 
-    assertNull(chatUser.getGameStatusInvalidationListener());
-    assertNull(chatUser.getSocialStatusInvalidationListener());
-    assertNull(chatUser.getClanTagInvalidationListener());
-    assertNull(chatUser.getAvatarInvalidationListener());
+    assertNull(chatUser.getGameStatusChangeListener());
+    assertNull(chatUser.getSocialStatusChangeListener());
+    assertNull(chatUser.getClanTagChangeListener());
+    assertNull(chatUser.getAvatarChangeListener());
     assertNull(chatUser.getCountryInvalidationListener());
-    assertNull(chatUser.getPopulatedInvalidationListener());
+    assertNull(chatUser.getDisplayedChangeListener());
   }
 
   @Test

--- a/src/test/java/com/faforever/client/chat/ChatUserServiceTest.java
+++ b/src/test/java/com/faforever/client/chat/ChatUserServiceTest.java
@@ -72,7 +72,7 @@ public class ChatUserServiceTest extends AbstractPlainJavaFxTest {
   @Mock
   private MapService mapService;
 
-
+  private Player player;
   private AvatarBean avatar;
   private Preferences preferences;
   private ChatChannelUser chatUser;
@@ -80,6 +80,7 @@ public class ChatUserServiceTest extends AbstractPlainJavaFxTest {
 
   @Before
   public void setUp() throws Exception {
+    player = PlayerBuilder.create("junit").defaultValues().get();
     avatar = AvatarBeanBuilder.create().defaultValues().get();
     chatUser = ChatChannelUserBuilder.create("junit").defaultValues().get();
     preferences = PreferencesBuilder.create().defaultValues()
@@ -129,7 +130,6 @@ public class ChatUserServiceTest extends AbstractPlainJavaFxTest {
   @Test
   public void testChatUserNotDisplayed() {
     chatUser.setDisplayed(false);
-    Player player = PlayerBuilder.create("test").defaultValues().get();
     instance.associatePlayerToChatUser(chatUser, player);
     WaitForAsyncUtils.waitForFxEvents();
 
@@ -147,8 +147,46 @@ public class ChatUserServiceTest extends AbstractPlainJavaFxTest {
   }
 
   @Test
+  public void testChatUserNotDisplayedToDisplayed() {
+    chatUser.setDisplayed(false);
+    instance.associatePlayerToChatUser(chatUser, player);
+    chatUser.setDisplayed(true);
+    WaitForAsyncUtils.waitForFxEvents();
+
+    verify(clanService).getClanByTag(anyString());
+    verify(countryFlagService).loadCountryFlag(anyString());
+    verify(avatarService).loadAvatar(anyString());
+    assertNotNull(chatUser.getAvatarChangeListener());
+    assertNotNull(chatUser.getSocialStatus());
+    assertNotNull(chatUser.getClanTagChangeListener());
+    assertNotNull(chatUser.getCountryInvalidationListener());
+    assertNotNull(chatUser.getGameStatusChangeListener());
+    assertNotNull(chatUser.getDisplayedChangeListener());
+  }
+
+  @Test
+  public void testChatUserDisplayedToNotDisplayed() {
+    chatUser.setDisplayed(true);
+    instance.associatePlayerToChatUser(chatUser, player);
+    WaitForAsyncUtils.waitForFxEvents();
+    chatUser.setDisplayed(false);
+    WaitForAsyncUtils.waitForFxEvents();
+
+    verify(clanService).getClanByTag(anyString());
+    verify(countryFlagService).loadCountryFlag(anyString());
+    verify(avatarService).loadAvatar(anyString());
+    assertTrue(chatUser.getStatusTooltipText().isEmpty());
+    assertTrue(chatUser.getGameStatusImage().isEmpty());
+    assertTrue(chatUser.getMapImage().isEmpty());
+    assertTrue(chatUser.getCountryFlag().isEmpty());
+    assertTrue(chatUser.getCountryName().isEmpty());
+    assertTrue(chatUser.getClan().isEmpty());
+    assertTrue(chatUser.getAvatar().isEmpty());
+  }
+
+  @Test
   public void testListenersRemovedOnSecondAssociation() {
-    Player player1 = PlayerBuilder.create("junit1").defaultValues().clan(testClan.getTag()).get();
+    Player player1 = PlayerBuilder.create("junit1").defaultValues().get();
     instance.associatePlayerToChatUser(chatUser, player1);
     WaitForAsyncUtils.waitForFxEvents();
 
@@ -159,7 +197,7 @@ public class ChatUserServiceTest extends AbstractPlainJavaFxTest {
     ChangeListener<String> countryListener = chatUser.getCountryInvalidationListener();
     ChangeListener<Boolean> displayedListener = chatUser.getDisplayedChangeListener();
 
-    Player player2 = PlayerBuilder.create("junit2").defaultValues().clan(testClan.getTag()).get();
+    Player player2 = PlayerBuilder.create("junit2").defaultValues().get();
     instance.associatePlayerToChatUser(chatUser, player2);
     WaitForAsyncUtils.waitForFxEvents();
 
@@ -173,8 +211,7 @@ public class ChatUserServiceTest extends AbstractPlainJavaFxTest {
 
   @Test
   public void testListenersRemovedOnNullAssociation() {
-    Player player1 = PlayerBuilder.create("junit1").defaultValues().clan(testClan.getTag()).get();
-    instance.associatePlayerToChatUser(chatUser, player1);
+    instance.associatePlayerToChatUser(chatUser, player);
     WaitForAsyncUtils.waitForFxEvents();
 
     assertNotNull(chatUser.getGameStatusChangeListener());
@@ -197,7 +234,7 @@ public class ChatUserServiceTest extends AbstractPlainJavaFxTest {
 
   @Test
   public void testClanNotNull() {
-    Player player = PlayerBuilder.create("junit").defaultValues().clan(testClan.getTag()).get();
+    player.setClan(testClan.getTag());
     instance.associatePlayerToChatUser(chatUser, player);
     WaitForAsyncUtils.waitForFxEvents();
 
@@ -211,7 +248,7 @@ public class ChatUserServiceTest extends AbstractPlainJavaFxTest {
     Clan newClan = new Clan();
     newClan.setTag("NC");
     when(clanService.getClanByTag(newClan.getTag())).thenReturn(CompletableFuture.completedFuture(Optional.of(newClan)));
-    Player player = PlayerBuilder.create("junit").defaultValues().clan(testClan.getTag()).get();
+    player.setClan(testClan.getTag());
     instance.associatePlayerToChatUser(chatUser, player);
     player.setClan(newClan.getTag());
     WaitForAsyncUtils.waitForFxEvents();
@@ -224,7 +261,7 @@ public class ChatUserServiceTest extends AbstractPlainJavaFxTest {
 
   @Test
   public void testClanSameChange() {
-    Player player = PlayerBuilder.create("junit").defaultValues().clan(testClan.getTag()).get();
+    player.setClan(testClan.getTag());
     instance.associatePlayerToChatUser(chatUser, player);
     player.setClan(testClan.getTag());
     WaitForAsyncUtils.waitForFxEvents();
@@ -236,7 +273,7 @@ public class ChatUserServiceTest extends AbstractPlainJavaFxTest {
 
   @Test
   public void testClanNull() {
-    Player player = PlayerBuilder.create("junit").defaultValues().clan(null).get();
+    player.setClan(null);
     instance.associatePlayerToChatUser(chatUser, player);
     WaitForAsyncUtils.waitForFxEvents();
 
@@ -247,7 +284,7 @@ public class ChatUserServiceTest extends AbstractPlainJavaFxTest {
 
   @Test
   public void testAvatarNotNull() {
-    Player player = PlayerBuilder.create("junit").defaultValues().avatar(avatar).get();
+    player.setAvatar(avatar);
     instance.associatePlayerToChatUser(chatUser, player);
     WaitForAsyncUtils.waitForFxEvents();
 
@@ -257,7 +294,7 @@ public class ChatUserServiceTest extends AbstractPlainJavaFxTest {
 
   @Test
   public void testAvatarChange() throws MalformedURLException {
-    Player player = PlayerBuilder.create("junit").defaultValues().avatar(avatar).get();
+    player.setAvatar(avatar);
     instance.associatePlayerToChatUser(chatUser, player);
     String newUrl = new URL("http://awesome.png").toExternalForm();
     player.setAvatarUrl(newUrl);
@@ -270,7 +307,7 @@ public class ChatUserServiceTest extends AbstractPlainJavaFxTest {
 
   @Test
   public void testAvatarSameChange() {
-    Player player = PlayerBuilder.create("junit").defaultValues().avatar(avatar).get();
+    player.setAvatar(avatar);
     instance.associatePlayerToChatUser(chatUser, player);
     player.setAvatarUrl(Objects.requireNonNull(avatar.getUrl()).toExternalForm());
     WaitForAsyncUtils.waitForFxEvents();
@@ -281,7 +318,7 @@ public class ChatUserServiceTest extends AbstractPlainJavaFxTest {
 
   @Test
   public void testAvatarNull() {
-    Player player = PlayerBuilder.create("junit").defaultValues().get();
+    player.setAvatar(null);
     instance.associatePlayerToChatUser(chatUser, player);
     WaitForAsyncUtils.waitForFxEvents();
 
@@ -291,7 +328,7 @@ public class ChatUserServiceTest extends AbstractPlainJavaFxTest {
 
   @Test
   public void testCountryNotNull() {
-    Player player = PlayerBuilder.create("junit").defaultValues().country("US").get();
+    player.setCountry("US");
     instance.associatePlayerToChatUser(chatUser, player);
     WaitForAsyncUtils.waitForFxEvents();
 
@@ -304,7 +341,7 @@ public class ChatUserServiceTest extends AbstractPlainJavaFxTest {
   public void testCountryChange() {
     when(i18n.getCountryNameLocalized("DE")).thenReturn("Germany");
 
-    Player player = PlayerBuilder.create("junit").defaultValues().country("US").get();
+    player.setCountry("US");
     instance.associatePlayerToChatUser(chatUser, player);
     player.setCountry("DE");
     WaitForAsyncUtils.waitForFxEvents();
@@ -317,7 +354,7 @@ public class ChatUserServiceTest extends AbstractPlainJavaFxTest {
 
   @Test
   public void testCountrySameChange() {
-    Player player = PlayerBuilder.create("junit").defaultValues().country("US").get();
+    player.setCountry("US");
     instance.associatePlayerToChatUser(chatUser, player);
     player.setCountry("US");
     WaitForAsyncUtils.waitForFxEvents();
@@ -329,7 +366,7 @@ public class ChatUserServiceTest extends AbstractPlainJavaFxTest {
 
   @Test
   public void testCountryNull() {
-    Player player = PlayerBuilder.create("junit").defaultValues().country(null).get();
+    player.setCountry(null);
     instance.associatePlayerToChatUser(chatUser, player);
     WaitForAsyncUtils.waitForFxEvents();
 
@@ -340,7 +377,7 @@ public class ChatUserServiceTest extends AbstractPlainJavaFxTest {
 
   @Test
   public void testStatusToIdle() {
-    Player player = PlayerBuilder.create("junit").defaultValues().game(null).get();
+    player.setGame(null);
     when(i18n.get("game.gameStatus.none")).thenReturn("None");
     instance.associatePlayerToChatUser(chatUser, player);
     WaitForAsyncUtils.waitForFxEvents();
@@ -354,7 +391,7 @@ public class ChatUserServiceTest extends AbstractPlainJavaFxTest {
   @Test
   public void testStatusToPlaying() {
     Game game = GameBuilder.create().defaultValues().status(GameStatus.PLAYING).get();
-    Player player = PlayerBuilder.create("junit").defaultValues().game(game).get();
+    player.setGame(game);
     when(i18n.get("game.gameStatus.playing")).thenReturn("Playing");
     instance.associatePlayerToChatUser(chatUser, player);
     WaitForAsyncUtils.waitForFxEvents();
@@ -368,7 +405,7 @@ public class ChatUserServiceTest extends AbstractPlainJavaFxTest {
   @Test
   public void testStatusToHosting() {
     Game game = GameBuilder.create().defaultValues().status(GameStatus.OPEN).host("junit").get();
-    Player player = PlayerBuilder.create("junit").defaultValues().game(game).get();
+    player.setGame(game);
     when(i18n.get("game.gameStatus.hosting")).thenReturn("Hosting");
     instance.associatePlayerToChatUser(chatUser, player);
     WaitForAsyncUtils.waitForFxEvents();
@@ -382,7 +419,7 @@ public class ChatUserServiceTest extends AbstractPlainJavaFxTest {
   @Test
   public void testStatusToLobbying() {
     Game game = GameBuilder.create().defaultValues().status(GameStatus.OPEN).get();
-    Player player = PlayerBuilder.create("junit").defaultValues().game(game).get();
+    player.setGame(game);
     when(i18n.get("game.gameStatus.lobby")).thenReturn("Waiting for game to start");
     instance.associatePlayerToChatUser(chatUser, player);
     WaitForAsyncUtils.waitForFxEvents();
@@ -396,7 +433,7 @@ public class ChatUserServiceTest extends AbstractPlainJavaFxTest {
   @Test
   public void testStatusChange() {
     Game game = GameBuilder.create().defaultValues().status(GameStatus.OPEN).get();
-    Player player = PlayerBuilder.create("junit").defaultValues().game(game).get();
+    player.setGame(game);
     when(i18n.get("game.gameStatus.lobby")).thenReturn("Waiting for game to start");
     when(i18n.get("game.gameStatus.playing")).thenReturn("Playing");
     instance.associatePlayerToChatUser(chatUser, player);
@@ -413,7 +450,7 @@ public class ChatUserServiceTest extends AbstractPlainJavaFxTest {
   @Test
   public void testStatusSameChange() {
     Game game = GameBuilder.create().defaultValues().status(GameStatus.OPEN).get();
-    Player player = PlayerBuilder.create("junit").defaultValues().game(game).get();
+    player.setGame(game);
     when(i18n.get("game.gameStatus.lobby")).thenReturn("Waiting for game to start");
     instance.associatePlayerToChatUser(chatUser, player);
     game.setStatus(GameStatus.OPEN);
@@ -446,10 +483,7 @@ public class ChatUserServiceTest extends AbstractPlainJavaFxTest {
   @Test
   public void testGroupColorSet() {
     preferences.getChat().setGroupToColor(FXCollections.observableMap(Map.of(ChatUserCategory.FRIEND, Color.AQUA)));
-    Player player = PlayerBuilder.create("junit")
-        .defaultValues()
-        .socialStatus(SocialStatus.FRIEND)
-        .get();
+    player.setSocialStatus(SocialStatus.FRIEND);
     instance.associatePlayerToChatUser(chatUser, player);
     WaitForAsyncUtils.waitForFxEvents();
 
@@ -460,10 +494,7 @@ public class ChatUserServiceTest extends AbstractPlainJavaFxTest {
   @Test
   public void testGroupChange() {
     preferences.getChat().setGroupToColor(FXCollections.observableMap(Map.of(ChatUserCategory.FRIEND, Color.AQUA)));
-    Player player = PlayerBuilder.create("junit")
-        .defaultValues()
-        .socialStatus(SocialStatus.FRIEND)
-        .get();
+    player.setSocialStatus(SocialStatus.FRIEND);
     instance.associatePlayerToChatUser(chatUser, player);
     player.setSocialStatus(SocialStatus.OTHER);
     WaitForAsyncUtils.waitForFxEvents();
@@ -474,10 +505,7 @@ public class ChatUserServiceTest extends AbstractPlainJavaFxTest {
   @Test
   public void testGroupSameChange() {
     preferences.getChat().setGroupToColor(FXCollections.observableMap(Map.of(ChatUserCategory.FRIEND, Color.AQUA)));
-    Player player = PlayerBuilder.create("junit")
-        .defaultValues()
-        .socialStatus(SocialStatus.FRIEND)
-        .get();
+    player.setSocialStatus(SocialStatus.FRIEND);
     instance.associatePlayerToChatUser(chatUser, player);
     player.setSocialStatus(SocialStatus.FRIEND);
     WaitForAsyncUtils.waitForFxEvents();
@@ -490,10 +518,7 @@ public class ChatUserServiceTest extends AbstractPlainJavaFxTest {
   public void testModeratorColorOverGroup() {
     preferences.getChat().setGroupToColor(FXCollections.observableMap(Map.of(ChatUserCategory.MODERATOR, Color.RED, ChatUserCategory.FRIEND, Color.AQUA)));
     chatUser.setModerator(true);
-    Player player = PlayerBuilder.create("junit")
-        .defaultValues()
-        .socialStatus(SocialStatus.FRIEND)
-        .get();
+    player.setSocialStatus(SocialStatus.FRIEND);
     instance.associatePlayerToChatUser(chatUser, player);
     WaitForAsyncUtils.waitForFxEvents();
 

--- a/src/test/java/com/faforever/client/chat/avatar/AvatarBeanBuilder.java
+++ b/src/test/java/com/faforever/client/chat/avatar/AvatarBeanBuilder.java
@@ -1,6 +1,7 @@
 package com.faforever.client.chat.avatar;
 
-import java.net.MalformedURLException;
+import lombok.SneakyThrows;
+
 import java.net.URL;
 
 public class AvatarBeanBuilder {
@@ -10,7 +11,8 @@ public class AvatarBeanBuilder {
     return new AvatarBeanBuilder();
   }
 
-  public AvatarBeanBuilder defaultValues() throws MalformedURLException {
+  @SneakyThrows
+  public AvatarBeanBuilder defaultValues() {
     avatarBean.setUrl(new URL("http://avatar.png"));
     avatarBean.setDescription("fancy");
     return this;

--- a/src/test/java/com/faforever/client/chat/avatar/AvatarBeanBuilder.java
+++ b/src/test/java/com/faforever/client/chat/avatar/AvatarBeanBuilder.java
@@ -1,0 +1,32 @@
+package com.faforever.client.chat.avatar;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+public class AvatarBeanBuilder {
+  private final AvatarBean avatarBean = new AvatarBean(null, null);
+
+  public static AvatarBeanBuilder create() {
+    return new AvatarBeanBuilder();
+  }
+
+  public AvatarBeanBuilder defaultValues() throws MalformedURLException {
+    avatarBean.setUrl(new URL("http://avatar.png"));
+    avatarBean.setDescription("fancy");
+    return this;
+  }
+
+  public AvatarBeanBuilder url(URL url) {
+    avatarBean.setUrl(url);
+    return this;
+  }
+
+  public AvatarBeanBuilder description(String description) {
+    avatarBean.setDescription(description);
+    return this;
+  }
+
+  public AvatarBean get() {
+    return avatarBean;
+  }
+}

--- a/src/test/java/com/faforever/client/clan/ClanBuilder.java
+++ b/src/test/java/com/faforever/client/clan/ClanBuilder.java
@@ -1,0 +1,86 @@
+package com.faforever.client.clan;
+
+import com.faforever.client.player.Player;
+import com.faforever.client.player.PlayerBuilder;
+import javafx.collections.ObservableList;
+
+import java.time.Instant;
+
+public class ClanBuilder {
+  public static final String TEST_CLAN_TAG = "TC";
+
+  private final Clan clan = new Clan();
+
+  public static ClanBuilder create() {
+    return new ClanBuilder();
+  }
+
+  public ClanBuilder defaultValues() {
+    Player founder = PlayerBuilder.create("junit").get();
+    id("e");
+    description("Fun Place");
+    founder(founder);
+    leader(founder);
+    name("test");
+    tag(TEST_CLAN_TAG);
+    tagColor("red");
+    websiteUrl("http:\\awesome.com");
+    createTime(Instant.EPOCH);
+    return this;
+  }
+
+  public ClanBuilder id(String id) {
+    clan.setId(id);
+    return this;
+  }
+
+  public ClanBuilder description(String description) {
+    clan.setDescription(description);
+    return this;
+  }
+
+  public ClanBuilder founder(Player founder) {
+    clan.setFounder(founder);
+    return this;
+  }
+
+  public ClanBuilder leader(Player leader) {
+    clan.setLeader(leader);
+    return this;
+  }
+
+  public ClanBuilder name(String name) {
+    clan.setName(name);
+    return this;
+  }
+
+  public ClanBuilder tag(String tag) {
+    clan.setTag(tag);
+    return this;
+  }
+
+  public ClanBuilder tagColor(String tagColor) {
+    clan.setTagColor(tagColor);
+    return this;
+  }
+
+  public ClanBuilder websiteUrl(String websiteUrl) {
+    clan.setWebsiteUrl(websiteUrl);
+    return this;
+  }
+
+  public ClanBuilder members(ObservableList<Player> members) {
+    clan.getMembers().addAll(members);
+    return this;
+  }
+
+  public ClanBuilder createTime(Instant createTime) {
+    clan.setCreateTime(createTime);
+    return this;
+  }
+
+  public Clan get() {
+    return clan;
+  }
+
+}

--- a/src/test/java/com/faforever/client/player/PlayerBuilder.java
+++ b/src/test/java/com/faforever/client/player/PlayerBuilder.java
@@ -1,6 +1,7 @@
 package com.faforever.client.player;
 
 import com.faforever.client.chat.avatar.AvatarBean;
+import com.faforever.client.clan.ClanBuilder;
 import com.faforever.client.game.Game;
 import com.faforever.client.leaderboard.LeaderboardRating;
 import com.faforever.client.leaderboard.LeaderboardRatingMapBuilder;
@@ -23,7 +24,7 @@ public class PlayerBuilder {
     id(1);
     leaderboardRatings(LeaderboardRatingMapBuilder.create().defaultValues().get());
     socialStatus(SocialStatus.OTHER);
-    clan("e");
+    clan(ClanBuilder.TEST_CLAN_TAG);
     country("US");
     return this;
   }

--- a/src/test/java/com/faforever/client/player/PlayerBuilder.java
+++ b/src/test/java/com/faforever/client/player/PlayerBuilder.java
@@ -1,6 +1,7 @@
 package com.faforever.client.player;
 
 import com.faforever.client.chat.avatar.AvatarBean;
+import com.faforever.client.chat.avatar.AvatarBeanBuilder;
 import com.faforever.client.clan.ClanBuilder;
 import com.faforever.client.game.Game;
 import com.faforever.client.leaderboard.LeaderboardRating;
@@ -26,6 +27,7 @@ public class PlayerBuilder {
     socialStatus(SocialStatus.OTHER);
     clan(ClanBuilder.TEST_CLAN_TAG);
     country("US");
+    avatar(AvatarBeanBuilder.create().defaultValues().get());
     return this;
   }
 


### PR DESCRIPTION
This uses Flowless Virtual Flow for the chat user list. Notably this removes the resetting of the chat user list everytime a user joins or leaves the channel. This will reduce the gpu load from constantly removing and creating the images and associated graphics