### PR TITLE
Copy files from cache rather than move

### DIFF
--- a/src/main/java/com/faforever/client/io/FeaturedModFileCacheService.java
+++ b/src/main/java/com/faforever/client/io/FeaturedModFileCacheService.java
@@ -52,7 +52,7 @@ public class FeaturedModFileCacheService implements InitializingBean {
     return getCachedFilePath(readHashFromFile(targetPath), targetPath.getParent().getFileName().toString());
   }
 
-  public void moveFeaturedModFileFromCache(FeaturedModFile featuredModFile, Path targetPath) throws IOException {
+  public void copyFeaturedModFileFromCache(FeaturedModFile featuredModFile, Path targetPath) throws IOException {
     Files.createDirectories(targetPath.getParent());
     ResourceLocks.acquireDiskLock();
 
@@ -61,7 +61,7 @@ public class FeaturedModFileCacheService implements InitializingBean {
         //We want to keep the old file for now in case it is needed again for example for old replays
         moveFeaturedModFileToCache(targetPath);
       }
-      Files.move(getCachedFilePath(featuredModFile), targetPath, StandardCopyOption.REPLACE_EXISTING);
+      Files.copy(getCachedFilePath(featuredModFile), targetPath, StandardCopyOption.REPLACE_EXISTING);
       UpdaterUtil.extractMoviesIfPresent(targetPath, preferencesService.getFafDataDirectory());
     } finally {
       ResourceLocks.freeDiskLock();

--- a/src/main/java/com/faforever/client/patch/SimpleHttpFeaturedModUpdaterTask.java
+++ b/src/main/java/com/faforever/client/patch/SimpleHttpFeaturedModUpdaterTask.java
@@ -71,10 +71,10 @@ public class SimpleHttpFeaturedModUpdaterTask extends CompletableTask<PatchResul
             if (fileAlreadyLoaded(featuredModFile, targetPath)) {
               log.debug("Featured mod file already prepared: {}", featuredModFile);
             } else if (featuredModFileCacheService.isCached(featuredModFile)) {
-              featuredModFileCacheService.moveFeaturedModFileFromCache(featuredModFile, targetPath);
+              featuredModFileCacheService.copyFeaturedModFileFromCache(featuredModFile, targetPath);
             } else {
               downloadFeaturedModFile(featuredModFile, featuredModFileCacheService.getCachedFilePath(featuredModFile));
-              featuredModFileCacheService.moveFeaturedModFileFromCache(featuredModFile, targetPath);
+              featuredModFileCacheService.copyFeaturedModFileFromCache(featuredModFile, targetPath);
             }
           } catch (IOException e) {
             log.error("Error on updating featured mod file: {}", featuredModFile, e);

--- a/src/test/java/com/faforever/client/io/FeaturedModFileCacheServiceTest.java
+++ b/src/test/java/com/faforever/client/io/FeaturedModFileCacheServiceTest.java
@@ -64,7 +64,7 @@ public class FeaturedModFileCacheServiceTest extends ServiceTest {
 
     assertThat(instance.getCachedFilePath(featuredModFile), is(cachePathNewFile));
 
-    instance.moveFeaturedModFileFromCache(featuredModFile, targetPath);
+    instance.copyFeaturedModFileFromCache(featuredModFile, targetPath);
 
     final Path oldFileNowInCachePath = groupFolderInCache.resolve(hashOldFile);
     assertTrue(Files.isRegularFile(oldFileNowInCachePath));


### PR DESCRIPTION
Currently we move files out of cache and then move them back if we use a different version.

This works great if we don;t modify the files. However for the exes we modify the files so we want a version of the file we downloaded preserved in cache that way we can just perform the modifications on that file rather than redownload everything again just to modify it again.