### PR TITLE
Remove indeterminate progress indicator

### DIFF
--- a/src/main/java/com/faforever/client/ui/taskbar/WindowsTaskbarProgressUpdater.java
+++ b/src/main/java/com/faforever/client/ui/taskbar/WindowsTaskbarProgressUpdater.java
@@ -80,9 +80,7 @@ public class WindowsTaskbarProgressUpdater implements InitializingBean {
 
       if (progress == null) {
         taskBarList.SetProgressState(taskBarPointer, ITaskbarList3.TbpFlag.TBPF_NOPROGRESS);
-      } else if (progress == ProgressIndicator.INDETERMINATE_PROGRESS) {
-        taskBarList.SetProgressState(taskBarPointer, ITaskbarList3.TbpFlag.TBPF_INDETERMINATE);
-      } else {
+      } else if (progress != ProgressIndicator.INDETERMINATE_PROGRESS) {
         taskBarList.SetProgressState(taskBarPointer, ITaskbarList3.TbpFlag.TBPF_NORMAL);
         taskBarList.SetProgressValue(taskBarPointer, (int) (progress * 100), 100);
       }


### PR DESCRIPTION
There seems to be a bug where if the progress taskbar icon is not updated within a certain amount of time then changes to it are not registered. This appears to only be an issue with tasks which have an indeterminate progress.