### PR TITLE
Reverse element order in the division picker

### DIFF
--- a/src/main/java/com/faforever/client/leaderboard/LeaderboardController.java
+++ b/src/main/java/com/faforever/client/leaderboard/LeaderboardController.java
@@ -46,6 +46,7 @@ import org.springframework.stereotype.Component;
 
 import java.time.format.FormatStyle;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -159,8 +160,12 @@ public class LeaderboardController implements Controller<Tab> {
   private void setUsernamesAutoCompletion(List<SubdivisionBean> subdivisions) {
     JavaFxUtil.runLater(() -> {
       majorDivisionPicker.getItems().clear();
-      majorDivisionPicker.getItems().addAll(
-          subdivisions.stream().filter(subdivision -> subdivision.getIndex() == 1).collect(Collectors.toList()));
+      List<SubdivisionBean> majorDivisions = subdivisions
+          .stream()
+          .filter(subdivision -> subdivision.getIndex() == 1)
+          .collect(Collectors.toList());
+      Collections.reverse(majorDivisions);
+      majorDivisionPicker.getItems().addAll(majorDivisions);
     });
     Set<String> leagueEntryNames = new HashSet<>();
     List<CompletableFuture<?>> futures = new ArrayList<>();
@@ -229,7 +234,7 @@ public class LeaderboardController implements Controller<Tab> {
 
   private void selectHighestDivision() {
     entryToSelect = null;
-    JavaFxUtil.runLater(() -> majorDivisionPicker.getSelectionModel().selectLast());
+    JavaFxUtil.runLater(() -> majorDivisionPicker.getSelectionModel().selectFirst());
   }
 
   private void selectLeagueEntry(LeagueEntryBean leagueEntry) {

--- a/src/test/java/com/faforever/client/leaderboard/LeaderboardControllerTest.java
+++ b/src/test/java/com/faforever/client/leaderboard/LeaderboardControllerTest.java
@@ -122,8 +122,8 @@ public class LeaderboardControllerTest extends UITest {
 
     assertEquals("SEASONNAME 1", instance.seasonLabel.getText());
     assertEquals(2, instance.majorDivisionPicker.getItems().size());
-    assertEquals(subdivisionBean1, instance.majorDivisionPicker.getItems().get(0));
-    assertTrue(instance.majorDivisionPicker.getSelectionModel().isSelected(1));
+    assertEquals(subdivisionBean1, instance.majorDivisionPicker.getItems().get(1));
+    assertTrue(instance.majorDivisionPicker.getSelectionModel().isSelected(0));
     assertTrue(instance.contentPane.isVisible());
     verifyNoInteractions(notificationService);
     assertNull(subDivisionTabController.ratingTable.getSelectionModel().getSelectedItem());


### PR DESCRIPTION
As Farms pointed out it makes more sense to have the highest divisions to be the highest in the dropdown list.