### PR TITLE
Use listeners for chat users

### DIFF
--- a/src/main/java/com/faforever/client/chat/ChatChannelUser.java
+++ b/src/main/java/com/faforever/client/chat/ChatChannelUser.java
@@ -5,6 +5,7 @@ import com.faforever.client.fx.JavaFxUtil;
 import com.faforever.client.game.PlayerStatus;
 import com.faforever.client.player.Player;
 import com.faforever.client.player.SocialStatus;
+import javafx.beans.InvalidationListener;
 import javafx.beans.binding.Bindings;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.ObjectProperty;
@@ -51,7 +52,7 @@ public class ChatChannelUser {
   private ChangeListener<String> clanTagChangeListener;
   private ChangeListener<String> avatarChangeListener;
   private ChangeListener<String> countryInvalidationListener;
-  private ChangeListener<Boolean> displayedChangeListener;
+  private InvalidationListener displayedChangeListener;
 
   ChatChannelUser(String username, boolean moderator) {
     this.username = new SimpleStringProperty(username);
@@ -280,11 +281,11 @@ public class ChatChannelUser {
     this.displayed.set(displayed);
   }
 
-  public ChangeListener<Boolean> getDisplayedChangeListener() {
+  public InvalidationListener getDisplayedChangeListener() {
     return displayedChangeListener;
   }
 
-  public void setDisplayedChangeListener(ChangeListener<Boolean> listener) {
+  public void setDisplayedInvalidationListener(InvalidationListener listener) {
     if (player.get() != null) {
       if (displayedChangeListener != null) {
         JavaFxUtil.removeListener(displayed, displayedChangeListener);

--- a/src/main/java/com/faforever/client/chat/ChatChannelUser.java
+++ b/src/main/java/com/faforever/client/chat/ChatChannelUser.java
@@ -291,7 +291,7 @@ public class ChatChannelUser {
       }
       displayedChangeListener = listener;
       if (displayedChangeListener != null) {
-        JavaFxUtil.addListener(displayed, displayedChangeListener);
+        JavaFxUtil.addAndTriggerListener(displayed, displayedChangeListener);
       }
     }
   }
@@ -306,7 +306,7 @@ public class ChatChannelUser {
     }
     socialStatusChangeListener = listener;
     if (socialStatusChangeListener != null) {
-      JavaFxUtil.addListener(socialStatus, socialStatusChangeListener);
+      JavaFxUtil.addAndTriggerListener(socialStatus, socialStatusChangeListener);
     }
   }
 
@@ -320,7 +320,7 @@ public class ChatChannelUser {
     }
     gameStatusChangeListener = listener;
     if (gameStatusChangeListener != null) {
-      JavaFxUtil.addListener(gameStatus, gameStatusChangeListener);
+      JavaFxUtil.addAndTriggerListener(gameStatus, gameStatusChangeListener);
     }
   }
 
@@ -334,7 +334,7 @@ public class ChatChannelUser {
     }
     clanTagChangeListener = listener;
     if (clanTagChangeListener != null) {
-      JavaFxUtil.addListener(clanTag, clanTagChangeListener);
+      JavaFxUtil.addAndTriggerListener(clanTag, clanTagChangeListener);
     }
   }
 
@@ -349,7 +349,7 @@ public class ChatChannelUser {
       }
       countryInvalidationListener = listener;
       if (countryInvalidationListener != null) {
-        JavaFxUtil.addListener(player.get().countryProperty(), countryInvalidationListener);
+        JavaFxUtil.addAndTriggerListener(player.get().countryProperty(), countryInvalidationListener);
       }
     }
   }
@@ -365,7 +365,7 @@ public class ChatChannelUser {
       }
       avatarChangeListener = listener;
       if (avatarChangeListener != null) {
-        JavaFxUtil.addListener(player.get().avatarUrlProperty(), avatarChangeListener);
+        JavaFxUtil.addAndTriggerListener(player.get().avatarUrlProperty(), avatarChangeListener);
       }
     }
   }
@@ -392,7 +392,7 @@ public class ChatChannelUser {
       socialStatusChangeListener = null;
     }
     if (displayedChangeListener != null) {
-      JavaFxUtil.addListener(displayed, displayedChangeListener);
+      JavaFxUtil.removeListener(displayed, displayedChangeListener);
       displayedChangeListener = null;
     }
   }

