### PR TITLE
bump ice adapter to 3.1.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 version=unspecified
 javafxPlatform=unspecified
-faf_ice_adapter_version=3.0.0
+faf_ice_adapter_version=3.1.2
 faf_uid_version=4.0.4
 springBootVersion=2.4.0
 springSecurityOauth2AutoconfigureVersion=2.3.4.RELEASE


### PR DESCRIPTION
disabling notification when a fallback server is used

This is a temporary solution. I disabled the notification on error, which should in theory not be removed. But to get uses not annoyed and playing again, I instead increased the verbosity of the log file message "a bit".

https://github.com/FAForever/java-ice-adapter/commit/e65e50105271f3503440b07bc7935fcdcfe54a5a