### PR TITLE
Use Path.of over Paths.get

### DIFF
--- a/src/main/java/com/faforever/client/achievements/AchievementService.java
+++ b/src/main/java/com/faforever/client/achievements/AchievementService.java
@@ -15,7 +15,7 @@ import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 
 import java.net.URL;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
@@ -61,7 +61,7 @@ public class AchievementService {
       case UNLOCKED -> noCatch(() -> new URL(achievementDefinition.getUnlockedIconUrl()));
       default -> throw new UnsupportedOperationException("Not yet implemented");
     };
-    return assetService.loadAndCacheImage(url, Paths.get("achievements").resolve(achievementState.name().toLowerCase()),
+    return assetService.loadAndCacheImage(url, Path.of("achievements").resolve(achievementState.name().toLowerCase()),
         null, ACHIEVEMENT_IMAGE_SIZE, ACHIEVEMENT_IMAGE_SIZE);
   }
 }

--- a/src/main/java/com/faforever/client/avatar/AvatarService.java
+++ b/src/main/java/com/faforever/client/avatar/AvatarService.java
@@ -14,7 +14,7 @@ import org.springframework.cache.annotation.Cacheable;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
@@ -32,7 +32,7 @@ public class AvatarService implements InitializingBean {
 
   @Cacheable(value = AVATARS, sync = true)
   public Image loadAvatar(AvatarBean avatar) {
-    return assetService.loadAndCacheImage(avatar.getUrl(), Paths.get("avatars"), null);
+    return assetService.loadAndCacheImage(avatar.getUrl(), Path.of("avatars"), null);
   }
 
   public CompletableFuture<List<AvatarBean>> getAvailableAvatars() {

--- a/src/main/java/com/faforever/client/fa/relay/ice/IceAdapterImpl.java
+++ b/src/main/java/com/faforever/client/fa/relay/ice/IceAdapterImpl.java
@@ -41,7 +41,6 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.net.ConnectException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -154,10 +153,10 @@ public class IceAdapterImpl implements IceAdapter, InitializingBean, DisposableB
 
       PlayerBean currentPlayer = playerService.getCurrentPlayer();
 
-      Path workDirectory = Paths.get(nativeDir).toAbsolutePath();
+      Path workDirectory = Path.of(nativeDir).toAbsolutePath();
 
       List<String> cmd = Lists.newArrayList(
-          Paths.get(System.getProperty("java.home")).resolve("bin").resolve(org.bridj.Platform.isWindows() ? "java.exe" : "java").toAbsolutePath().toString(),
+          Path.of(System.getProperty("java.home")).resolve("bin").resolve(org.bridj.Platform.isWindows() ? "java.exe" : "java").toAbsolutePath().toString(),
           "-jar",
           getBinaryName(workDirectory),
           "--id", String.valueOf(currentPlayer.getId()),

--- a/src/main/java/com/faforever/client/fx/JavaFxUtil.java
+++ b/src/main/java/com/faforever/client/fx/JavaFxUtil.java
@@ -72,7 +72,7 @@ public final class JavaFxUtil {
       if (Strings.isNullOrEmpty(string)) {
         return null;
       }
-      return Paths.get(string);
+      return Path.of(string);
     }
   };
 

--- a/src/main/java/com/faforever/client/game/GamePathHandler.java
+++ b/src/main/java/com/faforever/client/game/GamePathHandler.java
@@ -13,7 +13,6 @@ import org.springframework.stereotype.Component;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Optional;
@@ -24,11 +23,11 @@ import java.util.concurrent.CompletableFuture;
 @Slf4j
 public class GamePathHandler implements InitializingBean {
   private static final Collection<Path> USUAL_GAME_PATHS = Arrays.asList(
-      Paths.get(System.getenv("ProgramFiles") + "\\THQ\\Gas Powered Games\\Supreme Commander - Forged Alliance"),
-      Paths.get(System.getenv("ProgramFiles") + " (x86)\\THQ\\Gas Powered Games\\Supreme Commander - Forged Alliance"),
-      Paths.get(System.getenv("ProgramFiles") + " (x86)\\Steam\\steamapps\\common\\supreme commander forged alliance"),
-      Paths.get(System.getProperty("user.home"), ".steam", "steam", "steamapps", "common", "Supreme Commander Forged Alliance"),
-      Paths.get(System.getenv("ProgramFiles") + "\\Supreme Commander - Forged Alliance")
+      Path.of(System.getenv("ProgramFiles") + "\\THQ\\Gas Powered Games\\Supreme Commander - Forged Alliance"),
+      Path.of(System.getenv("ProgramFiles") + " (x86)\\THQ\\Gas Powered Games\\Supreme Commander - Forged Alliance"),
+      Path.of(System.getenv("ProgramFiles") + " (x86)\\Steam\\steamapps\\common\\supreme commander forged alliance"),
+      Path.of(System.getProperty("user.home"), ".steam", "steam", "steamapps", "common", "Supreme Commander Forged Alliance"),
+      Path.of(System.getenv("ProgramFiles") + "\\Supreme Commander - Forged Alliance")
   );
   private final NotificationService notificationService;
   private final I18n i18n;

--- a/src/main/java/com/faforever/client/i18n/I18n.java
+++ b/src/main/java/com/faforever/client/i18n/I18n.java
@@ -83,7 +83,7 @@ public class I18n implements InitializingBean {
           .map(path -> MESSAGES_FILE_PATTERN.matcher(path.toString()))
           .filter(Matcher::matches)
           .forEach(matcher -> {
-            newBaseNames.add(Paths.get(matcher.group(1)).toUri().toString());
+            newBaseNames.add(Path.of(matcher.group(1)).toUri().toString());
             availableLanguages.add(new Locale(matcher.group(2), Strings.nullToEmpty(matcher.group(3))));
           });
     }

--- a/src/main/java/com/faforever/client/legacy/PosixUidService.java
+++ b/src/main/java/com/faforever/client/legacy/PosixUidService.java
@@ -7,7 +7,6 @@ import org.springframework.stereotype.Service;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 
 @Lazy
@@ -18,7 +17,7 @@ public class PosixUidService implements UidService {
   @Override
   public String generate(String sessionId, Path logFile) throws IOException {
     String uidDir = System.getProperty("nativeDir", "lib");
-    Path uidPath = Paths.get(uidDir).resolve("faf-uid");
+    Path uidPath = Path.of(uidDir).resolve("faf-uid");
     return OsUtils.execAndGetOutput(uidPath.toAbsolutePath().toString(), sessionId);
   }
 }

--- a/src/main/java/com/faforever/client/map/MapService.java
+++ b/src/main/java/com/faforever/client/map/MapService.java
@@ -419,7 +419,7 @@ public class MapService implements InitializingBean, DisposableBean {
 
   @Cacheable(value = CacheNames.MAP_PREVIEW)
   public Image loadPreview(URL url, PreviewSize previewSize) {
-    return assetService.loadAndCacheImage(url, Paths.get("maps").resolve(previewSize.folderName),
+    return assetService.loadAndCacheImage(url, Path.of("maps").resolve(previewSize.folderName),
         () -> uiService.getThemeImage(UiService.UNKNOWN_MAP_IMAGE));
   }
 

--- a/src/main/java/com/faforever/client/map/generator/GeneratorCommand.java
+++ b/src/main/java/com/faforever/client/map/generator/GeneratorCommand.java
@@ -5,7 +5,6 @@ import lombok.Value;
 import org.apache.maven.artifact.versioning.ComparableVersion;
 
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -34,7 +33,7 @@ public class GeneratorCommand {
   String query;
 
   public List<String> getCommand() {
-    String javaPath = Paths.get(System.getProperty("java.home")).resolve("bin").resolve(org.bridj.Platform.isWindows() ? "java.exe" : "java").toAbsolutePath().toString();
+    String javaPath = Path.of(System.getProperty("java.home")).resolve("bin").resolve(org.bridj.Platform.isWindows() ? "java.exe" : "java").toAbsolutePath().toString();
     if (generatorExecutableFile == null) {
       throw new IllegalStateException("Map generator path not set");
     }

--- a/src/main/java/com/faforever/client/mod/InstallModTask.java
+++ b/src/main/java/com/faforever/client/mod/InstallModTask.java
@@ -21,7 +21,6 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Objects;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
@@ -108,7 +107,7 @@ public class InstallModTask extends CompletableTask<Void> {
   private void deleteOldModIfExisting(Path tempFile, Path modsDirectory) {
     try (ZipInputStream zipInputStream = new ZipInputStream(Files.newInputStream(tempFile))) {
       ZipEntry zipEntry = zipInputStream.getNextEntry();
-      Path pathToEntry = Paths.get(zipEntry.getName());
+      Path pathToEntry = Path.of(zipEntry.getName());
       Path topLevelDirectory = getTopLevelDirectory(pathToEntry);
       Path modDirectory = modsDirectory.resolve(topLevelDirectory);
       if (Files.isDirectory(modDirectory)) {

--- a/src/main/java/com/faforever/client/mod/ModService.java
+++ b/src/main/java/com/faforever/client/mod/ModService.java
@@ -296,7 +296,7 @@ public class ModService implements InitializingBean, DisposableBean {
   public Image loadThumbnail(ModVersionBean modVersion) {
     //FIXME: reintroduce correct caching
     URL url = modVersion.getThumbnailUrl();
-    return assetService.loadAndCacheImage(url, Paths.get("mods"), () -> IdenticonUtil.createIdenticon(modVersion.getMod().getDisplayName()));
+    return assetService.loadAndCacheImage(url, Path.of("mods"), () -> IdenticonUtil.createIdenticon(modVersion.getMod().getDisplayName()));
   }
 
   /**

--- a/src/main/java/com/faforever/client/os/FileOpeningHandler.java
+++ b/src/main/java/com/faforever/client/os/FileOpeningHandler.java
@@ -13,7 +13,6 @@ import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 /**
  * When a file type is associated with the client and the user opens such a file, this class will handle the opening
@@ -38,7 +37,7 @@ public class FileOpeningHandler implements ApplicationRunner, InitializingBean {
     if (parameters.split("\" \"").length > 2) {
       throw new IllegalArgumentException("Can't handle multiple files: " + parameters);
     }
-    Path filePath = Paths.get(parameters.replace("\"", ""));
+    Path filePath = Path.of(parameters.replace("\"", ""));
     runReplay(filePath);
   }
 
@@ -54,7 +53,7 @@ public class FileOpeningHandler implements ApplicationRunner, InitializingBean {
   public void run(ApplicationArguments args) {
     String[] sourceArgs = args.getSourceArgs();
     if (sourceArgs.length > 0) {
-      runReplay(Paths.get(sourceArgs[0]));
+      runReplay(Path.of(sourceArgs[0]));
     }
   }
 }

--- a/src/main/java/com/faforever/client/preferences/ForgedAlliancePrefs.java
+++ b/src/main/java/com/faforever/client/preferences/ForgedAlliancePrefs.java
@@ -24,17 +24,17 @@ public class ForgedAlliancePrefs {
   public static final String INIT_FILE_NAME = "init.lua";
 
   static {
-    FAF_VAULT_PATH = PreferencesService.FAF_DATA_DIRECTORY.resolve(Paths.get("user", "My Games", "Gas Powered Games", "Supreme Commander Forged Alliance"));
+    FAF_VAULT_PATH = PreferencesService.FAF_DATA_DIRECTORY.resolve(Path.of("user", "My Games", "Gas Powered Games", "Supreme Commander Forged Alliance"));
     if (org.bridj.Platform.isWindows()) {
-      GPG_VAULT_PATH = Paths.get(Shell32Util.getFolderPath(ShlObj.CSIDL_PERSONAL), "My Games", "Gas Powered Games", "Supreme Commander Forged Alliance");
+      GPG_VAULT_PATH = Path.of(Shell32Util.getFolderPath(ShlObj.CSIDL_PERSONAL), "My Games", "Gas Powered Games", "Supreme Commander Forged Alliance");
       //If steam is every swapped to a 64x client, needs to be updated to proper directory or handling must be put in place.
-      STEAM_FA_PATH = Paths.get(Shell32Util.getFolderPath(ShlObj.CSIDL_PROGRAM_FILESX86), "Steam", "steamapps", "common", "Supreme Commander Forged Alliance");
-      LOCAL_FA_DATA_PATH = Paths.get(Shell32Util.getFolderPath(ShlObj.CSIDL_LOCAL_APPDATA), "Gas Powered Games", "Supreme Commander Forged Alliance");
+      STEAM_FA_PATH = Path.of(Shell32Util.getFolderPath(ShlObj.CSIDL_PROGRAM_FILESX86), "Steam", "steamapps", "common", "Supreme Commander Forged Alliance");
+      LOCAL_FA_DATA_PATH = Path.of(Shell32Util.getFolderPath(ShlObj.CSIDL_LOCAL_APPDATA), "Gas Powered Games", "Supreme Commander Forged Alliance");
     } else {
       String userHome = System.getProperty("user.home");
-      GPG_VAULT_PATH = Paths.get(userHome, "My Games", "Gas Powered Games", "Supreme Commander Forged Alliance");
-      STEAM_FA_PATH = Paths.get(".");
-      LOCAL_FA_DATA_PATH = Paths.get(userHome, ".wine", "drive_c", "users", System.getProperty("user.name"), "Application Data", "Gas Powered Games", "Supreme Commander Forged Alliance");
+      GPG_VAULT_PATH = Path.of(userHome, "My Games", "Gas Powered Games", "Supreme Commander Forged Alliance");
+      STEAM_FA_PATH = Path.of(".");
+      LOCAL_FA_DATA_PATH = Path.of(userHome, ".wine", "drive_c", "users", System.getProperty("user.name"), "Application Data", "Gas Powered Games", "Supreme Commander Forged Alliance");
     }
   }
 

--- a/src/main/java/com/faforever/client/preferences/PreferencesService.java
+++ b/src/main/java/com/faforever/client/preferences/PreferencesService.java
@@ -101,7 +101,7 @@ public class PreferencesService implements InitializingBean {
   private static final String CORRUPTED_REPLAYS_SUB_FOLDER = "corrupt";
   private static final String CACHE_SUB_FOLDER = "cache";
   private static final String FEATURED_MOD_CACHE_SUB_FOLDER = "featured_mod";
-  private static final String CACHE_STYLESHEETS_SUB_FOLDER = Paths.get(CACHE_SUB_FOLDER, "stylesheets").toString();
+  private static final String CACHE_STYLESHEETS_SUB_FOLDER = Path.of(CACHE_SUB_FOLDER, "stylesheets").toString();
   private static final Path CACHE_DIRECTORY;
   private static final Pattern GAME_LOG_PATTERN = Pattern.compile("game(_\\d*)?.log");
   private static final int NUMBER_GAME_LOGS_STORED = 10;
@@ -109,9 +109,9 @@ public class PreferencesService implements InitializingBean {
 
   static {
     if (org.bridj.Platform.isWindows()) {
-      FAF_DATA_DIRECTORY = Paths.get(Shell32Util.getFolderPath(ShlObj.CSIDL_COMMON_APPDATA), "FAForever");
+      FAF_DATA_DIRECTORY = Path.of(Shell32Util.getFolderPath(ShlObj.CSIDL_COMMON_APPDATA), "FAForever");
     } else {
-      FAF_DATA_DIRECTORY = Paths.get(System.getProperty("user.home")).resolve(USER_HOME_SUB_FOLDER);
+      FAF_DATA_DIRECTORY = Path.of(System.getProperty("user.home")).resolve(USER_HOME_SUB_FOLDER);
     }
     CACHE_DIRECTORY = FAF_DATA_DIRECTORY.resolve(CACHE_SUB_FOLDER);
     FEATURED_MOD_CACHE_PATH = CACHE_DIRECTORY.resolve(FEATURED_MOD_CACHE_SUB_FOLDER);
@@ -185,9 +185,9 @@ public class PreferencesService implements InitializingBean {
 
   public Path getPreferencesDirectory() {
     if (org.bridj.Platform.isWindows()) {
-      return Paths.get(System.getenv("APPDATA")).resolve(APP_DATA_SUB_FOLDER);
+      return Path.of(System.getenv("APPDATA")).resolve(APP_DATA_SUB_FOLDER);
     }
-    return Paths.get(System.getProperty("user.home")).resolve(USER_HOME_SUB_FOLDER);
+    return Path.of(System.getProperty("user.home")).resolve(USER_HOME_SUB_FOLDER);
   }
 
   @Override

--- a/src/test/java/com/faforever/client/achievements/AchievementServiceTest.java
+++ b/src/test/java/com/faforever/client/achievements/AchievementServiceTest.java
@@ -15,7 +15,6 @@ import reactor.core.publisher.Flux;
 
 import java.net.URL;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -79,7 +78,7 @@ public class AchievementServiceTest extends ServiceTest {
   @Test
   public void testLoadAndCacheImageRevealed() throws Exception {
     AchievementDefinition achievementDefinition = AchievementDefinitionBuilder.create().defaultValues().get();
-    Path cacheSubDir = Paths.get("achievements").resolve(AchievementState.REVEALED.name().toLowerCase());
+    Path cacheSubDir = Path.of("achievements").resolve(AchievementState.REVEALED.name().toLowerCase());
     instance.getImage(achievementDefinition, AchievementState.REVEALED);
     verify(assetService).loadAndCacheImage(new URL(achievementDefinition.getRevealedIconUrl()), cacheSubDir, null, 128, 128);
   }
@@ -87,7 +86,7 @@ public class AchievementServiceTest extends ServiceTest {
   @Test
   public void testLoadAndCacheImageUnlocked() throws Exception {
     AchievementDefinition achievementDefinition = AchievementDefinitionBuilder.create().defaultValues().get();
-    Path cacheSubDir = Paths.get("achievements").resolve(AchievementState.UNLOCKED.name().toLowerCase());
+    Path cacheSubDir = Path.of("achievements").resolve(AchievementState.UNLOCKED.name().toLowerCase());
     instance.getImage(achievementDefinition, AchievementState.UNLOCKED);
     verify(assetService).loadAndCacheImage(new URL(achievementDefinition.getUnlockedIconUrl()), cacheSubDir, null, 128, 128);
   }

--- a/src/test/java/com/faforever/client/avatar/AvatarServiceTest.java
+++ b/src/test/java/com/faforever/client/avatar/AvatarServiceTest.java
@@ -18,7 +18,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.net.URL;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
@@ -51,7 +51,7 @@ public class AvatarServiceTest extends ServiceTest {
   public void testLoadAvatar() throws Exception {
     AvatarBean avatarBean = AvatarBeanBuilder.create().url(getClass().getResource("/theme/images/default_achievement.png").toURI().toURL()).get();
     instance.loadAvatar(avatarBean);
-    verify(assetService).loadAndCacheImage(avatarBean.getUrl(), Paths.get("avatars"), null);
+    verify(assetService).loadAndCacheImage(avatarBean.getUrl(), Path.of("avatars"), null);
   }
 
   @Test

--- a/src/test/java/com/faforever/client/builders/ModVersionBeanBuilder.java
+++ b/src/test/java/com/faforever/client/builders/ModVersionBeanBuilder.java
@@ -12,7 +12,6 @@ import org.apache.maven.artifact.versioning.ComparableVersion;
 
 import java.net.URL;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.time.OffsetDateTime;
 import java.util.List;
 
@@ -27,7 +26,7 @@ public class ModVersionBeanBuilder {
   @SneakyThrows
   public ModVersionBeanBuilder defaultValues() {
     mod(ModBeanBuilder.create().defaultValues().latestVersion(modVersionBean).get());
-    imagePath(Paths.get("."));
+    imagePath(Path.of("."));
     id(0);
     uid("id");
     description("This is a test mod");

--- a/src/test/java/com/faforever/client/fa/LaunchCommandBuilderTest.java
+++ b/src/test/java/com/faforever/client/fa/LaunchCommandBuilderTest.java
@@ -4,7 +4,7 @@ import com.faforever.client.test.ServiceTest;
 import com.faforever.commons.lobby.Faction;
 import org.junit.jupiter.api.Test;
 
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.util.List;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -18,9 +18,9 @@ public class LaunchCommandBuilderTest extends ServiceTest {
 
   private static LaunchCommandBuilder defaultBuilder() {
     return LaunchCommandBuilder.create()
-        .executable(Paths.get("test.exe"))
+        .executable(Path.of("test.exe"))
         .executableDecorator("%s")
-        .logFile(Paths.get("preferences.log"))
+        .logFile(Path.of("preferences.log"))
         .username("junit");
   }
 
@@ -95,14 +95,14 @@ public class LaunchCommandBuilderTest extends ServiceTest {
     String pathWithSpaces = "mypath/with space/test.exe";
     assertThat(
         defaultBuilder()
-            .executable(Paths.get(pathWithSpaces))
+            .executable(Path.of(pathWithSpaces))
             .executableDecorator("/path/to/my/wineprefix primusrun wine %s")
             .build(),
         contains(
-            "/path/to/my/wineprefix", "primusrun", "wine", Paths.get(pathWithSpaces).toAbsolutePath().toString(),
+            "/path/to/my/wineprefix", "primusrun", "wine", Path.of(pathWithSpaces).toAbsolutePath().toString(),
             "/init", "init.lua",
             "/nobugreport",
-            "/log", Paths.get("preferences.log").toAbsolutePath().toString()
+            "/log", Path.of("preferences.log").toAbsolutePath().toString()
         ));
   }
 
@@ -113,10 +113,10 @@ public class LaunchCommandBuilderTest extends ServiceTest {
             .executableDecorator("/path/to/my/wineprefix primusrun wine \"\"%s\"\"")
             .build(),
         contains(
-            "/path/to/my/wineprefix", "primusrun", "wine", Paths.get("test.exe").toAbsolutePath().toString(),
+            "/path/to/my/wineprefix", "primusrun", "wine", Path.of("test.exe").toAbsolutePath().toString(),
             "/init", "init.lua",
             "/nobugreport",
-            "/log", Paths.get("preferences.log").toAbsolutePath().toString()
+            "/log", Path.of("preferences.log").toAbsolutePath().toString()
         ));
   }
 
@@ -125,10 +125,10 @@ public class LaunchCommandBuilderTest extends ServiceTest {
     assertThat(
         defaultBuilder().rehost(true).build(),
         contains(
-            Paths.get("test.exe").toAbsolutePath().toString(),
+            Path.of("test.exe").toAbsolutePath().toString(),
             "/init", "init.lua",
             "/nobugreport",
-            "/log", Paths.get("preferences.log").toAbsolutePath().toString(),
+            "/log", Path.of("preferences.log").toAbsolutePath().toString(),
             "/rehost"
         ));
   }

--- a/src/test/java/com/faforever/client/fx/JavaFxUtilTest.java
+++ b/src/test/java/com/faforever/client/fx/JavaFxUtilTest.java
@@ -19,7 +19,7 @@ public class JavaFxUtilTest extends UITest {
 
   @Test
   public void testPathToStringConverter() throws Exception {
-    Path path = Paths.get(".");
+    Path path = Path.of(".");
 
     Path fromString = PATH_STRING_CONVERTER.fromString(path.toString());
     String toString = PATH_STRING_CONVERTER.toString(path);

--- a/src/test/java/com/faforever/client/game/CreateGameControllerTest.java
+++ b/src/test/java/com/faforever/client/game/CreateGameControllerTest.java
@@ -38,7 +38,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.testfx.util.WaitForAsyncUtils;
 
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
@@ -109,7 +109,7 @@ public class CreateGameControllerTest extends UITest {
 
     preferences = PreferencesBuilder.create().defaultValues()
         .forgedAlliancePrefs()
-        .installationPath(Paths.get(""))
+        .installationPath(Path.of(""))
         .then()
         .get();
     when(mapGeneratorService.downloadGeneratorIfNecessary(any())).thenReturn(completedFuture(null));

--- a/src/test/java/com/faforever/client/game/FaInitGeneratorTest.java
+++ b/src/test/java/com/faforever/client/game/FaInitGeneratorTest.java
@@ -15,7 +15,6 @@ import org.mockito.MockitoAnnotations;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -56,8 +55,8 @@ public class FaInitGeneratorTest extends ServiceTest {
   public void testGenerateInitFile() throws Exception {
     Path mountBasePath = this.mountBaseDir;
     List<MountInfo> mountPaths = Arrays.asList(
-        new MountInfo(mountBasePath, Paths.get("foobar"), "/foobar"),
-        new MountInfo(mountBasePath, Paths.get("gamedata/effects.nxt"), "/effects")
+        new MountInfo(mountBasePath, Path.of("foobar"), "/foobar"),
+        new MountInfo(mountBasePath, Path.of("gamedata/effects.nxt"), "/effects")
     );
 
     instance.generateInitFile(mountPaths, new HashSet<>(Arrays.asList("/schook", "/labwars")));

--- a/src/test/java/com/faforever/client/game/GameServiceTest.java
+++ b/src/test/java/com/faforever/client/game/GameServiceTest.java
@@ -52,7 +52,6 @@ import org.springframework.util.ReflectionUtils;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -247,7 +246,7 @@ public class GameServiceTest extends ServiceTest {
     GameBean game = GameBeanBuilder.create().defaultValues().get();
 
     GameLaunchResponse gameLaunchMessage = GameLaunchMessageBuilder.create().defaultValues().get();
-    Path replayPath = Paths.get("temp.scfareplay");
+    Path replayPath = Path.of("temp.scfareplay");
     int replayId = 1234;
 
     mockGlobalStartGameProcess(gameLaunchMessage.getUid());
@@ -276,7 +275,7 @@ public class GameServiceTest extends ServiceTest {
     GameBean game = GameBeanBuilder.create().defaultValues().get();
 
     GameLaunchResponse gameLaunchMessage = GameLaunchMessageBuilder.create().defaultValues().get();
-    Path replayPath = Paths.get("temp.scfareplay");
+    Path replayPath = Path.of("temp.scfareplay");
     int replayId = 1234;
 
     mockGlobalStartGameProcess(gameLaunchMessage.getUid());

--- a/src/test/java/com/faforever/client/game/GenerateMapControllerTest.java
+++ b/src/test/java/com/faforever/client/game/GenerateMapControllerTest.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.testfx.util.WaitForAsyncUtils;
 
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -72,7 +72,7 @@ public class GenerateMapControllerTest extends UITest {
 
     preferences = PreferencesBuilder.create().defaultValues()
         .forgedAlliancePrefs()
-        .installationPath(Paths.get(""))
+        .installationPath(Path.of(""))
         .then()
         .generatorPrefs()
         .spawnCount(10)

--- a/src/test/java/com/faforever/client/game/JoinGameHelperTest.java
+++ b/src/test/java/com/faforever/client/game/JoinGameHelperTest.java
@@ -20,7 +20,6 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -96,7 +95,7 @@ public class JoinGameHelperTest extends UITest {
     when(preferencesService.isGamePathValid()).thenReturn(false).thenReturn(true);
 
     doAnswer(invocation -> {
-      ((GameDirectoryChooseEvent) invocation.getArgument(0)).getFuture().ifPresent(future -> future.complete(Paths.get("")));
+      ((GameDirectoryChooseEvent) invocation.getArgument(0)).getFuture().ifPresent(future -> future.complete(Path.of("")));
       return null;
     }).when(eventBus).post(any(GameDirectoryChooseEvent.class));
 
@@ -118,7 +117,7 @@ public class JoinGameHelperTest extends UITest {
     doAnswer(invocation -> {
       Optional<CompletableFuture<Path>> optional = ((GameDirectoryChooseEvent) invocation.getArgument(0)).getFuture();
       if (invocationCounter.incrementAndGet() == 1) {
-        optional.ifPresent(future -> future.complete(Paths.get("")));
+        optional.ifPresent(future -> future.complete(Path.of("")));
       } else {
         optional.ifPresent(future -> future.complete(null));
       }

--- a/src/test/java/com/faforever/client/i18n/I18nTest.java
+++ b/src/test/java/com/faforever/client/i18n/I18nTest.java
@@ -111,7 +111,7 @@ public class I18nTest extends ServiceTest {
 
   @Test
   public void testLoadedLanguagesAreComplete() throws IOException {
-    final Path path = Paths.get("src", "main", "resources", "i18n");
+    final Path path = Path.of("src", "main", "resources", "i18n");
     try (Stream<Path> walk = Files.walk(path)) {
       final long messageFileCount = walk.filter(propertiesFile -> Files.isRegularFile(propertiesFile) && propertiesFile.getFileName().toString().endsWith(".properties")).count();
       assertThat(instance.getAvailableLanguages(), hasSize((int) messageFileCount));

--- a/src/test/java/com/faforever/client/main/MainControllerTest.java
+++ b/src/test/java/com/faforever/client/main/MainControllerTest.java
@@ -51,7 +51,6 @@ import org.springframework.core.env.Environment;
 import org.testfx.util.WaitForAsyncUtils;
 
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -295,7 +294,7 @@ public class MainControllerTest extends UITest {
 
   @Test
   public void testOnRevealLogFolder() throws Exception {
-    Path expectedPath = Paths.get("C:\\test\\path_log");
+    Path expectedPath = Path.of("C:\\test\\path_log");
     when(preferencesService.getFafLogDirectory()).thenReturn(expectedPath);
     instance.onRevealLogFolder();
     verify(platformService).reveal(expectedPath);

--- a/src/test/java/com/faforever/client/map/MapServiceTest.java
+++ b/src/test/java/com/faforever/client/map/MapServiceTest.java
@@ -191,7 +191,7 @@ public class MapServiceTest extends UITest {
 
   @Test
   public void testReadMap() throws Exception {
-    MapVersionBean mapBean = instance.readMap(Paths.get(getClass().getResource("/maps/SCMP_001").toURI()));
+    MapVersionBean mapBean = instance.readMap(Path.of(getClass().getResource("/maps/SCMP_001").toURI()));
 
     assertThat(mapBean, notNullValue());
     assertThat(mapBean.getId(), nullValue());
@@ -216,7 +216,7 @@ public class MapServiceTest extends UITest {
   @Test
   public void testLoadPreview() {
     for (PreviewSize previewSize : PreviewSize.values()) {
-      Path cacheSubDir = Paths.get("maps").resolve(previewSize.folderName);
+      Path cacheSubDir = Path.of("maps").resolve(previewSize.folderName);
       when(assetService.loadAndCacheImage(any(URL.class), eq(cacheSubDir), any())).thenReturn(new Image("theme/images/unknown_map.png"));
       instance.loadPreview("preview", previewSize);
       verify(assetService).loadAndCacheImage(any(URL.class), eq(cacheSubDir), any());
@@ -474,7 +474,7 @@ public class MapServiceTest extends UITest {
       String folder = map.getFolderName();
       Path mapPath = Files.createDirectories(mapsDirectory.resolve(folder));
       FileSystemUtils.copyRecursively(
-          Paths.get(getClass().getResource("/maps/" + folder).toURI()),
+          Path.of(getClass().getResource("/maps/" + folder).toURI()),
           mapPath
       );
       instance.addInstalledMap(mapPath);

--- a/src/test/java/com/faforever/client/map/StubDownloadMapTask.java
+++ b/src/test/java/com/faforever/client/map/StubDownloadMapTask.java
@@ -7,7 +7,6 @@ import org.springframework.util.FileSystemUtils;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 public class StubDownloadMapTask extends DownloadMapTask {
 
@@ -32,7 +31,7 @@ public class StubDownloadMapTask extends DownloadMapTask {
   private void imitateMapDownload() throws Exception {
     String folder = mapToDownload.getFolderName();
       FileSystemUtils.copyRecursively(
-          Paths.get(getClass().getResource("/maps/" + folder).toURI()),
+          Path.of(getClass().getResource("/maps/" + folder).toURI()),
           Files.createDirectories(customMapsDirectory.resolve(folder))
       );
   }

--- a/src/test/java/com/faforever/client/map/generator/GeneratorCommandTest.java
+++ b/src/test/java/com/faforever/client/map/generator/GeneratorCommandTest.java
@@ -6,7 +6,6 @@ import org.apache.maven.artifact.versioning.ComparableVersion;
 import org.junit.jupiter.api.Test;
 
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -16,7 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class GeneratorCommandTest extends ServiceTest {
 
-  private static final String javaPath = Paths.get(System.getProperty("java.home")).resolve("bin").resolve(org.bridj.Platform.isWindows() ? "java.exe" : "java").toAbsolutePath().toString();
+  private static final String javaPath = Path.of(System.getProperty("java.home")).resolve("bin").resolve(org.bridj.Platform.isWindows() ? "java.exe" : "java").toAbsolutePath().toString();
 
   private static GeneratorCommandBuilder defaultBuilder() {
     return GeneratorCommand.builder()
@@ -53,7 +52,7 @@ public class GeneratorCommandTest extends ServiceTest {
   @Test
   public void testMapNameNoException() {
     List<String> command = GeneratorCommand.builder().mapFilename("neroxis_map_generator_1.0.0_0")
-        .generatorExecutableFile(Paths.get("mapGenerator_1.0.0.jar"))
+        .generatorExecutableFile(Path.of("mapGenerator_1.0.0.jar"))
         .version(new ComparableVersion("1.0.0"))
         .build()
         .getCommand();

--- a/src/test/java/com/faforever/client/mod/ModServiceTest.java
+++ b/src/test/java/com/faforever/client/mod/ModServiceTest.java
@@ -340,7 +340,7 @@ public class ModServiceTest extends UITest {
     assertThat(modVersion.getUid(), is("9e8ea941-c306-4751-b367-a11000000502"));
     assertThat(modVersion.getModType(), equalTo(ModType.SIM));
     assertThat(modVersion.getMountPoints(), hasSize(10));
-    assertThat(modVersion.getMountPoints().get(3).getFile(), is(Paths.get("effects")));
+    assertThat(modVersion.getMountPoints().get(3).getFile(), is(Path.of("effects")));
     assertThat(modVersion.getMountPoints().get(3).getMountPoint(), is("/effects"));
     assertThat(modVersion.getHookDirectories(), contains("/blackops"));
 
@@ -407,7 +407,7 @@ public class ModServiceTest extends UITest {
 
     when(applicationContext.getBean(ModUploadTask.class)).thenReturn(modUploadTask);
 
-    Path modPath = Paths.get(".");
+    Path modPath = Path.of(".");
 
     instance.uploadMod(modPath);
 
@@ -422,7 +422,7 @@ public class ModServiceTest extends UITest {
         .thumbnailUrl(new URL("http://127.0.0.1:65534/thumbnail.png"))
         .get();
     instance.loadThumbnail(modVersion);
-    verify(assetService).loadAndCacheImage(eq(modVersion.getThumbnailUrl()), eq(Paths.get("mods")), any());
+    verify(assetService).loadAndCacheImage(eq(modVersion.getThumbnailUrl()), eq(Path.of("mods")), any());
   }
 
   @Test

--- a/src/test/java/com/faforever/client/mod/ModUploadTaskTest.java
+++ b/src/test/java/com/faforever/client/mod/ModUploadTaskTest.java
@@ -12,7 +12,6 @@ import reactor.core.publisher.Mono;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsArrayWithSize.emptyArray;
@@ -50,7 +49,7 @@ public class ModUploadTaskTest extends UITest {
 
   @Test
   public void testProgressListenerNull() throws Exception {
-    instance.setModPath(Paths.get("."));
+    instance.setModPath(Path.of("."));
     assertThrows(NullPointerException.class, () -> instance.call());
   }
 

--- a/src/test/java/com/faforever/client/os/FileOpeningHandlerTest.java
+++ b/src/test/java/com/faforever/client/os/FileOpeningHandlerTest.java
@@ -11,7 +11,7 @@ import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.DefaultApplicationArguments;
 
 import java.io.IOException;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 
 import static org.mockito.Mockito.verify;
 
@@ -34,6 +34,6 @@ public class FileOpeningHandlerTest extends ServiceTest {
     ApplicationArguments args = new DefaultApplicationArguments("foo.fafreplay");
     instance.run(args);
 
-    verify(replayService).runReplayFile(Paths.get("foo.fafreplay"));
+    verify(replayService).runReplayFile(Path.of("foo.fafreplay"));
   }
 }

--- a/src/test/java/com/faforever/client/preferences/PreferencesServiceTest.java
+++ b/src/test/java/com/faforever/client/preferences/PreferencesServiceTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.regex.Pattern;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -48,9 +47,9 @@ public class PreferencesServiceTest extends ServiceTest {
   @Test
   public void testGetFafDataDirectory() throws Exception {
     if (Platform.isWindows()) {
-      assertThat(instance.getFafDataDirectory(), is(Paths.get(Shell32Util.getFolderPath(ShlObj.CSIDL_COMMON_APPDATA), "FAForever")));
+      assertThat(instance.getFafDataDirectory(), is(Path.of(Shell32Util.getFolderPath(ShlObj.CSIDL_COMMON_APPDATA), "FAForever")));
     } else {
-      assertThat(instance.getFafDataDirectory(), is(Paths.get(System.getProperty("user.home")).resolve(".faforever")));
+      assertThat(instance.getFafDataDirectory(), is(Path.of(System.getProperty("user.home")).resolve(".faforever")));
     }
   }
 

--- a/src/test/java/com/faforever/client/replay/ReplayDetailControllerTest.java
+++ b/src/test/java/com/faforever/client/replay/ReplayDetailControllerTest.java
@@ -130,7 +130,7 @@ public class ReplayDetailControllerTest extends UITest {
         .featuredMod(new FeaturedModBean())
         .reviews(FXCollections.emptyObservableList())
         .title("test")
-        .replayFile(Paths.get("foo.tmp"))
+        .replayFile(Path.of("foo.tmp"))
         .get();
 
     instance = new ReplayDetailController(timeService, i18n, uiService, replayService, ratingService, mapService, mapGeneratorService, playerService, clientProperties, notificationService, reviewService);
@@ -334,7 +334,7 @@ public class ReplayDetailControllerTest extends UITest {
     instance.setReplay(replay);
     WaitForAsyncUtils.waitForFxEvents();
 
-    Path tmpPath = Paths.get("foo.tmp");
+    Path tmpPath = Path.of("foo.tmp");
     when(replayService.downloadReplay(replay.getId())).thenReturn(CompletableFuture.completedFuture(tmpPath));
 
     instance.onDownloadMoreInfoClicked();

--- a/src/test/java/com/faforever/client/replay/ReplayServiceTest.java
+++ b/src/test/java/com/faforever/client/replay/ReplayServiceTest.java
@@ -46,7 +46,6 @@ import reactor.core.publisher.Mono;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
@@ -412,7 +411,7 @@ public class ReplayServiceTest extends ServiceTest {
 
   @Test
   public void testEnrich() throws Exception {
-    Path path = Paths.get("foo.bar");
+    Path path = Path.of("foo.bar");
     when(replayFileReader.parseReplay(path)).thenReturn(replayDataParser);
 
     instance.enrich(new ReplayBean(), path);


### PR DESCRIPTION
From Oracle
`It is recommended to obtain a Path via the Path.of methods instead of via the get methods defined in this class as this class may be deprecated in a future release.`