--- a/src/main/java/com/faforever/client/chat/ChatUserItemController.java
+++ b/src/main/java/com/faforever/client/chat/ChatUserItemController.java
@@ -240,7 +240,7 @@ public class ChatUserItemController implements Controller<Node> {
     JavaFxUtil.addListener(this.chatUser.lastActiveProperty(), weakChatUserGameListener);
     JavaFxUtil.addListener(this.chatUser.mapImageProperty(), weakChatUserGameListener);
     JavaFxUtil.addListener(this.chatUser.gameStatusImageProperty(), weakChatUserGameListener);
-    JavaFxUtil.addListener(this.chatUser.statusTooltipTextProperty(), weakChatUserGameListener);
+    JavaFxUtil.addAndTriggerListener(this.chatUser.statusTooltipTextProperty(), weakChatUserGameListener);
   }
 
   private void updateChatUserDisplay() {

--- a/src/main/java/com/faforever/client/chat/ChatUserItemController.java
+++ b/src/main/java/com/faforever/client/chat/ChatUserItemController.java
@@ -56,6 +56,7 @@ public class ChatUserItemController implements Controller<Node> {
 
   private final InvalidationListener formatChangeListener;
   private final InvalidationListener chatUserPropertyInvalidationListener;
+  private final InvalidationListener chatUserGamePropertyInvalidationListener;
 
   public ImageView playerMapImage;
   public ImageView playerStatusIndicator;
@@ -85,6 +86,7 @@ public class ChatUserItemController implements Controller<Node> {
 
     formatChangeListener = observable -> updateFormat();
     chatUserPropertyInvalidationListener = observable -> updateChatUserDisplay();
+    chatUserGamePropertyInvalidationListener = observable -> updateChatUserGame();
 
     JavaFxUtil.addListener(chatPrefs.chatFormatProperty(), new WeakInvalidationListener(formatChangeListener));
   }
@@ -210,20 +212,6 @@ public class ChatUserItemController implements Controller<Node> {
     }
 
     if (this.chatUser != null) {
-      JavaFxUtil.removeListener(this.chatUser.usernameProperty(), chatUserPropertyInvalidationListener);
-      JavaFxUtil.removeListener(this.chatUser.colorProperty(), chatUserPropertyInvalidationListener);
-      JavaFxUtil.removeListener(this.chatUser.avatarProperty(), chatUserPropertyInvalidationListener);
-      JavaFxUtil.removeListener(this.chatUser.clanTagProperty(), chatUserPropertyInvalidationListener);
-      JavaFxUtil.removeListener(this.chatUser.countryFlagProperty(), chatUserPropertyInvalidationListener);
-      JavaFxUtil.removeListener(this.chatUser.countryNameProperty(), chatUserPropertyInvalidationListener);
-      JavaFxUtil.removeListener(this.chatUser.mapImageProperty(), chatUserPropertyInvalidationListener);
-      JavaFxUtil.removeListener(this.chatUser.gameStatusImageProperty(), chatUserPropertyInvalidationListener);
-      JavaFxUtil.removeListener(this.chatUser.statusTooltipTextProperty(), chatUserPropertyInvalidationListener);
-      JavaFxUtil.removeListener(this.chatUser.playerProperty(), chatUserPropertyInvalidationListener);
-      JavaFxUtil.removeListener(this.chatUser.socialStatusProperty(), chatUserPropertyInvalidationListener);
-      JavaFxUtil.removeListener(this.chatUser.clanProperty(), chatUserPropertyInvalidationListener);
-      JavaFxUtil.removeListener(this.chatUser.lastActiveProperty(), chatUserPropertyInvalidationListener);
-      JavaFxUtil.removeListener(this.chatUser.moderatorProperty(), chatUserPropertyInvalidationListener);
       this.chatUser.setDisplayed(false);
     }
 
@@ -231,36 +219,50 @@ public class ChatUserItemController implements Controller<Node> {
 
     if (this.chatUser != null) {
       this.chatUser.setDisplayed(true);
-      JavaFxUtil.addListener(this.chatUser.usernameProperty(), chatUserPropertyInvalidationListener);
-      JavaFxUtil.addListener(this.chatUser.colorProperty(), chatUserPropertyInvalidationListener);
-      JavaFxUtil.addListener(this.chatUser.avatarProperty(), chatUserPropertyInvalidationListener);
-      JavaFxUtil.addListener(this.chatUser.clanTagProperty(), chatUserPropertyInvalidationListener);
-      JavaFxUtil.addListener(this.chatUser.countryFlagProperty(), chatUserPropertyInvalidationListener);
-      JavaFxUtil.addListener(this.chatUser.countryNameProperty(), chatUserPropertyInvalidationListener);
-      JavaFxUtil.addListener(this.chatUser.mapImageProperty(), chatUserPropertyInvalidationListener);
-      JavaFxUtil.addListener(this.chatUser.gameStatusImageProperty(), chatUserPropertyInvalidationListener);
-      JavaFxUtil.addListener(this.chatUser.statusTooltipTextProperty(), chatUserPropertyInvalidationListener);
-      JavaFxUtil.addListener(this.chatUser.playerProperty(), chatUserPropertyInvalidationListener);
-      JavaFxUtil.addListener(this.chatUser.socialStatusProperty(), chatUserPropertyInvalidationListener);
-      JavaFxUtil.addListener(this.chatUser.clanProperty(), chatUserPropertyInvalidationListener);
-      JavaFxUtil.addListener(this.chatUser.lastActiveProperty(), chatUserPropertyInvalidationListener);
-      JavaFxUtil.addListener(this.chatUser.moderatorProperty(), chatUserPropertyInvalidationListener);
+      addListeners();
     }
+  }
+
+  private void addListeners() {
+    WeakInvalidationListener weakChatUserPropertyListener = new WeakInvalidationListener(chatUserPropertyInvalidationListener);
+    JavaFxUtil.addListener(this.chatUser.usernameProperty(), weakChatUserPropertyListener);
+    JavaFxUtil.addListener(this.chatUser.colorProperty(), weakChatUserPropertyListener);
+    JavaFxUtil.addListener(this.chatUser.avatarProperty(), weakChatUserPropertyListener);
+    JavaFxUtil.addListener(this.chatUser.clanTagProperty(), weakChatUserPropertyListener);
+    JavaFxUtil.addListener(this.chatUser.countryFlagProperty(), weakChatUserPropertyListener);
+    JavaFxUtil.addListener(this.chatUser.countryNameProperty(), weakChatUserPropertyListener);
+    JavaFxUtil.addListener(this.chatUser.playerProperty(), weakChatUserPropertyListener);
+    JavaFxUtil.addListener(this.chatUser.socialStatusProperty(), weakChatUserPropertyListener);
+    JavaFxUtil.addListener(this.chatUser.clanProperty(), weakChatUserPropertyListener);
+    JavaFxUtil.addAndTriggerListener(this.chatUser.moderatorProperty(), weakChatUserPropertyListener);
+
+    WeakInvalidationListener weakChatUserGameListener = new WeakInvalidationListener(chatUserGamePropertyInvalidationListener);
+    JavaFxUtil.addListener(this.chatUser.lastActiveProperty(), weakChatUserGameListener);
+    JavaFxUtil.addListener(this.chatUser.mapImageProperty(), weakChatUserGameListener);
+    JavaFxUtil.addListener(this.chatUser.gameStatusImageProperty(), weakChatUserGameListener);
+    JavaFxUtil.addListener(this.chatUser.statusTooltipTextProperty(), weakChatUserGameListener);
   }
 
   private void updateChatUserDisplay() {
     String styleString = chatUser.getColor().map(color -> String.format("-fx-text-fill: %s", JavaFxUtil.toRgbCode(color))).orElse("");
     String avatarString = chatUser.getPlayer().map(Player::getAvatarTooltip).orElse("");
+    String clanString = chatUser.getClanTag().orElse("");
     JavaFxUtil.runLater(() -> {
       usernameLabel.setText(chatUser.getUsername());
       usernameLabel.setStyle(styleString);
       avatarImageView.setImage(chatUser.getAvatar().orElse(null));
       countryImageView.setImage(chatUser.getCountryFlag().orElse(null));
       countryTooltip.setText(chatUser.getCountryName().orElse(""));
+      avatarTooltip.setText(avatarString);
+      clanMenu.setText(clanString);
+    });
+  }
+
+  private void updateChatUserGame() {
+    JavaFxUtil.runLater(() -> {
       playerMapImage.setImage(chatUser.getMapImage().orElse(null));
       playerStatusIndicator.setImage(chatUser.getGameStatusImage().orElse(null));
       statusGameTooltip.setText(chatUser.getStatusTooltipText().orElse(""));
-      avatarTooltip.setText(avatarString);
     });
   }
 

--- a/src/main/java/com/faforever/client/chat/ChatUserItemController.java
+++ b/src/main/java/com/faforever/client/chat/ChatUserItemController.java
@@ -15,7 +15,6 @@ import com.faforever.client.theme.UiService;
 import com.google.common.eventbus.EventBus;
 import javafx.beans.InvalidationListener;
 import javafx.beans.WeakInvalidationListener;
-import javafx.beans.binding.Bindings;
 import javafx.css.PseudoClass;
 import javafx.event.EventHandler;
 import javafx.scene.Node;
@@ -87,8 +86,6 @@ public class ChatUserItemController implements Controller<Node> {
     formatChangeListener = observable -> updateFormat();
     chatUserPropertyInvalidationListener = observable -> updateChatUserDisplay();
     chatUserGamePropertyInvalidationListener = observable -> updateChatUserGame();
-
-    JavaFxUtil.addListener(chatPrefs.chatFormatProperty(), new WeakInvalidationListener(formatChangeListener));
   }
 
   private void updateFormat() {
@@ -104,15 +101,14 @@ public class ChatUserItemController implements Controller<Node> {
 
     initializeTooltips();
 
-    formatChangeListener.invalidated(chatPrefs.chatFormatProperty());
-
     JavaFxUtil.bindManagedToVisible(countryImageView, clanMenu, playerStatusIndicator, playerMapImage);
 
-    JavaFxUtil.bind(avatarImageView.visibleProperty(), Bindings.isNotNull(avatarImageView.imageProperty()));
-    JavaFxUtil.bind(countryImageView.visibleProperty(), Bindings.isNotNull(countryImageView.imageProperty()));
-    JavaFxUtil.bind(clanMenu.visibleProperty(), Bindings.isNotEmpty(clanMenu.textProperty()));
-    JavaFxUtil.bind(playerStatusIndicator.visibleProperty(), Bindings.isNotNull(playerStatusIndicator.imageProperty()));
-    JavaFxUtil.bind(playerMapImage.visibleProperty(), Bindings.isNotNull(playerMapImage.imageProperty()));
+    JavaFxUtil.bind(avatarImageView.visibleProperty(), avatarImageView.imageProperty().isNotNull());
+    JavaFxUtil.bind(countryImageView.visibleProperty(), countryImageView.imageProperty().isNotNull());
+    JavaFxUtil.bind(clanMenu.visibleProperty(), clanMenu.textProperty().isNotEmpty());
+    JavaFxUtil.bind(playerStatusIndicator.visibleProperty(), playerStatusIndicator.imageProperty().isNotNull());
+    JavaFxUtil.bind(playerMapImage.visibleProperty(), playerMapImage.imageProperty().isNotNull());
+    JavaFxUtil.addAndTriggerListener(chatPrefs.chatFormatProperty(), new WeakInvalidationListener(formatChangeListener));
 
     updateFormat();
     addEventHandlersToPlayerMapImage();

--- a/src/main/java/com/faforever/client/chat/ChatUserService.java
+++ b/src/main/java/com/faforever/client/chat/ChatUserService.java
@@ -3,7 +3,6 @@ package com.faforever.client.chat;
 import com.faforever.client.chat.avatar.AvatarService;
 import com.faforever.client.clan.Clan;
 import com.faforever.client.clan.ClanService;
-import com.faforever.client.fx.JavaFxUtil;
 import com.faforever.client.game.PlayerStatus;
 import com.faforever.client.i18n.I18n;
 import com.faforever.client.map.MapService;
@@ -53,11 +52,10 @@ public class ChatUserService implements InitializingBean {
       chatChannelUser.getPlayer().ifPresent(player -> {
         if (player.getClan() != null) {
           clanService.getClanByTag(player.getClan())
-              .thenAccept(optionalClan -> JavaFxUtil.runLater(() -> {
-                    Clan clan = optionalClan.orElse(null);
-                    chatChannelUser.setClan(clan);
-                  })
-              );
+              .thenAccept(optionalClan -> {
+                Clan clan = optionalClan.orElse(null);
+                chatChannelUser.setClan(clan);
+              });
         } else {
           chatChannelUser.setClan(null);
         }
@@ -77,7 +75,7 @@ public class ChatUserService implements InitializingBean {
             } else {
               avatar = null;
             }
-            JavaFxUtil.runLater(() -> chatChannelUser.setAvatar(avatar));
+            chatChannelUser.setAvatar(avatar);
           });
     } else {
       chatChannelUser.setAvatar(null);
@@ -89,10 +87,8 @@ public class ChatUserService implements InitializingBean {
       chatChannelUser.getPlayer()
           .ifPresent(player -> {
             Optional<Image> countryFlag = countryFlagService.loadCountryFlag(player.getCountry());
-            JavaFxUtil.runLater(() -> {
-              chatChannelUser.setCountryFlag(countryFlag.orElse(null));
-              chatChannelUser.setCountryName(i18n.getCountryNameLocalized(player.getCountry()));
-            });
+            chatChannelUser.setCountryFlag(countryFlag.orElse(null));
+            chatChannelUser.setCountryName(i18n.getCountryNameLocalized(player.getCountry()));
           });
     } else {
       chatChannelUser.setCountryFlag(null);
@@ -152,11 +148,9 @@ public class ChatUserService implements InitializingBean {
     } else {
       mapImage = null;
     }
-    JavaFxUtil.runLater(() -> {
-      chatChannelUser.setStatusTooltipText(i18n.get(status.getI18nKey()));
-      chatChannelUser.setGameStatusImage(playerStatusImage);
-      chatChannelUser.setMapImage(mapImage);
-    });
+    chatChannelUser.setStatusTooltipText(i18n.get(status.getI18nKey()));
+    chatChannelUser.setGameStatusImage(playerStatusImage);
+    chatChannelUser.setMapImage(mapImage);
   }
 
   public void associatePlayerToChatUser(ChatChannelUser chatChannelUser, Player player) {

--- a/src/main/java/com/faforever/client/chat/ChatUserService.java
+++ b/src/main/java/com/faforever/client/chat/ChatUserService.java
@@ -157,6 +157,25 @@ public class ChatUserService implements InitializingBean {
     if (player != null && chatChannelUser.getPlayer().filter(userPlayer -> userPlayer.getUsername().equals(player.getUsername())).isEmpty()) {
       chatChannelUser.setPlayer(player);
       addListeners(chatChannelUser);
+      chatChannelUser.setDisplayedInvalidationListener(observable -> {
+        if (chatChannelUser.isDisplayed()) {
+          addListeners(chatChannelUser);
+          populateGameImages(chatChannelUser);
+          populateClan(chatChannelUser);
+          populateCountry(chatChannelUser);
+          populateAvatar(chatChannelUser);
+          populateColor(chatChannelUser);
+        } else {
+          removeListeners(chatChannelUser);
+          chatChannelUser.setStatusTooltipText(null);
+          chatChannelUser.setGameStatusImage(null);
+          chatChannelUser.setMapImage(null);
+          chatChannelUser.setCountryFlag(null);
+          chatChannelUser.setCountryName(null);
+          chatChannelUser.setClan(null);
+          chatChannelUser.setAvatar(null);
+        }
+      });
     } else if (player == null) {
       chatChannelUser.removeListeners();
       chatChannelUser.setPlayer(null);
@@ -197,25 +216,14 @@ public class ChatUserService implements InitializingBean {
         populateGameImages(chatChannelUser);
       }
     });
-    chatChannelUser.setDisplayedChangeListener((observable, oldValue, newValue) -> {
-      if (oldValue != newValue) {
-        if (newValue) {
-          populateGameImages(chatChannelUser);
-          populateClan(chatChannelUser);
-          populateCountry(chatChannelUser);
-          populateAvatar(chatChannelUser);
-          populateColor(chatChannelUser);
-        } else {
-          chatChannelUser.setStatusTooltipText(null);
-          chatChannelUser.setGameStatusImage(null);
-          chatChannelUser.setMapImage(null);
-          chatChannelUser.setCountryFlag(null);
-          chatChannelUser.setCountryName(null);
-          chatChannelUser.setClan(null);
-          chatChannelUser.setAvatar(null);
-        }
-      }
-    });
+  }
+
+  private void removeListeners(ChatChannelUser chatChannelUser) {
+    chatChannelUser.setAvatarChangeListener(null);
+    chatChannelUser.setClanTagChangeListener(null);
+    chatChannelUser.setCountryChangeListener(null);
+    chatChannelUser.setSocialStatusChangeListener(null);
+    chatChannelUser.setGameStatusChangeListener(null);
   }
 }
 

--- a/src/main/java/com/faforever/client/chat/ChatUserService.java
+++ b/src/main/java/com/faforever/client/chat/ChatUserService.java
@@ -156,11 +156,6 @@ public class ChatUserService implements InitializingBean {
   public void associatePlayerToChatUser(ChatChannelUser chatChannelUser, Player player) {
     if (player != null && chatChannelUser.getPlayer().filter(userPlayer -> userPlayer.getUsername().equals(player.getUsername())).isEmpty()) {
       chatChannelUser.setPlayer(player);
-      populateGameImages(chatChannelUser);
-      populateClan(chatChannelUser);
-      populateCountry(chatChannelUser);
-      populateAvatar(chatChannelUser);
-      populateColor(chatChannelUser);
       addListeners(chatChannelUser);
     } else if (player == null) {
       chatChannelUser.removeListeners();

--- a/src/test/java/com/faforever/client/chat/ChatUserItemControllerTest.java
+++ b/src/test/java/com/faforever/client/chat/ChatUserItemControllerTest.java
@@ -46,7 +46,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class ChatChannelUserItemControllerTest extends AbstractPlainJavaFxTest {
+public class ChatUserItemControllerTest extends AbstractPlainJavaFxTest {
 
   private ChatUserItemController instance;
   @Mock

--- a/src/test/java/com/faforever/client/chat/ChatUserServiceTest.java
+++ b/src/test/java/com/faforever/client/chat/ChatUserServiceTest.java
@@ -22,6 +22,7 @@ import com.faforever.client.remote.domain.GameStatus;
 import com.faforever.client.test.AbstractPlainJavaFxTest;
 import com.faforever.client.theme.UiService;
 import com.google.common.eventbus.EventBus;
+import javafx.beans.InvalidationListener;
 import javafx.beans.value.ChangeListener;
 import javafx.collections.FXCollections;
 import javafx.scene.image.Image;
@@ -195,7 +196,7 @@ public class ChatUserServiceTest extends AbstractPlainJavaFxTest {
     ChangeListener<String> clanTagListener = chatUser.getClanTagChangeListener();
     ChangeListener<String> avatarListener = chatUser.getAvatarChangeListener();
     ChangeListener<String> countryListener = chatUser.getCountryInvalidationListener();
-    ChangeListener<Boolean> displayedListener = chatUser.getDisplayedChangeListener();
+    InvalidationListener displayedListener = chatUser.getDisplayedChangeListener();
 
     Player player2 = PlayerBuilder.create("junit2").defaultValues().get();
     instance.associatePlayerToChatUser(chatUser, player2);

--- a/src/test/java/com/faforever/client/chat/ChatUserServiceTest.java
+++ b/src/test/java/com/faforever/client/chat/ChatUserServiceTest.java
@@ -172,9 +172,9 @@ public class ChatUserServiceTest extends AbstractPlainJavaFxTest {
     chatUser.setDisplayed(false);
     WaitForAsyncUtils.waitForFxEvents();
 
-    verify(clanService).getClanByTag(anyString());
-    verify(countryFlagService).loadCountryFlag(anyString());
-    verify(avatarService).loadAvatar(anyString());
+    verify(clanService, times(2)).getClanByTag(anyString());
+    verify(countryFlagService, times(2)).loadCountryFlag(anyString());
+    verify(avatarService, times(2)).loadAvatar(anyString());
     assertTrue(chatUser.getStatusTooltipText().isEmpty());
     assertTrue(chatUser.getGameStatusImage().isEmpty());
     assertTrue(chatUser.getMapImage().isEmpty());
@@ -238,7 +238,7 @@ public class ChatUserServiceTest extends AbstractPlainJavaFxTest {
     instance.associatePlayerToChatUser(chatUser, player);
     WaitForAsyncUtils.waitForFxEvents();
 
-    verify(clanService).getClanByTag(testClan.getTag());
+    verify(clanService, times(2)).getClanByTag(testClan.getTag());
     assertEquals(chatUser.getClan().orElse(null), testClan);
     assertEquals(chatUser.getClanTag().orElse(null), String.format("[%s]", testClan.getTag()));
   }
@@ -253,7 +253,7 @@ public class ChatUserServiceTest extends AbstractPlainJavaFxTest {
     player.setClan(newClan.getTag());
     WaitForAsyncUtils.waitForFxEvents();
 
-    verify(clanService, times(1)).getClanByTag(testClan.getTag());
+    verify(clanService, times(2)).getClanByTag(testClan.getTag());
     verify(clanService, times(1)).getClanByTag(newClan.getTag());
     assertEquals(chatUser.getClan().orElse(null), newClan);
     assertEquals(chatUser.getClanTag().orElse(null), String.format("[%s]", newClan.getTag()));
@@ -266,7 +266,7 @@ public class ChatUserServiceTest extends AbstractPlainJavaFxTest {
     player.setClan(testClan.getTag());
     WaitForAsyncUtils.waitForFxEvents();
 
-    verify(clanService, times(1)).getClanByTag(testClan.getTag());
+    verify(clanService, times(2)).getClanByTag(testClan.getTag());
     assertEquals(chatUser.getClan().orElse(null), testClan);
     assertEquals(chatUser.getClanTag().orElse(null), String.format("[%s]", testClan.getTag()));
   }
@@ -288,7 +288,7 @@ public class ChatUserServiceTest extends AbstractPlainJavaFxTest {
     instance.associatePlayerToChatUser(chatUser, player);
     WaitForAsyncUtils.waitForFxEvents();
 
-    verify(avatarService).loadAvatar(Objects.requireNonNull(avatar.getUrl()).toExternalForm());
+    verify(avatarService, times(2)).loadAvatar(Objects.requireNonNull(avatar.getUrl()).toExternalForm());
     assertTrue(chatUser.getAvatar().isPresent());
   }
 
@@ -300,7 +300,7 @@ public class ChatUserServiceTest extends AbstractPlainJavaFxTest {
     player.setAvatarUrl(newUrl);
     WaitForAsyncUtils.waitForFxEvents();
 
-    verify(avatarService).loadAvatar(Objects.requireNonNull(avatar.getUrl()).toExternalForm());
+    verify(avatarService, times(2)).loadAvatar(Objects.requireNonNull(avatar.getUrl()).toExternalForm());
     verify(avatarService).loadAvatar(newUrl);
     assertTrue(chatUser.getAvatar().isPresent());
   }
@@ -312,7 +312,7 @@ public class ChatUserServiceTest extends AbstractPlainJavaFxTest {
     player.setAvatarUrl(Objects.requireNonNull(avatar.getUrl()).toExternalForm());
     WaitForAsyncUtils.waitForFxEvents();
 
-    verify(avatarService, times(1)).loadAvatar(avatar.getUrl().toExternalForm());
+    verify(avatarService, times(2)).loadAvatar(avatar.getUrl().toExternalForm());
     assertTrue(chatUser.getAvatar().isPresent());
   }
 
@@ -332,7 +332,7 @@ public class ChatUserServiceTest extends AbstractPlainJavaFxTest {
     instance.associatePlayerToChatUser(chatUser, player);
     WaitForAsyncUtils.waitForFxEvents();
 
-    verify(countryFlagService).loadCountryFlag("US");
+    verify(countryFlagService, times(2)).loadCountryFlag("US");
     assertTrue(chatUser.getCountryFlag().isPresent());
     assertEquals("United States", chatUser.getCountryName().orElse(null));
   }
@@ -346,7 +346,7 @@ public class ChatUserServiceTest extends AbstractPlainJavaFxTest {
     player.setCountry("DE");
     WaitForAsyncUtils.waitForFxEvents();
 
-    verify(countryFlagService).loadCountryFlag("US");
+    verify(countryFlagService, times(2)).loadCountryFlag("US");
     verify(countryFlagService).loadCountryFlag("DE");
     assertTrue(chatUser.getCountryFlag().isPresent());
     assertEquals("Germany", chatUser.getCountryName().orElse(null));
@@ -359,7 +359,7 @@ public class ChatUserServiceTest extends AbstractPlainJavaFxTest {
     player.setCountry("US");
     WaitForAsyncUtils.waitForFxEvents();
 
-    verify(countryFlagService, times(1)).loadCountryFlag("US");
+    verify(countryFlagService, times(2)).loadCountryFlag("US");
     assertTrue(chatUser.getCountryFlag().isPresent());
     assertEquals("United States", chatUser.getCountryName().orElse(null));
   }
@@ -396,7 +396,7 @@ public class ChatUserServiceTest extends AbstractPlainJavaFxTest {
     instance.associatePlayerToChatUser(chatUser, player);
     WaitForAsyncUtils.waitForFxEvents();
 
-    verify(uiService).getThemeImage(UiService.CHAT_LIST_STATUS_PLAYING);
+    verify(uiService, times(2)).getThemeImage(UiService.CHAT_LIST_STATUS_PLAYING);
     assertTrue(chatUser.getMapImage().isPresent());
     assertEquals(PlayerStatus.PLAYING, chatUser.getGameStatus().orElse(null));
     assertEquals("Playing", chatUser.getStatusTooltipText().orElse(null));
@@ -410,7 +410,7 @@ public class ChatUserServiceTest extends AbstractPlainJavaFxTest {
     instance.associatePlayerToChatUser(chatUser, player);
     WaitForAsyncUtils.waitForFxEvents();
 
-    verify(uiService).getThemeImage(UiService.CHAT_LIST_STATUS_HOSTING);
+    verify(uiService, times(2)).getThemeImage(UiService.CHAT_LIST_STATUS_HOSTING);
     assertTrue(chatUser.getMapImage().isPresent());
     assertEquals(PlayerStatus.HOSTING, chatUser.getGameStatus().orElse(null));
     assertEquals("Hosting", chatUser.getStatusTooltipText().orElse(null));
@@ -424,7 +424,7 @@ public class ChatUserServiceTest extends AbstractPlainJavaFxTest {
     instance.associatePlayerToChatUser(chatUser, player);
     WaitForAsyncUtils.waitForFxEvents();
 
-    verify(uiService).getThemeImage(UiService.CHAT_LIST_STATUS_LOBBYING);
+    verify(uiService, times(2)).getThemeImage(UiService.CHAT_LIST_STATUS_LOBBYING);
     assertTrue(chatUser.getMapImage().isPresent());
     assertEquals(PlayerStatus.LOBBYING, chatUser.getGameStatus().orElse(null));
     assertEquals("Waiting for game to start", chatUser.getStatusTooltipText().orElse(null));
@@ -440,7 +440,7 @@ public class ChatUserServiceTest extends AbstractPlainJavaFxTest {
     game.setStatus(GameStatus.PLAYING);
     WaitForAsyncUtils.waitForFxEvents();
 
-    verify(uiService).getThemeImage(UiService.CHAT_LIST_STATUS_LOBBYING);
+    verify(uiService, times(2)).getThemeImage(UiService.CHAT_LIST_STATUS_LOBBYING);
     verify(uiService).getThemeImage(UiService.CHAT_LIST_STATUS_PLAYING);
     assertTrue(chatUser.getMapImage().isPresent());
     assertEquals(PlayerStatus.PLAYING, chatUser.getGameStatus().orElse(null));
@@ -456,7 +456,7 @@ public class ChatUserServiceTest extends AbstractPlainJavaFxTest {
     game.setStatus(GameStatus.OPEN);
     WaitForAsyncUtils.waitForFxEvents();
 
-    verify(uiService, times(1)).getThemeImage(UiService.CHAT_LIST_STATUS_LOBBYING);
+    verify(uiService, times(2)).getThemeImage(UiService.CHAT_LIST_STATUS_LOBBYING);
     assertTrue(chatUser.getMapImage().isPresent());
     assertEquals(PlayerStatus.LOBBYING, chatUser.getGameStatus().orElse(null));
     assertEquals("Waiting for game to start", chatUser.getStatusTooltipText().orElse(null));

--- a/src/test/java/com/faforever/client/chat/ChatUserServiceTest.java
+++ b/src/test/java/com/faforever/client/chat/ChatUserServiceTest.java
@@ -139,11 +139,11 @@ public class ChatUserServiceTest extends AbstractPlainJavaFxTest {
     verify(avatarService, never()).loadAvatar(anyString());
     verify(mapService, never()).loadPreview(anyString(), any(PreviewSize.class));
     verify(uiService, never()).getThemeImage(anyString());
-    assertNotNull(chatUser.getAvatarChangeListener());
-    assertNotNull(chatUser.getSocialStatus());
-    assertNotNull(chatUser.getClanTagChangeListener());
-    assertNotNull(chatUser.getCountryInvalidationListener());
-    assertNotNull(chatUser.getGameStatusChangeListener());
+    assertNull(chatUser.getAvatarChangeListener());
+    assertNull(chatUser.getSocialStatusChangeListener());
+    assertNull(chatUser.getClanTagChangeListener());
+    assertNull(chatUser.getCountryInvalidationListener());
+    assertNull(chatUser.getGameStatusChangeListener());
     assertNotNull(chatUser.getDisplayedChangeListener());
   }
 
@@ -154,9 +154,9 @@ public class ChatUserServiceTest extends AbstractPlainJavaFxTest {
     chatUser.setDisplayed(true);
     WaitForAsyncUtils.waitForFxEvents();
 
-    verify(clanService).getClanByTag(anyString());
-    verify(countryFlagService).loadCountryFlag(anyString());
-    verify(avatarService).loadAvatar(anyString());
+    verify(clanService, times(2)).getClanByTag(anyString());
+    verify(countryFlagService, times(2)).loadCountryFlag(anyString());
+    verify(avatarService, times(2)).loadAvatar(anyString());
     assertNotNull(chatUser.getAvatarChangeListener());
     assertNotNull(chatUser.getSocialStatus());
     assertNotNull(chatUser.getClanTagChangeListener());
@@ -173,9 +173,9 @@ public class ChatUserServiceTest extends AbstractPlainJavaFxTest {
     chatUser.setDisplayed(false);
     WaitForAsyncUtils.waitForFxEvents();
 
-    verify(clanService, times(2)).getClanByTag(anyString());
-    verify(countryFlagService, times(2)).loadCountryFlag(anyString());
-    verify(avatarService, times(2)).loadAvatar(anyString());
+    verify(clanService, times(3)).getClanByTag(anyString());
+    verify(countryFlagService, times(3)).loadCountryFlag(anyString());
+    verify(avatarService, times(3)).loadAvatar(anyString());
     assertTrue(chatUser.getStatusTooltipText().isEmpty());
     assertTrue(chatUser.getGameStatusImage().isEmpty());
     assertTrue(chatUser.getMapImage().isEmpty());
@@ -239,7 +239,7 @@ public class ChatUserServiceTest extends AbstractPlainJavaFxTest {
     instance.associatePlayerToChatUser(chatUser, player);
     WaitForAsyncUtils.waitForFxEvents();
 
-    verify(clanService, times(2)).getClanByTag(testClan.getTag());
+    verify(clanService, times(3)).getClanByTag(testClan.getTag());
     assertEquals(chatUser.getClan().orElse(null), testClan);
     assertEquals(chatUser.getClanTag().orElse(null), String.format("[%s]", testClan.getTag()));
   }
@@ -254,7 +254,7 @@ public class ChatUserServiceTest extends AbstractPlainJavaFxTest {
     player.setClan(newClan.getTag());
     WaitForAsyncUtils.waitForFxEvents();
 
-    verify(clanService, times(2)).getClanByTag(testClan.getTag());
+    verify(clanService, times(3)).getClanByTag(testClan.getTag());
     verify(clanService, times(1)).getClanByTag(newClan.getTag());
     assertEquals(chatUser.getClan().orElse(null), newClan);
     assertEquals(chatUser.getClanTag().orElse(null), String.format("[%s]", newClan.getTag()));
@@ -267,7 +267,7 @@ public class ChatUserServiceTest extends AbstractPlainJavaFxTest {
     player.setClan(testClan.getTag());
     WaitForAsyncUtils.waitForFxEvents();
 
-    verify(clanService, times(2)).getClanByTag(testClan.getTag());
+    verify(clanService, times(3)).getClanByTag(testClan.getTag());
     assertEquals(chatUser.getClan().orElse(null), testClan);
     assertEquals(chatUser.getClanTag().orElse(null), String.format("[%s]", testClan.getTag()));
   }
@@ -289,7 +289,7 @@ public class ChatUserServiceTest extends AbstractPlainJavaFxTest {
     instance.associatePlayerToChatUser(chatUser, player);
     WaitForAsyncUtils.waitForFxEvents();
 
-    verify(avatarService, times(2)).loadAvatar(Objects.requireNonNull(avatar.getUrl()).toExternalForm());
+    verify(avatarService, times(3)).loadAvatar(Objects.requireNonNull(avatar.getUrl()).toExternalForm());
     assertTrue(chatUser.getAvatar().isPresent());
   }
 
@@ -301,7 +301,7 @@ public class ChatUserServiceTest extends AbstractPlainJavaFxTest {
     player.setAvatarUrl(newUrl);
     WaitForAsyncUtils.waitForFxEvents();
 
-    verify(avatarService, times(2)).loadAvatar(Objects.requireNonNull(avatar.getUrl()).toExternalForm());
+    verify(avatarService, times(3)).loadAvatar(Objects.requireNonNull(avatar.getUrl()).toExternalForm());
     verify(avatarService).loadAvatar(newUrl);
     assertTrue(chatUser.getAvatar().isPresent());
   }
@@ -313,7 +313,7 @@ public class ChatUserServiceTest extends AbstractPlainJavaFxTest {
     player.setAvatarUrl(Objects.requireNonNull(avatar.getUrl()).toExternalForm());
     WaitForAsyncUtils.waitForFxEvents();
 
-    verify(avatarService, times(2)).loadAvatar(avatar.getUrl().toExternalForm());
+    verify(avatarService, times(3)).loadAvatar(avatar.getUrl().toExternalForm());
     assertTrue(chatUser.getAvatar().isPresent());
   }
 
@@ -333,7 +333,7 @@ public class ChatUserServiceTest extends AbstractPlainJavaFxTest {
     instance.associatePlayerToChatUser(chatUser, player);
     WaitForAsyncUtils.waitForFxEvents();
 
-    verify(countryFlagService, times(2)).loadCountryFlag("US");
+    verify(countryFlagService, times(3)).loadCountryFlag("US");
     assertTrue(chatUser.getCountryFlag().isPresent());
     assertEquals("United States", chatUser.getCountryName().orElse(null));
   }
@@ -347,7 +347,7 @@ public class ChatUserServiceTest extends AbstractPlainJavaFxTest {
     player.setCountry("DE");
     WaitForAsyncUtils.waitForFxEvents();
 
-    verify(countryFlagService, times(2)).loadCountryFlag("US");
+    verify(countryFlagService, times(3)).loadCountryFlag("US");
     verify(countryFlagService).loadCountryFlag("DE");
     assertTrue(chatUser.getCountryFlag().isPresent());
     assertEquals("Germany", chatUser.getCountryName().orElse(null));
@@ -360,7 +360,7 @@ public class ChatUserServiceTest extends AbstractPlainJavaFxTest {
     player.setCountry("US");
     WaitForAsyncUtils.waitForFxEvents();
 
-    verify(countryFlagService, times(2)).loadCountryFlag("US");
+    verify(countryFlagService, times(3)).loadCountryFlag("US");
     assertTrue(chatUser.getCountryFlag().isPresent());
     assertEquals("United States", chatUser.getCountryName().orElse(null));
   }
@@ -397,7 +397,7 @@ public class ChatUserServiceTest extends AbstractPlainJavaFxTest {
     instance.associatePlayerToChatUser(chatUser, player);
     WaitForAsyncUtils.waitForFxEvents();
 
-    verify(uiService, times(2)).getThemeImage(UiService.CHAT_LIST_STATUS_PLAYING);
+    verify(uiService, times(3)).getThemeImage(UiService.CHAT_LIST_STATUS_PLAYING);
     assertTrue(chatUser.getMapImage().isPresent());
     assertEquals(PlayerStatus.PLAYING, chatUser.getGameStatus().orElse(null));
     assertEquals("Playing", chatUser.getStatusTooltipText().orElse(null));
@@ -411,7 +411,7 @@ public class ChatUserServiceTest extends AbstractPlainJavaFxTest {
     instance.associatePlayerToChatUser(chatUser, player);
     WaitForAsyncUtils.waitForFxEvents();
 
-    verify(uiService, times(2)).getThemeImage(UiService.CHAT_LIST_STATUS_HOSTING);
+    verify(uiService, times(3)).getThemeImage(UiService.CHAT_LIST_STATUS_HOSTING);
     assertTrue(chatUser.getMapImage().isPresent());
     assertEquals(PlayerStatus.HOSTING, chatUser.getGameStatus().orElse(null));
     assertEquals("Hosting", chatUser.getStatusTooltipText().orElse(null));
@@ -425,7 +425,7 @@ public class ChatUserServiceTest extends AbstractPlainJavaFxTest {
     instance.associatePlayerToChatUser(chatUser, player);
     WaitForAsyncUtils.waitForFxEvents();
 
-    verify(uiService, times(2)).getThemeImage(UiService.CHAT_LIST_STATUS_LOBBYING);
+    verify(uiService, times(3)).getThemeImage(UiService.CHAT_LIST_STATUS_LOBBYING);
     assertTrue(chatUser.getMapImage().isPresent());
     assertEquals(PlayerStatus.LOBBYING, chatUser.getGameStatus().orElse(null));
     assertEquals("Waiting for game to start", chatUser.getStatusTooltipText().orElse(null));
@@ -441,7 +441,7 @@ public class ChatUserServiceTest extends AbstractPlainJavaFxTest {
     game.setStatus(GameStatus.PLAYING);
     WaitForAsyncUtils.waitForFxEvents();
 
-    verify(uiService, times(2)).getThemeImage(UiService.CHAT_LIST_STATUS_LOBBYING);
+    verify(uiService, times(3)).getThemeImage(UiService.CHAT_LIST_STATUS_LOBBYING);
     verify(uiService).getThemeImage(UiService.CHAT_LIST_STATUS_PLAYING);
     assertTrue(chatUser.getMapImage().isPresent());
     assertEquals(PlayerStatus.PLAYING, chatUser.getGameStatus().orElse(null));
@@ -457,7 +457,7 @@ public class ChatUserServiceTest extends AbstractPlainJavaFxTest {
     game.setStatus(GameStatus.OPEN);
     WaitForAsyncUtils.waitForFxEvents();
 
-    verify(uiService, times(2)).getThemeImage(UiService.CHAT_LIST_STATUS_LOBBYING);
+    verify(uiService, times(3)).getThemeImage(UiService.CHAT_LIST_STATUS_LOBBYING);
     assertTrue(chatUser.getMapImage().isPresent());
     assertEquals(PlayerStatus.LOBBYING, chatUser.getGameStatus().orElse(null));
     assertEquals("Waiting for game to start", chatUser.getStatusTooltipText().orElse(null));


### PR DESCRIPTION
Use weak listeners rather than bindings for the chat user to remove coupling of ui with server messages