### PR TITLE
Enable install4j i18n for languages supported by FAF.

### DIFF
--- a/downlords-faf-client.install4j
+++ b/downlords-faf-client.install4j
@@ -2,6 +2,19 @@
 <install4j version="8.0.8" transformSequenceNumber="8">
   <directoryPresets config="./src/media/appicon" />
   <application name="Downlord's FAF Client" applicationId="2848-7798-9769-5013" mediaDir="./build/install4j" lzmaCompression="true" pack200Compression="true" shortName="dfc" publisher="Downlord" publisherWeb="https://github.com/FAForever/downlords-faf-client" allPathsRelative="true" autoSave="true" macVolumeId="e230e730a6fc064c" javaMinVersion="15" javaMaxVersion="15" allowBetaVM="true">
+    <languages>
+      <additionalLanguages>
+        <language id="zh_CN" />
+        <language id="zh_TW" />
+        <language id="cs" />
+        <language id="fr" />
+        <language id="de" />
+        <language id="it" />
+        <language id="pl" />
+        <language id="ru" />
+        <language id="es" />
+      </additionalLanguages>
+    </languages>
     <searchSequence empty="true" />
   </application>
   <files>


### PR DESCRIPTION
Fixes #2286.

With this change, the installer will show a language selection dialog right at the beginning. If the user's system language is available in the "additional languages", the dialog is shown in the system language, having it selected in the dropdown. All languages supported by the installer are listed in the dropdown. Btw. I just noticed by chance that install4j also supports creating installers for Unix as you can see on the screenshots below which I created from an install4j sample.
![install4j_en](https://user-images.githubusercontent.com/37223176/123335501-d7cd9900-d544-11eb-91b7-c32f45916389.png)
![install4j_zh_CN](https://user-images.githubusercontent.com/37223176/123335513-dbf9b680-d544-11eb-94e6-c059c25cb97c.png)
