### PR TITLE
league ui fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -298,7 +298,7 @@ dependencies {
   implementation("org.springframework:spring-web")
   implementation("org.springframework:spring-websocket")
 
-  implementation("com.github.FAForever:faf-java-commons:067586f4582daaf2a0702da0f8f61d15484a4e47") {
+  implementation("com.github.FAForever:faf-java-commons:016488e71a4872716a9c8e79f051a60723a4e56f") {
     exclude module: 'guava'
   }
   implementation("com.google.guava:guava:30.0-jre")

--- a/src/main/java/com/faforever/client/domain/SubdivisionBean.java
+++ b/src/main/java/com/faforever/client/domain/SubdivisionBean.java
@@ -19,7 +19,7 @@ import java.net.URL;
 @Value
 public class SubdivisionBean extends AbstractEntityBean<SubdivisionBean> {
   @ToString.Include
-  StringProperty NameKey = new SimpleStringProperty();
+  StringProperty nameKey = new SimpleStringProperty();
   StringProperty descriptionKey = new SimpleStringProperty();
   IntegerProperty index = new SimpleIntegerProperty();
   IntegerProperty highestScore = new SimpleIntegerProperty();
@@ -31,15 +31,15 @@ public class SubdivisionBean extends AbstractEntityBean<SubdivisionBean> {
   ObjectProperty<URL> smallImageUrl = new SimpleObjectProperty<>();
 
   public String getNameKey() {
-    return NameKey.get();
+    return nameKey.get();
   }
 
   public void setNameKey(String nameKey) {
-    this.NameKey.set(nameKey);
+    this.nameKey.set(nameKey);
   }
 
   public StringProperty nameKeyProperty() {
-    return NameKey;
+    return nameKey;
   }
 
   public String getDescriptionKey() {

--- a/src/main/java/com/faforever/client/mapstruct/LeaderboardMapper.java
+++ b/src/main/java/com/faforever/client/mapstruct/LeaderboardMapper.java
@@ -25,7 +25,7 @@ import org.mapstruct.Mapping;
 
 import java.util.List;
 
-@Mapper(componentModel = "spring", uses = {ReplayMapper.class, PlayerMapper.class}, config = MapperConfiguration.class)
+@Mapper(componentModel = "spring", uses = {ReplayMapper.class, PlayerMapper.class, UrlMapper.class}, config = MapperConfiguration.class)
 public interface LeaderboardMapper {
   LeaderboardBean map(Leaderboard dto, @Context CycleAvoidingMappingContext context);
 

--- a/src/main/resources/theme/style.css
+++ b/src/main/resources/theme/style.css
@@ -767,7 +767,7 @@
 .score-circle {
   -fx-fill: transparent;
   -fx-stroke-width: 20;
-  -fx-stroke: #1e1e1e;
+  -fx-stroke: #1e1e1e99;
 }
 
 .score {
@@ -804,8 +804,7 @@
 .division-selector {
   -fx-border-width: 0;
   -fx-font-size: 20px;
-  -fx-background-color: #1e1e1e;
-  -fx-background-radius: 10;
+  -fx-background-color: #1e1e1ebb;
   -fx-font-family: 'Source Sans Pro Semibold';
 }
 
@@ -857,6 +856,11 @@
   -fx-cell-size: 1.6em;
 }
 
+.division-table *.scroll-bar:horizontal *.increment-button,
+.division-table *.scroll-bar:horizontal *.decrement-button {
+  -fx-padding: 0;
+}
+
 .leaderboardChart {
   chart_color_1: #2b71d9;
   chart_color_2: #2b71d9;
@@ -865,18 +869,17 @@
   chart_color_5: #2b71d9;
 }
 
-/***************** Match maker *****************/
-
-.player-card {
-  -fx-background-color: #1e1e1e;
-  -fx-border-color: #636363;
-  -fx-background-radius: 9;
-  -fx-border-radius: 9;
-  -fx-border-width: 1;
-  -fx-font-family: 'Source Sans Pro';
-  -fx-font-size: 14px;
+.leaderboardChart .chart-plot-background {
+  -fx-background-color: #24242499;
 }
 
+.leaderboardChart .chart-vertical-grid-lines {
+  -fx-stroke: transparent;
+}
+
+.leaderboardChart .chart-horizontal-grid-lines {
+  -fx-stroke: transparent;
+}
 
 /***************** Match maker *****************/
 


### PR DESCRIPTION
This fixes some ui issues with the league system, most notably the division images, but also some annoyances when using background images.
Requires https://github.com/FAForever/faf-java-commons/pull/78 to be merged so I can bump the faf commons version to the appropriate commit.
With this we should be able to make a new prerelease that has no known bugs, so I can make a forum post to promote it for testing.