### PR TITLE
Use non pooled web client and non-blocking token service

### DIFF
--- a/src/main/java/com/faforever/client/api/OAuthTokenFilter.java
+++ b/src/main/java/com/faforever/client/api/OAuthTokenFilter.java
@@ -2,6 +2,7 @@ package com.faforever.client.api;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.ClientRequest;
@@ -17,9 +18,9 @@ public class OAuthTokenFilter implements ExchangeFilterFunction {
   private final TokenService tokenService;
 
   @Override
-  public Mono<ClientResponse> filter(ClientRequest request, ExchangeFunction next) {
-    return next.exchange(ClientRequest.from(request)
-        .headers(headers -> headers.add(HttpHeaders.AUTHORIZATION, "Bearer " + tokenService.getRefreshedTokenValue()))
-        .build());
+  public @NotNull Mono<ClientResponse> filter(@NotNull ClientRequest request, @NotNull ExchangeFunction next) {
+    return tokenService.getRefreshedTokenValue().flatMap(token -> next.exchange(ClientRequest.from(request)
+        .headers(headers -> headers.add(HttpHeaders.AUTHORIZATION, "Bearer " + token))
+        .build()));
   }
 }

--- a/src/main/java/com/faforever/client/config/WebClientConfigurer.java
+++ b/src/main/java/com/faforever/client/config/WebClientConfigurer.java
@@ -2,10 +2,8 @@ package com.faforever.client.config;
 
 import com.faforever.client.api.JsonApiReader;
 import com.faforever.client.api.JsonApiWriter;
-import io.netty.resolver.DefaultAddressResolverGroup;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.web.reactive.function.client.WebClientCustomizer;
-import org.springframework.http.client.reactive.ClientHttpConnector;
 import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -20,10 +18,8 @@ public class WebClientConfigurer implements WebClientCustomizer {
 
   @Override
   public void customize(WebClient.Builder webClientBuilder) {
-    HttpClient httpClient = HttpClient.create().resolver(DefaultAddressResolverGroup.INSTANCE);
-    ClientHttpConnector clientHttpConnector = new ReactorClientHttpConnector(httpClient);
     webClientBuilder.defaultHeader("User-Agent", clientProperties.getUserAgent())
-        .clientConnector(clientHttpConnector)
+        .clientConnector(new ReactorClientHttpConnector(HttpClient.newConnection()))
         .codecs(clientCodecConfigurer -> {
           clientCodecConfigurer.customCodecs().register(jsonApiReader);
           clientCodecConfigurer.customCodecs().register(jsonApiWriter);

--- a/src/main/java/com/faforever/client/login/LoginController.java
+++ b/src/main/java/com/faforever/client/login/LoginController.java
@@ -405,6 +405,7 @@ public class LoginController implements Controller<Pane> {
     showLoginProgess();
     userService.login(code)
         .exceptionally(throwable -> {
+          log.warn("Could not log in with code", throwable);
           showLoginForm();
           notificationService.addImmediateErrorNotification(throwable, "login.failed");
           return null;
@@ -415,6 +416,7 @@ public class LoginController implements Controller<Pane> {
     showLoginProgess();
     userService.loginWithRefreshToken(refreshToken)
         .exceptionally(throwable -> {
+          log.warn("Could not log in with refresh", throwable);
           showLoginForm();
           if (!(throwable.getCause() instanceof HttpClientErrorException.BadRequest
               || throwable.getCause() instanceof HttpClientErrorException.Unauthorized)) {

--- a/src/main/java/com/faforever/client/main/MainController.java
+++ b/src/main/java/com/faforever/client/main/MainController.java
@@ -250,7 +250,6 @@ public class MainController implements Controller<Node> {
   @Subscribe
   public void onLoggedOutEvent(LoggedOutEvent event) {
     viewCache.invalidateAll();
-    contentPane.getChildren().clear();
     JavaFxUtil.runLater(this::enterLoggedOutState);
   }
 
@@ -368,6 +367,7 @@ public class MainController implements Controller<Node> {
   }
 
   private void enterLoggedOutState() {
+    contentPane.getChildren().clear();
     fxStage.getStage().setTitle(i18n.get("login.title"));
 
     LoginController loginController = uiService.loadFxml("theme/login/login.fxml");

--- a/src/main/java/com/faforever/client/user/UserService.java
+++ b/src/main/java/com/faforever/client/user/UserService.java
@@ -69,12 +69,7 @@ public class UserService implements InitializingBean, DisposableBean {
   public CompletableFuture<Void> login(String code) {
     if (loginFuture == null || loginFuture.isDone()) {
       log.info("Logging in with authorization code");
-      loginFuture = CompletableFuture.runAsync(() -> tokenService.loginWithAuthorizationCode(code))
-          .whenComplete((aVoid, throwable) -> {
-            if (throwable != null) {
-              log.warn("Could not log into the user service with code", throwable);
-            }
-          })
+      loginFuture = tokenService.loginWithAuthorizationCode(code).toFuture()
           .thenCompose(aVoid -> loginToServices());
     }
     return loginFuture;
@@ -83,12 +78,7 @@ public class UserService implements InitializingBean, DisposableBean {
   public CompletableFuture<Void> loginWithRefreshToken(String refreshToken) {
     if (loginFuture == null || loginFuture.isDone()) {
       log.info("Logging in with refresh token");
-      loginFuture = CompletableFuture.runAsync(() -> tokenService.loginWithRefreshToken(refreshToken))
-          .whenComplete((aVoid, throwable) -> {
-            if (throwable != null) {
-              log.info("Could not log into the user service with refresh token", throwable);
-            }
-          })
+      loginFuture = tokenService.loginWithRefreshToken(refreshToken).toFuture()
           .thenCompose(aVoid -> loginToServices());
     }
     return loginFuture;

--- a/src/test/java/com/faforever/client/remote/ServerAccessorTest.java
+++ b/src/test/java/com/faforever/client/remote/ServerAccessorTest.java
@@ -143,7 +143,7 @@ public class ServerAccessorTest extends ServiceTest {
 
   @BeforeEach
   public void setUp() throws Exception {
-    when(tokenService.getRefreshedTokenValue()).thenReturn(token);
+    when(tokenService.getRefreshedTokenValue()).thenReturn(Mono.just(token));
     objectMapper = new ObjectMapper()
         .registerModule(new KotlinModule())
         .registerModule(new JavaTimeModule())

--- a/src/test/java/com/faforever/client/user/UserServiceTest.java
+++ b/src/test/java/com/faforever/client/user/UserServiceTest.java
@@ -39,7 +39,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -114,6 +113,7 @@ public class UserServiceTest extends ServiceTest {
     when(fafApiAccessor.getMe()).thenReturn(Mono.just(meResult));
     when(fafServerAccessor.connectAndLogIn()).thenReturn(CompletableFuture.completedFuture(validLoginMessage));
     when(tokenService.getRefreshedTokenValue()).thenReturn(Mono.just("def"));
+    when(tokenService.loginWithAuthorizationCode("abc")).thenReturn(Mono.empty());
 
     instance.login("abc").join();
 
@@ -131,6 +131,7 @@ public class UserServiceTest extends ServiceTest {
     when(fafApiAccessor.getMe()).thenReturn(Mono.just(meResult));
     when(fafServerAccessor.connectAndLogIn()).thenReturn(CompletableFuture.completedFuture(validLoginMessage));
     when(tokenService.getRefreshedTokenValue()).thenReturn(Mono.just("def"));
+    when(tokenService.loginWithAuthorizationCode("abc")).thenReturn(Mono.empty());
 
     instance.login("abc").join();
 
@@ -149,7 +150,7 @@ public class UserServiceTest extends ServiceTest {
     when(fafServerAccessor.connectAndLogIn()).thenReturn(CompletableFuture.completedFuture(validLoginMessage));
     when(tokenService.getRefreshedTokenValue()).thenReturn(Mono.just("def"));
     FakeTestException testException = new FakeTestException("failed");
-    doThrow(testException).when(tokenService).loginWithAuthorizationCode(anyString());
+    when(tokenService.loginWithAuthorizationCode("abc")).thenReturn(Mono.error(testException));
 
     CompletionException thrown = assertThrows(CompletionException.class, () -> instance.login("abc").join());
 
@@ -167,6 +168,7 @@ public class UserServiceTest extends ServiceTest {
     when(fafApiAccessor.getMe()).thenReturn(Mono.just(meResult));
     when(fafServerAccessor.connectAndLogIn()).thenReturn(CompletableFuture.completedFuture(validLoginMessage));
     when(tokenService.getRefreshedTokenValue()).thenReturn(Mono.just("def"));
+    when(tokenService.loginWithAuthorizationCode("abc")).thenReturn(Mono.empty());
     FakeTestException testException = new FakeTestException("failed");
     doThrow(testException).when(fafApiAccessor).authorize();
 
@@ -186,6 +188,7 @@ public class UserServiceTest extends ServiceTest {
     when(fafApiAccessor.getMe()).thenReturn(Mono.just(meResult));
     when(fafServerAccessor.connectAndLogIn()).thenReturn(CompletableFuture.completedFuture(validLoginMessage));
     when(tokenService.getRefreshedTokenValue()).thenReturn(Mono.just("def"));
+    when(tokenService.loginWithAuthorizationCode("abc")).thenReturn(Mono.empty());
     FakeTestException testException = new FakeTestException("failed");
     when(fafApiAccessor.getMe()).thenReturn(Mono.error(testException));
 
@@ -205,6 +208,7 @@ public class UserServiceTest extends ServiceTest {
     when(fafApiAccessor.getMe()).thenReturn(Mono.just(meResult));
     when(fafServerAccessor.connectAndLogIn()).thenReturn(CompletableFuture.completedFuture(validLoginMessage));
     when(tokenService.getRefreshedTokenValue()).thenReturn(Mono.just("def"));
+    when(tokenService.loginWithAuthorizationCode("abc")).thenReturn(Mono.empty());
     FakeTestException testException = new FakeTestException("failed");
     when(fafServerAccessor.connectAndLogIn()).thenReturn(CompletableFuture.failedFuture(testException));
 
@@ -226,6 +230,7 @@ public class UserServiceTest extends ServiceTest {
     when(fafServerAccessor.getConnectionState()).thenReturn(ConnectionState.DISCONNECTED);
     when(fafApiAccessor.getMe()).thenReturn(Mono.just(meResult));
     when(fafServerAccessor.connectAndLogIn()).thenReturn(CompletableFuture.completedFuture(invalidLoginMessage));
+    when(tokenService.loginWithAuthorizationCode("abc")).thenReturn(Mono.empty());
     when(tokenService.getRefreshedTokenValue()).thenReturn(Mono.just("def"));
     FakeTestException testException = new FakeTestException("failed");
     when(fafServerAccessor.connectAndLogIn()).thenReturn(CompletableFuture.failedFuture(testException));
@@ -247,6 +252,7 @@ public class UserServiceTest extends ServiceTest {
     when(fafApiAccessor.getMe()).thenReturn(Mono.just(meResult));
     when(fafServerAccessor.connectAndLogIn()).thenReturn(CompletableFuture.completedFuture(validLoginMessage));
     when(tokenService.getRefreshedTokenValue()).thenReturn(Mono.just("def"));
+    when(tokenService.loginWithAuthorizationCode("abc")).thenReturn(Mono.empty());
 
     instance.login("abc").join();
 
@@ -272,6 +278,7 @@ public class UserServiceTest extends ServiceTest {
     when(fafApiAccessor.getMe()).thenReturn(Mono.just(meResult));
     when(fafServerAccessor.connectAndLogIn()).thenReturn(CompletableFuture.completedFuture(validLoginMessage));
     when(tokenService.getRefreshedTokenValue()).thenReturn(Mono.just("def"));
+    when(tokenService.loginWithRefreshToken("abc")).thenReturn(Mono.empty());
 
     instance.loginWithRefreshToken("abc").join();
 
@@ -290,7 +297,7 @@ public class UserServiceTest extends ServiceTest {
     when(fafServerAccessor.connectAndLogIn()).thenReturn(CompletableFuture.completedFuture(validLoginMessage));
     when(tokenService.getRefreshedTokenValue()).thenReturn(Mono.just("def"));
     FakeTestException testException = new FakeTestException("failed");
-    doThrow(testException).when(tokenService).loginWithRefreshToken(anyString());
+    when(tokenService.loginWithRefreshToken("abc")).thenReturn(Mono.error(testException));
 
     CompletionException thrown = assertThrows(CompletionException.class, () -> instance.loginWithRefreshToken("abc").join());
 

--- a/src/test/java/com/faforever/client/user/UserServiceTest.java
+++ b/src/test/java/com/faforever/client/user/UserServiceTest.java
@@ -113,7 +113,7 @@ public class UserServiceTest extends ServiceTest {
     when(fafServerAccessor.getConnectionState()).thenReturn(ConnectionState.DISCONNECTED);
     when(fafApiAccessor.getMe()).thenReturn(Mono.just(meResult));
     when(fafServerAccessor.connectAndLogIn()).thenReturn(CompletableFuture.completedFuture(validLoginMessage));
-    when(tokenService.getRefreshedTokenValue()).thenReturn("def");
+    when(tokenService.getRefreshedTokenValue()).thenReturn(Mono.just("def"));
 
     instance.login("abc").join();
 
@@ -130,7 +130,7 @@ public class UserServiceTest extends ServiceTest {
     when(fafServerAccessor.getConnectionState()).thenReturn(ConnectionState.CONNECTED);
     when(fafApiAccessor.getMe()).thenReturn(Mono.just(meResult));
     when(fafServerAccessor.connectAndLogIn()).thenReturn(CompletableFuture.completedFuture(validLoginMessage));
-    when(tokenService.getRefreshedTokenValue()).thenReturn("def");
+    when(tokenService.getRefreshedTokenValue()).thenReturn(Mono.just("def"));
 
     instance.login("abc").join();
 
@@ -147,7 +147,7 @@ public class UserServiceTest extends ServiceTest {
     when(fafServerAccessor.getConnectionState()).thenReturn(ConnectionState.DISCONNECTED);
     when(fafApiAccessor.getMe()).thenReturn(Mono.just(meResult));
     when(fafServerAccessor.connectAndLogIn()).thenReturn(CompletableFuture.completedFuture(validLoginMessage));
-    when(tokenService.getRefreshedTokenValue()).thenReturn("def");
+    when(tokenService.getRefreshedTokenValue()).thenReturn(Mono.just("def"));
     FakeTestException testException = new FakeTestException("failed");
     doThrow(testException).when(tokenService).loginWithAuthorizationCode(anyString());
 
@@ -166,7 +166,7 @@ public class UserServiceTest extends ServiceTest {
     when(fafServerAccessor.getConnectionState()).thenReturn(ConnectionState.DISCONNECTED);
     when(fafApiAccessor.getMe()).thenReturn(Mono.just(meResult));
     when(fafServerAccessor.connectAndLogIn()).thenReturn(CompletableFuture.completedFuture(validLoginMessage));
-    when(tokenService.getRefreshedTokenValue()).thenReturn("def");
+    when(tokenService.getRefreshedTokenValue()).thenReturn(Mono.just("def"));
     FakeTestException testException = new FakeTestException("failed");
     doThrow(testException).when(fafApiAccessor).authorize();
 
@@ -185,7 +185,7 @@ public class UserServiceTest extends ServiceTest {
     when(fafServerAccessor.getConnectionState()).thenReturn(ConnectionState.DISCONNECTED);
     when(fafApiAccessor.getMe()).thenReturn(Mono.just(meResult));
     when(fafServerAccessor.connectAndLogIn()).thenReturn(CompletableFuture.completedFuture(validLoginMessage));
-    when(tokenService.getRefreshedTokenValue()).thenReturn("def");
+    when(tokenService.getRefreshedTokenValue()).thenReturn(Mono.just("def"));
     FakeTestException testException = new FakeTestException("failed");
     when(fafApiAccessor.getMe()).thenReturn(Mono.error(testException));
 
@@ -204,7 +204,7 @@ public class UserServiceTest extends ServiceTest {
     when(fafServerAccessor.getConnectionState()).thenReturn(ConnectionState.DISCONNECTED);
     when(fafApiAccessor.getMe()).thenReturn(Mono.just(meResult));
     when(fafServerAccessor.connectAndLogIn()).thenReturn(CompletableFuture.completedFuture(validLoginMessage));
-    when(tokenService.getRefreshedTokenValue()).thenReturn("def");
+    when(tokenService.getRefreshedTokenValue()).thenReturn(Mono.just("def"));
     FakeTestException testException = new FakeTestException("failed");
     when(fafServerAccessor.connectAndLogIn()).thenReturn(CompletableFuture.failedFuture(testException));
 
@@ -226,7 +226,7 @@ public class UserServiceTest extends ServiceTest {
     when(fafServerAccessor.getConnectionState()).thenReturn(ConnectionState.DISCONNECTED);
     when(fafApiAccessor.getMe()).thenReturn(Mono.just(meResult));
     when(fafServerAccessor.connectAndLogIn()).thenReturn(CompletableFuture.completedFuture(invalidLoginMessage));
-    when(tokenService.getRefreshedTokenValue()).thenReturn("def");
+    when(tokenService.getRefreshedTokenValue()).thenReturn(Mono.just("def"));
     FakeTestException testException = new FakeTestException("failed");
     when(fafServerAccessor.connectAndLogIn()).thenReturn(CompletableFuture.failedFuture(testException));
 
@@ -246,7 +246,7 @@ public class UserServiceTest extends ServiceTest {
     when(fafServerAccessor.getConnectionState()).thenReturn(ConnectionState.DISCONNECTED);
     when(fafApiAccessor.getMe()).thenReturn(Mono.just(meResult));
     when(fafServerAccessor.connectAndLogIn()).thenReturn(CompletableFuture.completedFuture(validLoginMessage));
-    when(tokenService.getRefreshedTokenValue()).thenReturn("def");
+    when(tokenService.getRefreshedTokenValue()).thenReturn(Mono.just("def"));
 
     instance.login("abc").join();
 
@@ -271,7 +271,7 @@ public class UserServiceTest extends ServiceTest {
     when(fafServerAccessor.getConnectionState()).thenReturn(ConnectionState.DISCONNECTED);
     when(fafApiAccessor.getMe()).thenReturn(Mono.just(meResult));
     when(fafServerAccessor.connectAndLogIn()).thenReturn(CompletableFuture.completedFuture(validLoginMessage));
-    when(tokenService.getRefreshedTokenValue()).thenReturn("def");
+    when(tokenService.getRefreshedTokenValue()).thenReturn(Mono.just("def"));
 
     instance.loginWithRefreshToken("abc").join();
 
@@ -288,7 +288,7 @@ public class UserServiceTest extends ServiceTest {
     when(fafServerAccessor.getConnectionState()).thenReturn(ConnectionState.DISCONNECTED);
     when(fafApiAccessor.getMe()).thenReturn(Mono.just(meResult));
     when(fafServerAccessor.connectAndLogIn()).thenReturn(CompletableFuture.completedFuture(validLoginMessage));
-    when(tokenService.getRefreshedTokenValue()).thenReturn("def");
+    when(tokenService.getRefreshedTokenValue()).thenReturn(Mono.just("def"));
     FakeTestException testException = new FakeTestException("failed");
     doThrow(testException).when(tokenService).loginWithRefreshToken(anyString());
 


### PR DESCRIPTION
Some players are experiencing connection reset issues with the sockets from the web Client. This might be due to the web Client using pooled connections by default, and the server timing out the connections or the connections timing out.

This also fixes the issue of the token service being blocking which causes errors when used in the oAuth token filter.