### PR TITLE
bump ice adapter to 3.1.0 - relay latency check fallback, increased logging

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 version=unspecified
 javafxPlatform=unspecified
-faf_ice_adapter_version=3.0.0
+faf_ice_adapter_version=3.1.0
 faf_uid_version=4.0.4
 springBootVersion=2.4.0
 springSecurityOauth2AutoconfigureVersion=2.3.4.RELEASE

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 version=unspecified
 javafxPlatform=unspecified
-faf_ice_adapter_version=3.1.0
+faf_ice_adapter_version=3.1.1
 faf_uid_version=4.0.4
 springBootVersion=2.4.0
 springSecurityOauth2AutoconfigureVersion=2.3.4.RELEASE


### PR DESCRIPTION
Use fallback servers for estimating the latency in case the relay server doesn't respond to ICMP echo requests. This prevents usage of the defaut relay in case its latency would be too high but couldn't be estimated due to server misconfiguration. (which is currently the case for oceanians and prevents quite a lot of them from playing)

Also increases log verbosity by adding info about the available types of candidates and the chosen candidate pair after connectivity establishment to ease identification of issues in absence of JavaFX needed for the debug window.
