### PR TITLE
Change team and sim mods to object properties containing unmodifiable maps

### DIFF
--- a/src/main/java/com/faforever/client/game/Game.java
+++ b/src/main/java/com/faforever/client/game/Game.java
@@ -271,7 +271,11 @@ public class Game {
   }
 
   public void setSimMods(Map<String, String> simMods) {
-    this.simMods.set(Collections.unmodifiableMap(simMods));
+    if (simMods == null) {
+      this.simMods.set(Map.of());
+    } else {
+      this.simMods.set(Collections.unmodifiableMap(simMods));
+    }
   }
 
   public ObjectProperty<Map<String, String>> simModsProperty() {
@@ -286,7 +290,11 @@ public class Game {
   }
 
   public void setTeams(Map<String, List<String>> teams) {
-    this.teams.set(Collections.unmodifiableMap(teams));
+    if (teams == null) {
+      this.teams.set(Map.of());
+    } else {
+      this.teams.set(Collections.unmodifiableMap(teams));
+    }
   }
 
   public ObjectProperty<Map<String, List<String>>> teamsProperty() {

--- a/src/main/java/com/faforever/client/game/Game.java
+++ b/src/main/java/com/faforever/client/game/Game.java
@@ -23,6 +23,7 @@ import javafx.collections.ObservableMap;
 import org.apache.commons.lang3.StringEscapeUtils;
 
 import java.time.Instant;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -53,8 +54,8 @@ public class Game {
   /**
    * Maps a sim mod's UID to its name.
    */
-  private final MapProperty<String, String> simMods = new SimpleMapProperty<>(FXCollections.synchronizedObservableMap(FXCollections.observableHashMap()));
-  private final MapProperty<String, List<String>> teams = new SimpleMapProperty<>(FXCollections.synchronizedObservableMap(FXCollections.observableHashMap()));
+  private final ObjectProperty<Map<String, String>> simMods = new SimpleObjectProperty<>(Map.of());
+  private final ObjectProperty<Map<String, List<String>>> teams = new SimpleObjectProperty<>(Map.of());
   /**
    * Maps an index (1,2,3,4...) to a version number. Don't ask me what this index maps to.
    */
@@ -79,21 +80,8 @@ public class Game {
     setPasswordProtected(gameInfoMessage.getPasswordProtected());
     setGameType(gameInfoMessage.getGameType());
     setRatingType(gameInfoMessage.getRatingType());
-
-    synchronized (getSimMods()) {
-      getSimMods().clear();
-      if (gameInfoMessage.getSimMods() != null) {
-        getSimMods().putAll(gameInfoMessage.getSimMods());
-      }
-    }
-
-    synchronized (getTeams()) {
-      getTeams().clear();
-      if (gameInfoMessage.getTeams() != null) {
-        getTeams().putAll(gameInfoMessage.getTeams());
-      }
-    }
-
+    setSimMods(gameInfoMessage.getSimMods());
+    setTeams(gameInfoMessage.getTeams());
     setMinRating(gameInfoMessage.getRatingMin());
     setMaxRating(gameInfoMessage.getRatingMax());
     setEnforceRating(gameInfoMessage.getEnforceRatingRange());
@@ -276,36 +264,32 @@ public class Game {
   }
 
   /**
-   * Returns a map of simulation mod UIDs to the mod's name. <strong>Make sure to manually synchronize when iterating
-   * over any of its collection views (e.g. values, entrySet, keySet).</strong> See {@link
-   * java.util.Collections#synchronizedMap(Map)} for details.
+   * Returns an unmodifiable map of simulation mod UIDs to the mod's name
    */
-  public ObservableMap<String, String> getSimMods() {
+  public Map<String, String> getSimMods() {
     return simMods.get();
   }
 
   public void setSimMods(Map<String, String> simMods) {
-    this.simMods.set(FXCollections.synchronizedObservableMap(FXCollections.observableMap(simMods)));
+    this.simMods.set(Collections.unmodifiableMap(simMods));
   }
 
-  public MapProperty<String, String> simModsProperty() {
+  public ObjectProperty<Map<String, String>> simModsProperty() {
     return simMods;
   }
 
   /**
-   * Maps team names ("1", "2", ...) to a list of player names. <strong>Make sure to manually synchronize when iterating
-   * over any of its collection views (e.g. values, entrySet, keySet).</strong> See {@link
-   * java.util.Collections#synchronizedMap(Map)} for details.
+   * Returns an unmodifiable map that maps team names ("1", "2", ...) to a list of player names.
    */
-  public ObservableMap<String, List<String>> getTeams() {
+  public Map<String, List<String>> getTeams() {
     return teams.get();
   }
 
   public void setTeams(Map<String, List<String>> teams) {
-    this.teams.set(FXCollections.synchronizedObservableMap(FXCollections.observableMap(teams)));
+    this.teams.set(Collections.unmodifiableMap(teams));
   }
 
-  public MapProperty<String, List<String>> teamsProperty() {
+  public ObjectProperty<Map<String, List<String>>> teamsProperty() {
     return teams;
   }
 

--- a/src/main/java/com/faforever/client/game/GameDetailController.java
+++ b/src/main/java/com/faforever/client/game/GameDetailController.java
@@ -155,7 +155,7 @@ public class GameDetailController implements Controller<Pane> {
     WeakInvalidationListener weakNumPlayersListener = new WeakInvalidationListener(numPlayersInvalidationListener);
 
     JavaFxUtil.addAndTriggerListener(game.featuredModProperty(), new WeakInvalidationListener(featuredModInvalidationListener));
-    JavaFxUtil.addAndTriggerListener(game.getTeams(), weakTeamListener);
+    JavaFxUtil.addAndTriggerListener(game.teamsProperty(), weakTeamListener);
     JavaFxUtil.addAndTriggerListener(game.statusProperty(), weakGameStatusListener);
     JavaFxUtil.addAndTriggerListener(game.titleProperty(), weakGamePropertiesListener);
     JavaFxUtil.addListener(game.mapFolderNameProperty(), weakGamePropertiesListener);

--- a/src/main/java/com/faforever/client/game/GameTileController.java
+++ b/src/main/java/com/faforever/client/game/GameTileController.java
@@ -11,7 +11,6 @@ import com.faforever.client.util.Assert;
 import com.google.common.base.Joiner;
 import javafx.beans.InvalidationListener;
 import javafx.beans.WeakInvalidationListener;
-import javafx.collections.ObservableMap;
 import javafx.css.PseudoClass;
 import javafx.scene.Node;
 import javafx.scene.control.Label;
@@ -25,6 +24,7 @@ import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -106,20 +106,17 @@ public class GameTileController implements Controller<Node> {
     JavaFxUtil.addListener(game.titleProperty(), weakGamePropertiesListener);
     JavaFxUtil.addListener(game.mapFolderNameProperty(), weakGamePropertiesListener);
     JavaFxUtil.addListener(game.hostProperty(), weakGamePropertiesListener);
-    JavaFxUtil.addListener(game.getSimMods(), weakGamePropertiesListener);
+    JavaFxUtil.addListener(game.simModsProperty(), weakGamePropertiesListener);
     JavaFxUtil.addAndTriggerListener(game.passwordProtectedProperty(), weakGamePropertiesListener);
     JavaFxUtil.addListener(game.numPlayersProperty(), weakNumPlayersListener);
     JavaFxUtil.addListener(game.maxPlayersProperty(), weakNumPlayersListener);
     JavaFxUtil.addAndTriggerListener(game.averageRatingProperty(), weakNumPlayersListener);
   }
 
-  private String getSimModsLabelContent(ObservableMap<String, String> simMods) {
-    List<String> modNames;
-    synchronized (simMods) {
-      modNames = simMods.values().stream()
-          .limit(2)
-          .collect(Collectors.toList());
-    }
+  private String getSimModsLabelContent(Map<String, String> simMods) {
+    List<String> modNames = simMods.values().stream()
+        .limit(2)
+        .collect(Collectors.toList());
 
     if (simMods.size() > 2) {
       return i18n.get("game.mods.twoAndMore", modNames.get(0), simMods.size() - 1);

--- a/src/main/java/com/faforever/client/game/GameTooltipController.java
+++ b/src/main/java/com/faforever/client/game/GameTooltipController.java
@@ -18,8 +18,6 @@ import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
-import java.util.Map;
-
 @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
 @Component
 @RequiredArgsConstructor
@@ -65,8 +63,8 @@ public class GameTooltipController implements Controller<Node> {
   }
 
   private void resetListeners() {
-    teamInvalidationListener = change -> createTeams();
-    simModsInvalidationListener = change -> createModsList(game.getSimMods());
+    teamInvalidationListener = observable -> createTeams();
+    simModsInvalidationListener = observable -> createModsList();
   }
 
   private void createTeams() {
@@ -76,9 +74,11 @@ public class GameTooltipController implements Controller<Node> {
     }
   }
 
-  private void createModsList(Map<? extends String, ? extends String> simMods) {
-    String stringSimMods = Joiner.on(System.getProperty("line.separator")).join(simMods.values());
-    JavaFxUtil.runLater(() -> modsLabel.setText(stringSimMods));
+  private void createModsList() {
+    if (game != null) {
+      String stringSimMods = Joiner.on(System.getProperty("line.separator")).join(game.getSimMods().values());
+      JavaFxUtil.runLater(() -> modsLabel.setText(stringSimMods));
+    }
   }
 
   public void setShowMods(boolean showMods) {

--- a/src/main/java/com/faforever/client/game/GameTooltipController.java
+++ b/src/main/java/com/faforever/client/game/GameTooltipController.java
@@ -50,10 +50,10 @@ public class GameTooltipController implements Controller<Node> {
   }
 
   public void displayGame() {
+    resetListeners();
     if (game == null) {
       return;
     }
-    resetListeners();
     WeakInvalidationListener weakTeamInvalidationListener = new WeakInvalidationListener(teamInvalidationListener);
     JavaFxUtil.addAndTriggerListener(game.teamsProperty(), weakTeamInvalidationListener);
     if (showMods) {

--- a/src/main/java/com/faforever/client/game/GamesTableController.java
+++ b/src/main/java/com/faforever/client/game/GamesTableController.java
@@ -22,7 +22,6 @@ import javafx.beans.value.ChangeListener;
 import javafx.beans.value.ObservableValue;
 import javafx.beans.value.WeakChangeListener;
 import javafx.collections.ObservableList;
-import javafx.collections.ObservableMap;
 import javafx.collections.transformation.SortedList;
 import javafx.css.PseudoClass;
 import javafx.scene.Node;
@@ -185,14 +184,12 @@ public class GamesTableController implements Controller<Node> {
 
   @NotNull
   private ObservableValue<String> modCell(CellDataFeatures<Game, String> param) {
-    ObservableMap<String, String> simMods = param.getValue().getSimMods();
+    Map<String, String> simMods = param.getValue().getSimMods();
     int simModCount = simMods.size();
     List<String> modNames;
-    synchronized (simMods) {
       modNames = simMods.values().stream()
           .limit(2)
           .collect(Collectors.toList());
-    }
     if (simModCount > 2) {
       return new SimpleStringProperty(i18n.get("game.mods.twoAndMore", modNames.get(0), modNames.size() - 1));
     }

--- a/src/main/java/com/faforever/client/game/TeamCardController.java
+++ b/src/main/java/com/faforever/client/game/TeamCardController.java
@@ -51,19 +51,17 @@ public class TeamCardController implements Controller<Node> {
   static void createAndAdd(Game game, PlayerService playerService, UiService uiService, Pane teamsPane) {
     List<Node> teamCardPanes = new ArrayList<>();
     if (game != null) {
-      synchronized (game.getTeams()) {
-        for (Map.Entry<? extends String, ? extends List<String>> entry : game.getTeams().entrySet()) {
-          String team = entry.getKey();
-          if (team != null) {
-            List<Player> players = entry.getValue().stream()
-                .flatMap(playerName -> playerService.getPlayerByNameIfOnline(playerName).stream())
-                .collect(Collectors.toList());
+      for (Map.Entry<? extends String, ? extends List<String>> entry : game.getTeams().entrySet()) {
+        String team = entry.getKey();
+        if (team != null) {
+          List<Player> players = entry.getValue().stream()
+              .flatMap(playerName -> playerService.getPlayerByNameIfOnline(playerName).stream())
+              .collect(Collectors.toList());
 
-            TeamCardController teamCardController = uiService.loadFxml("theme/team_card.fxml");
-            teamCardController.setPlayersInTeam(team, players,
-                player -> RatingUtil.getLeaderboardRating(player, game.getRatingType()), null, RatingPrecision.ROUNDED);
-            teamCardPanes.add(teamCardController.getRoot());
-          }
+          TeamCardController teamCardController = uiService.loadFxml("theme/team_card.fxml");
+          teamCardController.setPlayersInTeam(team, players,
+              player -> RatingUtil.getLeaderboardRating(player, game.getRatingType()), null, RatingPrecision.ROUNDED);
+          teamCardPanes.add(teamCardController.getRoot());
         }
       }
     }
@@ -99,12 +97,16 @@ public class TeamCardController implements Controller<Node> {
     }
 
     String teamTitle;
-    if (Game.NO_TEAM.equals(team)) {
-      teamTitle = i18n.get("game.tooltip.teamTitleNoTeam");
-    } else if (Game.OBSERVERS_TEAM.equals(team)) {
-      teamTitle = i18n.get("game.tooltip.observers");
+    if (team != null) {
+      if (Game.NO_TEAM.equals(team)) {
+        teamTitle = i18n.get("game.tooltip.teamTitleNoTeam");
+      } else if (Game.OBSERVERS_TEAM.equals(team)) {
+        teamTitle = i18n.get("game.tooltip.observers");
+      } else {
+        teamTitle = i18n.get("game.tooltip.teamTitle", Integer.parseInt(team) - 1, totalRating);
+      }
     } else {
-      teamTitle = i18n.get("game.tooltip.teamTitle", Integer.parseInt(team) - 1, totalRating);
+      teamTitle = i18n.get("game.tooltip.teamTitleNoTeam");
     }
     teamNameLabel.setText(teamTitle);
   }

--- a/src/main/java/com/faforever/client/player/PlayerService.java
+++ b/src/main/java/com/faforever/client/player/PlayerService.java
@@ -152,12 +152,10 @@ public class PlayerService implements InitializingBean {
   }
 
   public List<Player> getAllPlayersInGame(Game game) {
-    synchronized (game.getTeams()) {
-      return game.getTeams().values().stream()
-          .flatMap(Collection::stream)
-          .flatMap(playerName -> getPlayerByNameIfOnline(playerName).stream())
-          .collect(Collectors.toList());
-    }
+    return game.getTeams().values().stream()
+        .flatMap(Collection::stream)
+        .flatMap(playerName -> getPlayerByNameIfOnline(playerName).stream())
+        .collect(Collectors.toList());
   }
 
   public boolean isCurrentPlayerInGame(Game game) {

--- a/src/main/java/com/faforever/client/teammatchmaking/PartyMemberItemController.java
+++ b/src/main/java/com/faforever/client/teammatchmaking/PartyMemberItemController.java
@@ -25,12 +25,14 @@ import javafx.scene.image.ImageView;
 import javafx.scene.input.ContextMenuEvent;
 import javafx.scene.layout.HBox;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
 import java.lang.ref.WeakReference;
 
+@Slf4j
 @Component
 @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
 @RequiredArgsConstructor
@@ -83,6 +85,10 @@ public class PartyMemberItemController implements Controller<Node> {
   public void setMember(PartyMember member) {
     Assert.checkNotNullIllegalState(player, "Party member already set");
     player = member.getPlayer();
+    if (player == null) {
+      log.info("Player of party member is null");
+      return;
+    }
 
     // TODO: replace this with divisionproperty once it is available
     leagueImageView.setVisible(false);

--- a/src/main/java/com/faforever/client/teammatchmaking/TeamMatchmakingController.java
+++ b/src/main/java/com/faforever/client/teammatchmaking/TeamMatchmakingController.java
@@ -238,26 +238,28 @@ public class TeamMatchmakingController extends AbstractViewController<Node> {
   }
 
   private synchronized void renderPartyMembers() {
-    List<PartyMember> members = new ArrayList<>(teamMatchmakingService.getParty().getMembers());
-    members.removeIf(partyMember -> partyMember.getPlayer().equals(player));
-    List<Node> memberCards = members.stream().map(member -> {
-      PartyMemberItemController controller = uiService.loadFxml("theme/play/teammatchmaking/matchmaking_member_card.fxml");
-      controller.setMember(member);
-      return controller.getRoot();
-    }).collect(Collectors.toList());
-    JavaFxUtil.runLater(() -> {
-      playerCard.pseudoClassStateChanged(LEADER_PSEUDO_CLASS,
-          (teamMatchmakingService.getParty().getOwner().equals(player) && teamMatchmakingService.getParty().getMembers().size() > 1));
-      partyMemberPane.getChildren().clear();
-      int numMemberCards = memberCards.size();
-      for (int i = 0; i < numMemberCards; i++) {
-        if (numMemberCards == 1) {
-          partyMemberPane.add(memberCards.get(i), 0, 0, 2, 1);
-        } else {
-          partyMemberPane.add(memberCards.get(i), i % 2, i / 2);
+    if (player != null) {
+      List<PartyMember> members = new ArrayList<>(teamMatchmakingService.getParty().getMembers());
+      members.removeIf(partyMember -> player.equals(partyMember.getPlayer()));
+      List<Node> memberCards = members.stream().map(member -> {
+        PartyMemberItemController controller = uiService.loadFxml("theme/play/teammatchmaking/matchmaking_member_card.fxml");
+        controller.setMember(member);
+        return controller.getRoot();
+      }).collect(Collectors.toList());
+      JavaFxUtil.runLater(() -> {
+        playerCard.pseudoClassStateChanged(LEADER_PSEUDO_CLASS,
+            (teamMatchmakingService.getParty().getOwner().equals(player) && teamMatchmakingService.getParty().getMembers().size() > 1));
+        partyMemberPane.getChildren().clear();
+        int numMemberCards = memberCards.size();
+        for (int i = 0; i < numMemberCards; i++) {
+          if (numMemberCards == 1) {
+            partyMemberPane.add(memberCards.get(i), 0, 0, 2, 1);
+          } else {
+            partyMemberPane.add(memberCards.get(i), i % 2, i / 2);
+          }
         }
-      }
-    });
+      });
+    }
   }
 
   @Override

--- a/src/main/java/com/faforever/client/vault/replay/LiveReplayController.java
+++ b/src/main/java/com/faforever/client/vault/replay/LiveReplayController.java
@@ -20,7 +20,6 @@ import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.value.ObservableValue;
 import javafx.collections.ObservableList;
-import javafx.collections.ObservableMap;
 import javafx.collections.transformation.FilteredList;
 import javafx.collections.transformation.SortedList;
 import javafx.scene.Node;
@@ -36,6 +35,7 @@ import org.springframework.stereotype.Component;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.stream.Collectors;
 
@@ -121,15 +121,13 @@ public class LiveReplayController extends AbstractViewController<Node> {
 
   @NotNull
   private ObservableValue<String> modCell(CellDataFeatures<Game, String> param) {
-    ObservableMap<String, String> simMods = param.getValue().getSimMods();
+    Map<String, String> simMods = param.getValue().getSimMods();
     int simModCount = simMods.size();
     List<String> modNames;
-    synchronized (simMods) {
-      modNames = simMods.entrySet().stream()
-          .limit(2)
-          .map(Entry::getValue)
-          .collect(Collectors.toList());
-    }
+    modNames = simMods.entrySet().stream()
+        .limit(2)
+        .map(Entry::getValue)
+        .collect(Collectors.toList());
     if (simModCount > 2) {
       return new SimpleStringProperty(i18n.get("game.mods.twoAndMore", modNames.get(0), simMods.size() - 1));
     }

--- a/src/test/java/com/faforever/client/game/GameInfoMessageBuilder.java
+++ b/src/test/java/com/faforever/client/game/GameInfoMessageBuilder.java
@@ -5,10 +5,12 @@ import com.faforever.client.remote.domain.GameStatus;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class GameInfoMessageBuilder {
 
-  private GameInfoMessage gameInfoMessage;
+  private final GameInfoMessage gameInfoMessage;
 
   private GameInfoMessageBuilder(Integer uid) {
     gameInfoMessage = new GameInfoMessage();
@@ -28,6 +30,7 @@ public class GameInfoMessageBuilder {
     gameInfoMessage.setState(GameStatus.OPEN);
     gameInfoMessage.setTitle("Test preferences");
     gameInfoMessage.setTeams(new HashMap<>());
+    gameInfoMessage.setSimMods(new HashMap<>());
     gameInfoMessage.setPasswordProtected(false);
     gameInfoMessage.setEnforceRatingRange(false);
     gameInfoMessage.setRatingMax(3000);
@@ -40,6 +43,7 @@ public class GameInfoMessageBuilder {
   }
 
   public GameInfoMessageBuilder addTeamMember(String team, String playerName) {
+    Map<String, List<String>> newTeams = new HashMap<>();
     if (!gameInfoMessage.getTeams().containsKey(team)) {
       gameInfoMessage.getTeams().put(team, new ArrayList<>());
     }

--- a/src/test/java/com/faforever/client/game/GameTooltipControllerTest.java
+++ b/src/test/java/com/faforever/client/game/GameTooltipControllerTest.java
@@ -4,8 +4,7 @@ import com.faforever.client.player.Player;
 import com.faforever.client.player.PlayerService;
 import com.faforever.client.test.AbstractPlainJavaFxTest;
 import com.faforever.client.theme.UiService;
-import javafx.collections.FXCollections;
-import javafx.collections.ObservableMap;
+import javafx.beans.property.SimpleObjectProperty;
 import javafx.scene.layout.Pane;
 import org.junit.Before;
 import org.junit.Test;
@@ -13,7 +12,9 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.testfx.util.WaitForAsyncUtils;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.hamcrest.core.Is.is;
@@ -48,17 +49,19 @@ public class GameTooltipControllerTest extends AbstractPlainJavaFxTest {
   
   @Test
   public void testSetGame() {
-    ObservableMap<String, String> simMods = FXCollections.observableHashMap();
+    Map<String, String> simMods = new HashMap<>();
     when(game.getSimMods()).thenReturn(simMods);
-    ObservableMap<String, List<String>> teams = FXCollections.observableHashMap();
+    when(game.simModsProperty()).thenReturn(new SimpleObjectProperty<>(simMods));
+    Map<String, List<String>> teams = new HashMap<>();
     when(game.getTeams()).thenReturn(teams);
-    
+    when(game.teamsProperty()).thenReturn(new SimpleObjectProperty<>(teams));
+
     instance.setGame(game);
     instance.displayGame();
     WaitForAsyncUtils.waitForFxEvents();
     assertFalse(instance.modsPane.isVisible());
     assertThat(instance.teamsPane.getPrefColumns(), is(0));
-    
+
     teams.put("team1", List.of("Bob"));
     instance.setGame(game);
     instance.displayGame();


### PR DESCRIPTION
With the decoupling of the game service and ui there have been a few issues with concurrent modification of the teams even though the teams map of a game is always synchronized. To solve these this pr changes the teams object on a game to be an object property wrapping an unmodifiable map. Now when there is a game update the map in the object property is wholly replaced rather than being cleared and updated with the new values. This should stop synchronization issues and allows us to remove the synchronization locks altogether.