### PR TITLE
Clean up teammatchmaking service and controller

### DIFF
--- a/src/main/java/com/faforever/client/fx/JavaFxUtil.java
+++ b/src/main/java/com/faforever/client/fx/JavaFxUtil.java
@@ -220,7 +220,7 @@ public final class JavaFxUtil {
     }
     if (image.isBackgroundLoading() && image.getProgress() < 1) {
       // Let's hope that loading doesn't finish before the listener is added
-      JavaFxUtil.addListener(image.progressProperty(), new ChangeListener<Number>() {
+      JavaFxUtil.addListener(image.progressProperty(), new ChangeListener<>() {
         @Override
         public void changed(ObservableValue<? extends Number> observable, Number oldValue, Number newValue) {
           if (newValue.intValue() >= 1) {

--- a/src/main/java/com/faforever/client/player/PlayerService.java
+++ b/src/main/java/com/faforever/client/player/PlayerService.java
@@ -315,8 +315,12 @@ public class PlayerService implements InitializingBean {
         .collect(Collectors.toList());
   }
 
+  public Optional<Player> getPlayerIfOnlineById(int playerId) {
+    return Optional.ofNullable(playersById.get(playerId));
+  }
+
   private void onPlayersInfo(PlayersMessage playersMessage) {
-    playersMessage.getPlayers().forEach(dto -> JavaFxUtil.runLater(() -> onPlayerInfo(dto)));
+    playersMessage.getPlayers().forEach(this::onPlayerInfo);
   }
 
   private void onFoeList(SocialMessage socialMessage) {

--- a/src/main/java/com/faforever/client/rankedmatch/MatchmakerInfoMessage.java
+++ b/src/main/java/com/faforever/client/rankedmatch/MatchmakerInfoMessage.java
@@ -10,16 +10,21 @@ import lombok.Setter;
 
 import java.util.List;
 
+@Getter
+@Setter
 public class MatchmakerInfoMessage extends FafServerMessage {
+  private List<MatchmakerQueue> queues;
+
+  public MatchmakerInfoMessage() {
+    super(FafServerMessageType.MATCHMAKER_INFO);
+  }
 
   @Data
   public static class MatchmakerQueue {
 
     private String queueName;
     private String queuePopTime;
-    @SerializedName("team_size")
     private int teamSize;
-    @SerializedName("num_players")
     private int numPlayers;
 
     // The boundaries indicate the ranges applicable for other searching players,
@@ -39,12 +44,4 @@ public class MatchmakerInfoMessage extends FafServerMessage {
     }
 
   }
-  @Getter
-  @Setter
-  private List<MatchmakerQueue> queues;
-
-  public MatchmakerInfoMessage() {
-    super(FafServerMessageType.MATCHMAKER_INFO);
-  }
-
 }

--- a/src/main/java/com/faforever/client/remote/FafServerAccessorImpl.java
+++ b/src/main/java/com/faforever/client/remote/FafServerAccessorImpl.java
@@ -592,7 +592,7 @@ public class FafServerAccessorImpl extends AbstractServerAccessor implements Faf
 
   @Override
   public void gameMatchmaking(MatchmakingQueue queue, MatchmakingState state) {
-    writeToServer(new GameMatchmakingMessage(queue.getQueueName(), state));
+    writeToServer(new GameMatchmakingMessage(queue.getTechnicalName(), state));
   }
 
   @Override

--- a/src/main/java/com/faforever/client/remote/FafService.java
+++ b/src/main/java/com/faforever/client/remote/FafService.java
@@ -21,6 +21,7 @@ import com.faforever.client.remote.domain.GameLaunchMessage;
 import com.faforever.client.remote.domain.IceMessage;
 import com.faforever.client.remote.domain.IceServersServerMessage.IceServer;
 import com.faforever.client.remote.domain.LoginMessage;
+import com.faforever.client.remote.domain.MatchmakingState;
 import com.faforever.client.remote.domain.PeriodType;
 import com.faforever.client.remote.domain.ServerMessage;
 import com.faforever.client.replay.Replay;
@@ -34,6 +35,7 @@ import com.faforever.client.vault.search.SearchController.SearchConfig;
 import com.faforever.client.vault.search.SearchController.SortConfig;
 import com.faforever.commons.api.dto.AchievementDefinition;
 import com.faforever.commons.api.dto.CoopResult;
+import com.faforever.commons.api.dto.Faction;
 import com.faforever.commons.api.dto.FeaturedModFile;
 import com.faforever.commons.api.dto.Game;
 import com.faforever.commons.api.dto.GameReview;
@@ -548,6 +550,38 @@ public class FafService {
   public CompletableFuture<Optional<MatchmakingQueue>> getMatchmakingQueue(String technicalName) {
     return CompletableFuture.completedFuture(fafApiAccessor.getMatchmakerQueue(technicalName)
         .map(MatchmakingQueue::fromDto));
+  }
+
+  public void acceptPartyInvite(Player player) {
+    fafServerAccessor.acceptPartyInvite(player);
+  }
+
+  public void inviteToParty(Player player) {
+    fafServerAccessor.inviteToParty(player);
+  }
+
+  public void kickPlayerFromParty(Player player) {
+    fafServerAccessor.kickPlayerFromParty(player);
+  }
+
+  public void leaveParty() {
+    fafServerAccessor.leaveParty();
+  }
+
+  public void readyParty() {
+    fafServerAccessor.readyParty();
+  }
+
+  public void unreadyParty() {
+    fafServerAccessor.unreadyParty();
+  }
+
+  public void setPartyFactions(List<Faction> factions) {
+    fafServerAccessor.setPartyFactions(factions);
+  }
+
+  public void updateMatchmakerState(MatchmakingQueue queue, MatchmakingState state) {
+    fafServerAccessor.gameMatchmaking(queue, state);
   }
 
   @Async

--- a/src/main/java/com/faforever/client/teammatchmaking/MatchmakingQueue.java
+++ b/src/main/java/com/faforever/client/teammatchmaking/MatchmakingQueue.java
@@ -17,7 +17,7 @@ import java.time.Instant;
 
 public class MatchmakingQueue {
   private final IntegerProperty queueId;
-  private final StringProperty queueName;
+  private final StringProperty technicalName;
   private final ObjectProperty<Instant> queuePopTime;
   private final IntegerProperty teamSize;
   private final IntegerProperty partiesInQueue;
@@ -28,7 +28,7 @@ public class MatchmakingQueue {
 
   public MatchmakingQueue() {
     this.queueId = new SimpleIntegerProperty();
-    this.queueName = new SimpleStringProperty();
+    this.technicalName = new SimpleStringProperty();
     this.queuePopTime = new SimpleObjectProperty<>(Instant.now().plus(Duration.ofDays(1)));
     this.teamSize = new SimpleIntegerProperty(0);
     this.partiesInQueue = new SimpleIntegerProperty(0);
@@ -41,7 +41,7 @@ public class MatchmakingQueue {
   public static MatchmakingQueue fromDto(MatchmakerQueue dto) {
     MatchmakingQueue queue = new MatchmakingQueue();
     queue.setQueueId(Integer.parseInt(dto.getId()));
-    queue.setQueueName(dto.getTechnicalName());
+    queue.setTechnicalName(dto.getTechnicalName());
     queue.setLeaderboard(Leaderboard.fromDto(dto.getLeaderboard()));
     return queue;
   }
@@ -83,16 +83,16 @@ public class MatchmakingQueue {
     return queueId;
   }
 
-  public String getQueueName() {
-    return queueName.get();
+  public String getTechnicalName() {
+    return technicalName.get();
   }
 
-  public void setQueueName(String queueName) {
-    this.queueName.set(queueName);
+  public void setTechnicalName(String technicalName) {
+    this.technicalName.set(technicalName);
   }
 
-  public StringProperty queueNameProperty() {
-    return queueName;
+  public StringProperty technicalNameProperty() {
+    return technicalName;
   }
 
   public Instant getQueuePopTime() {

--- a/src/main/java/com/faforever/client/teammatchmaking/Party.java
+++ b/src/main/java/com/faforever/client/teammatchmaking/Party.java
@@ -1,12 +1,13 @@
 package com.faforever.client.teammatchmaking;
 
+import com.faforever.client.fx.JavaFxUtil;
 import com.faforever.client.player.Player;
 import com.faforever.commons.api.dto.Faction;
+import javafx.beans.InvalidationListener;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
-import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 
@@ -40,19 +41,34 @@ public class Party {
     return members;
   }
 
-  public void setMembers(ObservableList<PartyMember> members) {
+  public void setMembers(List<PartyMember> members) {
     this.members.setAll(members);
   }
 
   @Data
-  @AllArgsConstructor
   public static class PartyMember {
     private final Player player;
     private List<Faction> factions;
+    private InvalidationListener gameStatusChangeListener;
 
     public PartyMember(Player player) {
       this.player = player;
       this.factions = Arrays.asList(Faction.AEON, Faction.CYBRAN, Faction.SERAPHIM, Faction.UEF);
+    }
+
+    public PartyMember(Player player, List<Faction> factions) {
+      this.player = player;
+      this.factions = factions;
+    }
+
+    public void setGameStatusChangeListener(InvalidationListener listener) {
+      if (gameStatusChangeListener != null) {
+        JavaFxUtil.removeListener(player.statusProperty(), gameStatusChangeListener);
+      }
+      gameStatusChangeListener = listener;
+      if (gameStatusChangeListener != null) {
+        JavaFxUtil.addAndTriggerListener(player.statusProperty(), gameStatusChangeListener);
+      }
     }
   }
 }

--- a/src/main/java/com/faforever/client/teammatchmaking/event/PartyOwnerChangedEvent.java
+++ b/src/main/java/com/faforever/client/teammatchmaking/event/PartyOwnerChangedEvent.java
@@ -1,0 +1,9 @@
+package com.faforever.client.teammatchmaking.event;
+
+import com.faforever.client.player.Player;
+import lombok.Value;
+
+@Value
+public class PartyOwnerChangedEvent {
+  Player newOwner;
+}

--- a/src/test/java/com/faforever/client/teammatchmaking/MatchmakingQueueBuilder.java
+++ b/src/test/java/com/faforever/client/teammatchmaking/MatchmakingQueueBuilder.java
@@ -1,0 +1,78 @@
+package com.faforever.client.teammatchmaking;
+
+import com.faforever.client.leaderboard.Leaderboard;
+import com.faforever.client.leaderboard.LeaderboardBuilder;
+import com.faforever.client.teammatchmaking.MatchmakingQueue.MatchingStatus;
+
+import java.time.Instant;
+
+public class MatchmakingQueueBuilder {
+
+  private final MatchmakingQueue matchmakingQueue = new MatchmakingQueue();
+
+  public static MatchmakingQueueBuilder create() {
+    return new MatchmakingQueueBuilder();
+  }
+
+  public MatchmakingQueueBuilder defaultValues() {
+    queueId(1);
+    technicalName("test_queue");
+    queuePopTime(Instant.MAX);
+    teamSize(1);
+    partiesInQueue(0);
+    playersInQueue(0);
+    joined(false);
+    matchingStatus(null);
+    leaderboard(LeaderboardBuilder.create().defaultValues().get());
+    return this;
+  }
+
+  public MatchmakingQueueBuilder queueId(int queueId) {
+    matchmakingQueue.setQueueId(queueId);
+    return this;
+  }
+
+  public MatchmakingQueueBuilder technicalName(String technicalName) {
+    matchmakingQueue.setTechnicalName(technicalName);
+    return this;
+  }
+
+  public MatchmakingQueueBuilder queuePopTime(Instant queuePopTime) {
+    matchmakingQueue.setQueuePopTime(queuePopTime);
+    return this;
+  }
+
+  public MatchmakingQueueBuilder teamSize(int teamSize) {
+    matchmakingQueue.setTeamSize(teamSize);
+    return this;
+  }
+
+  public MatchmakingQueueBuilder partiesInQueue(int partiesInQueue) {
+    matchmakingQueue.setPartiesInQueue(partiesInQueue);
+    return this;
+  }
+
+  public MatchmakingQueueBuilder playersInQueue(int playersInQueue) {
+    matchmakingQueue.setPlayersInQueue(playersInQueue);
+    return this;
+  }
+
+  public MatchmakingQueueBuilder joined(boolean joined) {
+    matchmakingQueue.setJoined(joined);
+    return this;
+  }
+
+  public MatchmakingQueueBuilder matchingStatus(MatchingStatus matchingStatus) {
+    matchmakingQueue.setMatchingStatus(matchingStatus);
+    return this;
+  }
+
+  public MatchmakingQueueBuilder leaderboard(Leaderboard leaderboard) {
+    matchmakingQueue.setLeaderboard(leaderboard);
+    return this;
+  }
+
+  public MatchmakingQueue get() {
+    return matchmakingQueue;
+  }
+}

--- a/src/test/java/com/faforever/client/teammatchmaking/MatchmakingQueueItemControllerTest.java
+++ b/src/test/java/com/faforever/client/teammatchmaking/MatchmakingQueueItemControllerTest.java
@@ -3,26 +3,26 @@ package com.faforever.client.teammatchmaking;
 import com.faforever.client.i18n.I18n;
 import com.faforever.client.main.event.ShowMapPoolEvent;
 import com.faforever.client.player.Player;
+import com.faforever.client.player.PlayerBuilder;
 import com.faforever.client.player.PlayerService;
-import com.faforever.client.teammatchmaking.Party.PartyMember;
+import com.faforever.client.teammatchmaking.MatchmakingQueue.MatchingStatus;
 import com.faforever.client.test.AbstractPlainJavaFxTest;
 import com.google.common.eventbus.EventBus;
-import javafx.collections.FXCollections;
-import javafx.collections.ObservableList;
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.ReadOnlyBooleanWrapper;
 import javafx.event.ActionEvent;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.testfx.util.WaitForAsyncUtils;
 
 import java.util.Optional;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.mock;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -36,72 +36,160 @@ public class MatchmakingQueueItemControllerTest extends AbstractPlainJavaFxTest 
   private TeamMatchmakingService teamMatchmakingService;
   @Mock
   private EventBus eventBus;
-  @Mock
-  private Player player;
 
+  private Player player;
   private MatchmakingQueueItemController instance;
+  private MatchmakingQueue queue;
+  private Party party;
+  private BooleanProperty partyMembersNotReadyProperty;
 
   @Before
   public void setUp() throws Exception {
+    partyMembersNotReadyProperty = new ReadOnlyBooleanWrapper();
+
+    queue = MatchmakingQueueBuilder.create().defaultValues().get();
+    party = PartyBuilder.create().defaultValues().get();
+    player = party.getOwner();
+    when(teamMatchmakingService.getParty()).thenReturn(party);
+    when(i18n.getOrDefault(eq(queue.getTechnicalName()), anyString())).thenReturn(queue.getTechnicalName());
     when(i18n.get(anyString())).thenReturn("");
-    when(i18n.get("teammatchmaking.playersInQueue", 1)).thenReturn("");
+    when(i18n.get("teammatchmaking.playersInQueue", queue.getPlayersInQueue())).thenReturn(String.valueOf(queue.getPlayersInQueue()));
     when(playerService.getCurrentPlayer()).thenReturn(Optional.of(player));
-    prepareParty();
 
     instance = new MatchmakingQueueItemController(playerService, teamMatchmakingService, i18n, eventBus);
-    when(teamMatchmakingService.getPlayersInGame()).thenReturn(FXCollections.observableSet());
+    when(teamMatchmakingService.partyMembersNotReadyProperty()).thenReturn(partyMembersNotReadyProperty);
+    when(teamMatchmakingService.partyMembersNotReady()).thenReturn(partyMembersNotReadyProperty.get());
     loadFxml("theme/play/teammatchmaking/matchmaking_queue_card.fxml", clazz -> instance);
-    MatchmakingQueue queue = new MatchmakingQueue();
-    queue.setQueueName("1");
-    queue.setPlayersInQueue(1);
-    queue.setTeamSize(2);
-    queue.setJoined(false);
-    instance.setQueue(queue);
+    runOnFxThreadAndWait(() -> instance.setQueue(queue));
   }
 
-  private void prepareParty() {
-    Party party = new Party();
-    party.setOwner(player);
-    PartyMember member = mock(PartyMember.class);
-    ObservableList<PartyMember> members = FXCollections.observableArrayList();
-    members.add(member);
-    party.setMembers(members);
-    when(teamMatchmakingService.getParty()).thenReturn(party);
+  @Test
+  public void testQueueNameSet() {
+    assertThat(instance.joinLeaveQueueButton.getText(), is(queue.getTechnicalName()));
   }
 
   @Test
   public void testShowMapPool() {
     instance.showMapPool(new ActionEvent());
 
-    ArgumentCaptor<ShowMapPoolEvent> captor = ArgumentCaptor.forClass(ShowMapPoolEvent.class);
-    verify(eventBus).post(captor.capture());
+    verify(eventBus).post(any(ShowMapPoolEvent.class));
   }
 
   @Test
   public void testOnJoinLeaveQueueButtonClicked() {
     when(teamMatchmakingService.joinQueue(any())).thenReturn(true);
 
-    instance.joinLeaveQueueButton.fire();
-    WaitForAsyncUtils.waitForFxEvents();
+    runOnFxThreadAndWait(() -> instance.joinLeaveQueueButton.fire());
 
-    verify(teamMatchmakingService).joinQueue(instance.queue);
-    assertThat(instance.joinLeaveQueueButton.selectedProperty().get(), is(true));
+    verify(teamMatchmakingService).joinQueue(queue);
+    assertThat(instance.refreshingLabel.isVisible(), is(true));
 
-    instance.queue.setJoined(true);
-    instance.joinLeaveQueueButton.fire();
-    WaitForAsyncUtils.waitForFxEvents();
+    queue.setJoined(true);
+    runOnFxThreadAndWait(() -> instance.joinLeaveQueueButton.fire());
 
     verify(teamMatchmakingService).leaveQueue(instance.queue);
-    assertThat(instance.joinLeaveQueueButton.selectedProperty().get(), is(false));
+    assertThat(instance.refreshingLabel.isVisible(), is(true));
   }
 
   @Test
   public void testOnJoinQueueFailed() {
     when(teamMatchmakingService.joinQueue(any())).thenReturn(false);
 
-    instance.joinLeaveQueueButton.fire();
-    WaitForAsyncUtils.waitForFxEvents();
+    runOnFxThreadAndWait(() -> instance.joinLeaveQueueButton.fire());
 
-    assertThat(instance.joinLeaveQueueButton.selectedProperty().get(), is(false));
+    assertThat(instance.joinLeaveQueueButton.isSelected(), is(false));
+  }
+
+  @Test
+  public void testMatchStatusListeners() {
+    assertThat(instance.matchFoundLabel.isVisible(), is(false));
+    assertThat(instance.matchStartingLabel.isVisible(), is(false));
+    assertThat(instance.matchCancelledLabel.isVisible(), is(false));
+
+    queue.setMatchingStatus(MatchingStatus.MATCH_FOUND);
+    assertThat(instance.matchFoundLabel.isVisible(), is(true));
+    assertThat(instance.matchStartingLabel.isVisible(), is(false));
+    assertThat(instance.matchCancelledLabel.isVisible(), is(false));
+
+    queue.setMatchingStatus(MatchingStatus.MATCH_CANCELLED);
+    assertThat(instance.matchFoundLabel.isVisible(), is(false));
+    assertThat(instance.matchStartingLabel.isVisible(), is(false));
+    assertThat(instance.matchCancelledLabel.isVisible(), is(true));
+
+    queue.setMatchingStatus(MatchingStatus.GAME_LAUNCHING);
+    assertThat(instance.matchFoundLabel.isVisible(), is(false));
+    assertThat(instance.matchStartingLabel.isVisible(), is(true));
+    assertThat(instance.matchCancelledLabel.isVisible(), is(false));
+
+    queue.setMatchingStatus(null);
+    assertThat(instance.matchFoundLabel.isVisible(), is(false));
+    assertThat(instance.matchStartingLabel.isVisible(), is(false));
+    assertThat(instance.matchCancelledLabel.isVisible(), is(false));
+  }
+
+  @Test
+  public void testPopulationListener() {
+    assertThat(instance.playersInQueueLabel.getText(), is(String.valueOf(queue.getPlayersInQueue())));
+    when(i18n.get(eq("teammatchmaking.playersInQueue"), anyInt())).thenReturn("10");
+    runOnFxThreadAndWait(() -> queue.setPlayersInQueue(10));
+    verify(i18n).get("teammatchmaking.playersInQueue", queue.getPlayersInQueue());
+    assertThat(instance.playersInQueueLabel.getText(), is(String.valueOf(queue.getPlayersInQueue())));
+  }
+
+  @Test
+  public void testQueueStateListener() {
+    assertThat(instance.refreshingLabel.isVisible(), is(false));
+    assertThat(instance.joinLeaveQueueButton.isSelected(), is(false));
+    instance.refreshingLabel.setVisible(true);
+    runOnFxThreadAndWait(() -> queue.setJoined(true));
+    assertThat(instance.refreshingLabel.isVisible(), is(false));
+    assertThat(instance.joinLeaveQueueButton.isSelected(), is(true));
+    instance.refreshingLabel.setVisible(true);
+    runOnFxThreadAndWait(() -> queue.setJoined(false));
+    assertThat(instance.refreshingLabel.isVisible(), is(false));
+    assertThat(instance.joinLeaveQueueButton.isSelected(), is(false));
+  }
+
+  @Test
+  public void testPartySizeListener() {
+    assertThat(instance.joinLeaveQueueButton.isDisabled(), is(false));
+
+    runOnFxThreadAndWait(() -> party.getMembers().add(new PartyBuilder.PartyMemberBuilder(
+        PlayerBuilder.create("notMe").defaultValues().get()).defaultValues().get()));
+    assertThat(instance.joinLeaveQueueButton.isDisabled(), is(true));
+
+    runOnFxThreadAndWait(() -> party.getMembers().setAll(party.getMembers().get(0)));
+    assertThat(instance.joinLeaveQueueButton.isDisabled(), is(false));
+  }
+
+  @Test
+  public void testTeamSizeListener() {
+    assertThat(instance.joinLeaveQueueButton.isDisabled(), is(false));
+
+    runOnFxThreadAndWait(() -> queue.setTeamSize(0));
+    assertThat(instance.joinLeaveQueueButton.isDisabled(), is(true));
+
+    runOnFxThreadAndWait(() -> queue.setTeamSize(2));
+    assertThat(instance.joinLeaveQueueButton.isDisabled(), is(false));
+  }
+
+  @Test
+  public void testPartyOwnerListener() {
+    assertThat(instance.joinLeaveQueueButton.isDisabled(), is(false));
+
+    runOnFxThreadAndWait(() -> party.setOwner(PlayerBuilder.create("notMe").defaultValues().id(100).get()));
+    assertThat(instance.joinLeaveQueueButton.isDisabled(), is(true));
+
+    runOnFxThreadAndWait(() -> party.setOwner(player));
+    assertThat(instance.joinLeaveQueueButton.isDisabled(), is(false));
+  }
+
+  @Test
+  public void testMembersNotReadyListener() {
+    assertThat(instance.joinLeaveQueueButton.isDisabled(), is(false));
+
+    when(teamMatchmakingService.partyMembersNotReady()).thenReturn(true);
+    runOnFxThreadAndWait(() -> partyMembersNotReadyProperty.set(true));
+    assertThat(instance.joinLeaveQueueButton.isDisabled(), is(true));
   }
 }

--- a/src/test/java/com/faforever/client/teammatchmaking/PartyBuilder.java
+++ b/src/test/java/com/faforever/client/teammatchmaking/PartyBuilder.java
@@ -1,0 +1,72 @@
+package com.faforever.client.teammatchmaking;
+
+import com.faforever.client.player.Player;
+import com.faforever.client.player.PlayerBuilder;
+import com.faforever.client.teammatchmaking.Party.PartyMember;
+import com.faforever.commons.api.dto.Faction;
+import javafx.beans.InvalidationListener;
+
+import java.util.List;
+
+public class PartyBuilder {
+  private final Party party = new Party();
+
+  public static PartyBuilder create() {
+    return new PartyBuilder();
+  }
+
+  public PartyBuilder defaultValues() {
+    Player player = PlayerBuilder.create("junit").defaultValues().get();
+    owner(player);
+    members(List.of(PartyMemberBuilder.create(player).defaultValues().get()));
+    return this;
+  }
+
+  public PartyBuilder owner(Player owner) {
+    party.setOwner(owner);
+    return this;
+  }
+
+  public PartyBuilder members(List<PartyMember> members) {
+    party.setMembers(members);
+    return this;
+  }
+
+  public Party get() {
+    return party;
+  }
+
+
+  public static class PartyMemberBuilder {
+    private final PartyMember partyMember;
+
+    public PartyMemberBuilder(Player player) {
+      partyMember = new PartyMember(player);
+    }
+
+    public static PartyMemberBuilder create(Player player) {
+      return new PartyMemberBuilder(player);
+    }
+
+    public PartyMemberBuilder defaultValues() {
+      factions(List.of(Faction.values()));
+      gameStatusChangeListener(null);
+      return this;
+    }
+
+    public PartyMemberBuilder factions(List<Faction> factions) {
+      partyMember.setFactions(factions);
+      return this;
+    }
+
+    public PartyMemberBuilder gameStatusChangeListener(InvalidationListener gameStatusChangeListener) {
+      partyMember.setGameStatusChangeListener(gameStatusChangeListener);
+      return this;
+    }
+
+    public PartyMember get() {
+      return partyMember;
+    }
+
+  }
+}

--- a/src/test/java/com/faforever/client/teammatchmaking/TeamMatchmakingControllerTest.java
+++ b/src/test/java/com/faforever/client/teammatchmaking/TeamMatchmakingControllerTest.java
@@ -5,23 +5,25 @@ import com.faforever.client.chat.CountryFlagService;
 import com.faforever.client.chat.MatchmakingChatController;
 import com.faforever.client.chat.avatar.AvatarService;
 import com.faforever.client.chat.event.ChatMessageEvent;
+import com.faforever.client.game.GameBuilder;
 import com.faforever.client.i18n.I18n;
 import com.faforever.client.player.Player;
+import com.faforever.client.player.PlayerBuilder;
 import com.faforever.client.player.PlayerService;
 import com.faforever.client.preferences.Preferences;
 import com.faforever.client.preferences.PreferencesBuilder;
 import com.faforever.client.preferences.PreferencesService;
-import com.faforever.client.remote.FafService;
-import com.faforever.client.teammatchmaking.Party.PartyMember;
+import com.faforever.client.teammatchmaking.PartyBuilder.PartyMemberBuilder;
 import com.faforever.client.test.AbstractPlainJavaFxTest;
 import com.faforever.client.theme.UiService;
 import com.faforever.commons.api.dto.Faction;
 import com.google.common.eventbus.EventBus;
+import javafx.beans.property.ReadOnlyBooleanWrapper;
 import javafx.beans.property.SimpleBooleanProperty;
-import javafx.beans.property.SimpleObjectProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.scene.control.Tab;
+import javafx.scene.layout.AnchorPane;
 import javafx.scene.layout.VBox;
 import org.junit.Before;
 import org.junit.Test;
@@ -32,11 +34,16 @@ import org.testfx.util.WaitForAsyncUtils;
 import java.util.List;
 import java.util.Optional;
 
+import static com.faforever.client.teammatchmaking.PartyMemberItemController.LEADER_PSEUDO_CLASS;
+import static com.faforever.client.teammatchmaking.TeamMatchmakingController.CHAT_AT_BOTTOM_PSEUDO_CLASS;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -60,31 +67,33 @@ public class TeamMatchmakingControllerTest extends AbstractPlainJavaFxTest {
   @Mock
   private TeamMatchmakingService teamMatchmakingService;
   @Mock
-  private FafService fafService;
-  @Mock
   private EventBus eventBus;
 
   private Preferences preferences;
   private TeamMatchmakingController instance;
+  private Player player;
+  private Party party;
+  private ObservableList<MatchmakingQueue> matchmakingQueues;
 
   @Before
   public void setUp() throws Exception {
-    Player player = new Player("tester");
-    player.setId(1);
-    prepareParty(player);
+    party = PartyBuilder.create().defaultValues().get();
+    player = party.getOwner();
+    matchmakingQueues = FXCollections.synchronizedObservableList(FXCollections.observableArrayList());
     ObservableList<Faction> factionList = FXCollections.observableArrayList(Faction.SERAPHIM, Faction.AEON);
-
     preferences = PreferencesBuilder.create().defaultValues()
         .matchmakerPrefs()
         .factions(factionList)
         .then()
         .get();
+
+    when(teamMatchmakingService.getParty()).thenReturn(party);
     when(preferencesService.getPreferences()).thenReturn(preferences);
     when(i18n.get(anyString(), any(Object.class))).thenReturn("");
     when(teamMatchmakingService.currentlyInQueueProperty()).thenReturn(new SimpleBooleanProperty(false));
-    when(teamMatchmakingService.queuesReadyForUpdateProperty()).thenReturn(new SimpleBooleanProperty(false));
-    when(teamMatchmakingService.getPlayersInGame()).thenReturn(FXCollections.observableSet());
-    when(playerService.currentPlayerProperty()).thenReturn(new SimpleObjectProperty<Player>());
+    when(teamMatchmakingService.partyMembersNotReadyProperty()).thenReturn(new ReadOnlyBooleanWrapper());
+    when(teamMatchmakingService.partyMembersNotReady()).thenReturn(false);
+    when(teamMatchmakingService.getMatchmakingQueues()).thenReturn(matchmakingQueues);
     when(playerService.getCurrentPlayer()).thenReturn(Optional.of(player));
     when(i18n.get(anyString())).thenReturn("");
     when(uiService.loadFxml("theme/play/teammatchmaking/matchmaking_chat.fxml")).thenAnswer(invocation -> {
@@ -93,18 +102,8 @@ public class TeamMatchmakingControllerTest extends AbstractPlainJavaFxTest {
       return controller;
     });
     instance = new TeamMatchmakingController(countryFlagService, avatarService, preferencesService, playerService, i18n, uiService,
-        teamMatchmakingService, fafService, eventBus);
+        teamMatchmakingService, eventBus);
     loadFxml("theme/play/team_matchmaking.fxml", clazz -> instance);
-  }
-
-  private void prepareParty(Player player) {
-    Party party = new Party();
-    party.setOwner(player);
-    PartyMember member = new PartyMember(player);
-    ObservableList<PartyMember> members = FXCollections.observableArrayList();
-    members.add(member);
-    party.setMembers(members);
-    when(teamMatchmakingService.getParty()).thenReturn(party);
   }
 
   @Test
@@ -146,15 +145,11 @@ public class TeamMatchmakingControllerTest extends AbstractPlainJavaFxTest {
     instance.aeonButton.setSelected(true);
     instance.cybranButton.setSelected(false);
     instance.seraphimButton.setSelected(false);
-    @SuppressWarnings("unchecked")
-    ArgumentCaptor<List<Faction>> captor = ArgumentCaptor.forClass(List.class);
 
     instance.onFactionButtonClicked();
 
     assertThat(preferences.getMatchmaker().getFactions(), containsInAnyOrder(Faction.UEF, Faction.AEON));
-    // First invocation happens in initialize()
-    verify(teamMatchmakingService, times(2)).sendFactionSelection(captor.capture());
-    assertThat(captor.getValue(), containsInAnyOrder(Faction.UEF, Faction.AEON));
+    verify(teamMatchmakingService, times(2)).sendFactionSelection(eq(List.of(Faction.UEF, Faction.AEON)));
     verify(preferencesService).storeInBackground();
   }
 
@@ -199,19 +194,87 @@ public class TeamMatchmakingControllerTest extends AbstractPlainJavaFxTest {
   }
 
   @Test
+  public void testQueueHeadingListener() {
+    verify(i18n, times(2)).get("teammatchmaking.queueTitle");
+
+    runOnFxThreadAndWait(() -> player.setGame(GameBuilder.create().defaultValues().get()));
+    verify(i18n).get("teammatchmaking.queueTitle.inGame");
+
+    when(teamMatchmakingService.partyMembersNotReady()).thenReturn(true);
+    runOnFxThreadAndWait(() -> player.setGame(null));
+    verify(i18n).get("teammatchmaking.queueTitle.memberInGame");
+
+    runOnFxThreadAndWait(() -> party.setOwner(PlayerBuilder.create("test").defaultValues().id(100).get()));
+    verify(i18n).get("teammatchmaking.queueTitle.inParty");
+
+    when(teamMatchmakingService.isCurrentlyInQueue()).thenReturn(true);
+    runOnFxThreadAndWait(() -> party.setOwner(player));
+    verify(i18n).get("teammatchmaking.queueTitle.inParty");
+  }
+
+  @Test
   public void testOnQueuesAdded() {
-    ObservableList<MatchmakingQueue> queues = FXCollections.observableArrayList();
-    queues.addAll(new MatchmakingQueue(), new MatchmakingQueue());
-    when(teamMatchmakingService.getMatchmakingQueues()).thenReturn(queues);
     when(uiService.loadFxml("theme/play/teammatchmaking/matchmaking_queue_card.fxml")).thenAnswer(invocation -> {
       MatchmakingQueueItemController controller = mock(MatchmakingQueueItemController.class);
       when(controller.getRoot()).thenReturn(new VBox());
       return controller;
     });
 
-    teamMatchmakingService.queuesReadyForUpdateProperty().set(true);
+    matchmakingQueues.add(MatchmakingQueueBuilder.create().defaultValues().queueId(1).get());
+    matchmakingQueues.add(MatchmakingQueueBuilder.create().defaultValues().queueId(2).get());
     WaitForAsyncUtils.waitForFxEvents();
 
     assertThat(instance.queuePane.getChildren().size(), is(2));
+
+    matchmakingQueues.add(MatchmakingQueueBuilder.create().defaultValues().queueId(3).get());
+    matchmakingQueues.add(MatchmakingQueueBuilder.create().defaultValues().queueId(4).get());
+    WaitForAsyncUtils.waitForFxEvents();
+
+    assertThat(instance.queuePane.getChildren().size(), is(4));
+  }
+
+  @Test
+  public void testOnPartyMembersAdded() {
+    when(uiService.loadFxml("theme/play/teammatchmaking/matchmaking_member_card.fxml")).thenAnswer(invocation -> {
+      PartyMemberItemController controller = mock(PartyMemberItemController.class);
+      when(controller.getRoot()).thenReturn(new AnchorPane());
+      return controller;
+    });
+
+    assertFalse(instance.playerCard.getPseudoClassStates().contains(LEADER_PSEUDO_CLASS));
+
+    Player player1 = PlayerBuilder.create("m1").defaultValues().id(101).get();
+    Player player2 = PlayerBuilder.create("m2").defaultValues().id(102).get();
+    party.getMembers().add(PartyMemberBuilder.create(player1).defaultValues().get());
+    party.getMembers().add(PartyMemberBuilder.create(player2).defaultValues().get());
+    WaitForAsyncUtils.waitForFxEvents();
+
+    assertTrue(instance.playerCard.getPseudoClassStates().contains(LEADER_PSEUDO_CLASS));
+    assertThat(instance.partyMemberPane.getChildren().size(), is(2));
+
+    Player player3 = PlayerBuilder.create("m3").defaultValues().id(103).get();
+    party.getMembers().add(PartyMemberBuilder.create(player3).defaultValues().get());
+    WaitForAsyncUtils.waitForFxEvents();
+
+    assertThat(instance.partyMemberPane.getChildren().size(), is(3));
+
+    party.getMembers().remove(3);
+    WaitForAsyncUtils.waitForFxEvents();
+
+    assertThat(instance.partyMemberPane.getChildren().size(), is(2));
+  }
+
+  @Test
+  public void testGetRoot() {
+    assertThat(instance.getRoot(), is(instance.teamMatchmakingRoot));
+  }
+
+  @Test
+  public void testDynamicChatListener() {
+    runOnFxThreadAndWait(() -> instance.contentPane.resize(2000, 1000));
+    assertFalse(instance.chatTabPane.getPseudoClassStates().contains(CHAT_AT_BOTTOM_PSEUDO_CLASS));
+
+    runOnFxThreadAndWait(() -> instance.contentPane.resize(1000, 1000));
+    assertTrue(instance.chatTabPane.getPseudoClassStates().contains(CHAT_AT_BOTTOM_PSEUDO_CLASS));
   }
 }


### PR DESCRIPTION
Currently there is little separation between the service and ui controller for teammatchmaking. The service is frequently changing the UI directly and the controller is modifying service variables directly.

This pr aims to clean up the code.

Closes #2148 