### PR TITLE
#2422 - Separate the version number from the word "version" in "Maps" tab

### DIFF
--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -612,7 +612,7 @@ chat.userContext.copyUsername=Copy username
 userInfo.idleTimeFormat=Last seen\: {0}
 map.playCount=Times played
 map.numberOfDownloads=Downloads
-map.versionFormat=v{0}
+map.versionFormat=v {0}
 settings.appearance=Appearance
 settings.language=Language
 # Noun


### PR DESCRIPTION
Closes #2422 