### PR TITLE
Download all matchmaker maps before queueing

### DIFF
--- a/src/main/java/com/faforever/client/map/MapService.java
+++ b/src/main/java/com/faforever/client/map/MapService.java
@@ -542,6 +542,13 @@ public class MapService implements InitializingBean, DisposableBean {
     return fafService.getMatchmakerMapsWithPageCount(matchmakerQueue.getQueueId(), meanRating, count, page);
   }
 
+  public CompletableFuture<List<MapBean>> getAllMatchmakerMaps(MatchmakingQueue matchmakerQueue) {
+    Player player = playerService.getCurrentPlayer().orElseThrow(() -> new IllegalStateException("No user is logged in"));
+    float meanRating = Optional.ofNullable(player.getLeaderboardRatings().get(matchmakerQueue.getLeaderboard().getTechnicalName()))
+        .map(LeaderboardRating::getMean).orElse(0f);
+    return fafService.getAllMatchmakerMaps(matchmakerQueue.getQueueId(), meanRating);
+  }
+
   private CompletableFuture<Void> downloadAndInstallMap(String folderName, URL downloadUrl, @Nullable DoubleProperty progressProperty, @Nullable StringProperty titleProperty) {
     if (mapGeneratorService.isGeneratedMap(folderName)) {
       return mapGeneratorService.generateMap(folderName).thenRun(() -> {

--- a/src/main/java/com/faforever/client/remote/FafService.java
+++ b/src/main/java/com/faforever/client/remote/FafService.java
@@ -501,6 +501,18 @@ public class FafService {
     return paginateResult(count, page, mapVersions);
   }
 
+  @Async
+  public CompletableFuture<List<MapBean>> getAllMatchmakerMaps(int matchmakerQueueId, float rating) {
+    List<MapPoolAssignment> poolAssignments = fafApiAccessor.getMatchmakerPoolMaps(matchmakerQueueId, rating);
+    List<MapBean> mapVersions = poolAssignments.stream()
+        .map(MapPoolAssignment::getMapVersion)
+        .distinct()
+        .filter(Objects::nonNull)
+        .map(MapBean::fromMapVersionDto)
+        .collect(Collectors.toList());
+    return CompletableFuture.completedFuture(mapVersions);
+  }
+
   @NotNull
   private <T> CompletableFuture<Tuple<List<T>, Integer>> paginateResult(int count, int page, List<T> results) {
     int totalPages = (results.size() - 1) / count + 1;

--- a/src/main/java/com/faforever/client/teammatchmaking/MatchmakingQueueItemController.java
+++ b/src/main/java/com/faforever/client/teammatchmaking/MatchmakingQueueItemController.java
@@ -138,8 +138,10 @@ public class MatchmakingQueueItemController implements Controller<VBox> {
           .thenAccept(aVoid -> {
             boolean success = teamMatchmakingService.joinQueue(queue);
             if (!success) {
-              joinLeaveQueueButton.setSelected(false);
-              refreshingLabel.setVisible(false);
+              JavaFxUtil.runLater(() -> {
+                joinLeaveQueueButton.setSelected(false);
+                refreshingLabel.setVisible(false);
+              });
             }
           });
     }

--- a/src/test/java/com/faforever/client/map/MapServiceTest.java
+++ b/src/test/java/com/faforever/client/map/MapServiceTest.java
@@ -4,6 +4,8 @@ import com.faforever.client.config.ClientProperties;
 import com.faforever.client.i18n.I18n;
 import com.faforever.client.map.MapService.PreviewSize;
 import com.faforever.client.map.generator.MapGeneratorService;
+import com.faforever.client.player.Player;
+import com.faforever.client.player.PlayerBuilder;
 import com.faforever.client.player.PlayerService;
 import com.faforever.client.preferences.Preferences;
 import com.faforever.client.preferences.PreferencesBuilder;
@@ -12,6 +14,8 @@ import com.faforever.client.remote.AssetService;
 import com.faforever.client.remote.FafService;
 import com.faforever.client.task.CompletableTask;
 import com.faforever.client.task.TaskService;
+import com.faforever.client.teammatchmaking.MatchmakingQueue;
+import com.faforever.client.teammatchmaking.MatchmakingQueueBuilder;
 import com.faforever.client.test.AbstractPlainJavaFxTest;
 import com.faforever.client.theme.UiService;
 import com.faforever.client.update.ClientConfiguration;
@@ -301,6 +305,32 @@ public class MapServiceTest extends AbstractPlainJavaFxTest {
     assertThat(checkCustomMapFolderExist(map), is(true));
     assertThat(instance.updateLatestVersionIfNecessary(map).join(), is(map));
     assertThat(checkCustomMapFolderExist(map), is(true));
+  }
+
+  @Test
+  public void testGetMatchMakerMaps() throws Exception {
+    Player player = PlayerBuilder.create("test").defaultValues().get();
+    MatchmakingQueue queue = MatchmakingQueueBuilder.create().defaultValues().get();
+
+    when(playerService.getCurrentPlayer()).thenReturn(Optional.of(player));
+    when(fafService.getAllMatchmakerMaps(queue.getQueueId(), player.getLeaderboardRatings().get(queue.getLeaderboard().getTechnicalName()).getMean()))
+        .thenReturn(CompletableFuture.completedFuture(List.of()));
+
+    instance.getAllMatchmakerMaps(queue);
+
+    verify(playerService).getCurrentPlayer();
+  }
+
+  @Test
+  public void testGetMatchMakerMapsNoUser() throws Exception {
+    expectedException.expect(IllegalStateException.class);
+    MatchmakingQueue queue = MatchmakingQueueBuilder.create().defaultValues().get();
+
+    when(playerService.getCurrentPlayer()).thenReturn(Optional.empty());
+
+    instance.getAllMatchmakerMaps(queue);
+
+    verify(playerService).getCurrentPlayer();
   }
 
   private void prepareDownloadMapTask(MapBean mapToDownload) {

--- a/src/test/java/com/faforever/client/teammatchmaking/MatchmakingQueueBuilder.java
+++ b/src/test/java/com/faforever/client/teammatchmaking/MatchmakingQueueBuilder.java
@@ -1,0 +1,78 @@
+package com.faforever.client.teammatchmaking;
+
+import com.faforever.client.leaderboard.Leaderboard;
+import com.faforever.client.leaderboard.LeaderboardBuilder;
+import com.faforever.client.teammatchmaking.MatchmakingQueue.MatchingStatus;
+
+import java.time.Instant;
+
+public class MatchmakingQueueBuilder {
+  private final MatchmakingQueue matchmakingQueue = new MatchmakingQueue();
+
+  public static MatchmakingQueueBuilder create() {
+    return new MatchmakingQueueBuilder();
+  }
+
+  public MatchmakingQueueBuilder defaultValues() {
+    queueId(1);
+    queueName("test");
+    queuePopTime(Instant.MAX);
+    teamSize(2);
+    partiesInQueue(0);
+    playersInQueue(0);
+    joined(false);
+    matchingStatus(null);
+    leaderboard(LeaderboardBuilder.create().defaultValues().get());
+    return this;
+  }
+
+  public MatchmakingQueueBuilder queueId(int queueId) {
+    matchmakingQueue.setQueueId(queueId);
+    return this;
+  }
+
+  public MatchmakingQueueBuilder queueName(String queueName) {
+    matchmakingQueue.setQueueName(queueName);
+    return this;
+  }
+
+  public MatchmakingQueueBuilder queuePopTime(Instant queuePopTime) {
+    matchmakingQueue.setQueuePopTime(queuePopTime);
+    return this;
+  }
+
+  public MatchmakingQueueBuilder teamSize(int teamSize) {
+    matchmakingQueue.setTeamSize(teamSize);
+    return this;
+  }
+
+  public MatchmakingQueueBuilder partiesInQueue(int partiesInQueue) {
+    matchmakingQueue.setPartiesInQueue(partiesInQueue);
+    return this;
+  }
+
+  public MatchmakingQueueBuilder playersInQueue(int playersInQueue) {
+    matchmakingQueue.setPlayersInQueue(playersInQueue);
+    return this;
+  }
+
+  public MatchmakingQueueBuilder joined(boolean joined) {
+    matchmakingQueue.setJoined(joined);
+    return this;
+  }
+
+  public MatchmakingQueueBuilder matchingStatus(MatchingStatus matchingStatus) {
+    matchmakingQueue.setMatchingStatus(matchingStatus);
+    return this;
+  }
+
+  public MatchmakingQueueBuilder leaderboard(Leaderboard leaderboard) {
+    matchmakingQueue.setLeaderboard(leaderboard);
+    return this;
+  }
+
+  public MatchmakingQueue get() {
+    return matchmakingQueue;
+  }
+
+}

--- a/src/test/java/com/faforever/client/teammatchmaking/MatchmakingQueueItemControllerTest.java
+++ b/src/test/java/com/faforever/client/teammatchmaking/MatchmakingQueueItemControllerTest.java
@@ -101,8 +101,13 @@ public class MatchmakingQueueItemControllerTest extends AbstractPlainJavaFxTest 
     when(mapService.isInstalled(map1.getFolderName())).thenReturn(false);
     when(mapService.isInstalled(map2.getFolderName())).thenReturn(true);
     when(mapService.isInstalled(map3.getFolderName())).thenReturn(false);
+    CompletableFuture<Void> downloadFuture = new CompletableFuture<>();
+    when(mapService.downloadAndInstallMap(any(), any(), any())).thenReturn(downloadFuture);
 
     instance.joinLeaveQueueButton.fire();
+    WaitForAsyncUtils.waitForFxEvents();
+
+    downloadFuture.complete(null);
     WaitForAsyncUtils.waitForFxEvents();
 
     verify(mapService).downloadAndInstallMap(eq(map1), isNull(), isNull());
@@ -122,6 +127,8 @@ public class MatchmakingQueueItemControllerTest extends AbstractPlainJavaFxTest 
   @Test
   public void testOnJoinQueueFailed() {
     when(teamMatchmakingService.joinQueue(any())).thenReturn(false);
+    when(mapService.getAllMatchmakerMaps(queue)).thenReturn(CompletableFuture.completedFuture(
+        List.of()));
 
     instance.joinLeaveQueueButton.fire();
     WaitForAsyncUtils.waitForFxEvents();

--- a/src/test/java/com/faforever/client/teammatchmaking/MatchmakingQueueItemControllerTest.java
+++ b/src/test/java/com/faforever/client/teammatchmaking/MatchmakingQueueItemControllerTest.java
@@ -2,6 +2,9 @@ package com.faforever.client.teammatchmaking;
 
 import com.faforever.client.i18n.I18n;
 import com.faforever.client.main.event.ShowMapPoolEvent;
+import com.faforever.client.map.MapBean;
+import com.faforever.client.map.MapBeanBuilder;
+import com.faforever.client.map.MapService;
 import com.faforever.client.player.Player;
 import com.faforever.client.player.PlayerService;
 import com.faforever.client.teammatchmaking.Party.PartyMember;
@@ -16,13 +19,19 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.testfx.util.WaitForAsyncUtils;
 
+import java.net.MalformedURLException;
+import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -30,6 +39,8 @@ public class MatchmakingQueueItemControllerTest extends AbstractPlainJavaFxTest 
 
   @Mock
   private PlayerService playerService;
+  @Mock
+  private MapService mapService;
   @Mock
   private I18n i18n;
   @Mock
@@ -40,6 +51,7 @@ public class MatchmakingQueueItemControllerTest extends AbstractPlainJavaFxTest 
   private Player player;
 
   private MatchmakingQueueItemController instance;
+  private MatchmakingQueue queue;
 
   @Before
   public void setUp() throws Exception {
@@ -48,10 +60,10 @@ public class MatchmakingQueueItemControllerTest extends AbstractPlainJavaFxTest 
     when(playerService.getCurrentPlayer()).thenReturn(Optional.of(player));
     prepareParty();
 
-    instance = new MatchmakingQueueItemController(playerService, teamMatchmakingService, i18n, eventBus);
+    instance = new MatchmakingQueueItemController(playerService, mapService, teamMatchmakingService, i18n, eventBus);
     when(teamMatchmakingService.getPlayersInGame()).thenReturn(FXCollections.observableSet());
     loadFxml("theme/play/teammatchmaking/matchmaking_queue_card.fxml", clazz -> instance);
-    MatchmakingQueue queue = new MatchmakingQueue();
+    queue = new MatchmakingQueue();
     queue.setQueueName("1");
     queue.setPlayersInQueue(1);
     queue.setTeamSize(2);
@@ -78,12 +90,24 @@ public class MatchmakingQueueItemControllerTest extends AbstractPlainJavaFxTest 
   }
 
   @Test
-  public void testOnJoinLeaveQueueButtonClicked() {
+  public void testOnJoinLeaveQueueButtonClicked() throws MalformedURLException {
+    MapBean map1 = MapBeanBuilder.create().defaultValues().folderName("map1").get();
+    MapBean map2 = MapBeanBuilder.create().defaultValues().folderName("map2").get();
+    MapBean map3 = MapBeanBuilder.create().defaultValues().folderName("map3").get();
+
     when(teamMatchmakingService.joinQueue(any())).thenReturn(true);
+    when(mapService.getAllMatchmakerMaps(queue)).thenReturn(CompletableFuture.completedFuture(
+        List.of(map1, map2, map3)));
+    when(mapService.isInstalled(map1.getFolderName())).thenReturn(false);
+    when(mapService.isInstalled(map2.getFolderName())).thenReturn(true);
+    when(mapService.isInstalled(map3.getFolderName())).thenReturn(false);
 
     instance.joinLeaveQueueButton.fire();
     WaitForAsyncUtils.waitForFxEvents();
 
+    verify(mapService).downloadAndInstallMap(eq(map1), isNull(), isNull());
+    verify(mapService, never()).downloadAndInstallMap(eq(map2), isNull(), isNull());
+    verify(mapService).downloadAndInstallMap(eq(map3), isNull(), isNull());
     verify(teamMatchmakingService).joinQueue(instance.queue);
     assertThat(instance.joinLeaveQueueButton.selectedProperty().get(), is(true));
 


### PR DESCRIPTION
Fixes #1767 

This downloads all your matchmaker maps before queueing. Currently only works for the party leader since it is on the queue button clicked and there is no way to know when the other party members have finished downloading their maps.

