### PR TITLE
Fix possible memory leak in CSS Classes of cells

### DIFF
--- a/src/main/java/com/faforever/client/fx/DecimalCell.java
+++ b/src/main/java/com/faforever/client/fx/DecimalCell.java
@@ -9,12 +9,11 @@ public class DecimalCell<S, T extends Number> extends TableCell<S, T> {
 
   private final DecimalFormat format;
   private final Function<T, T> roundingFunction;
-  private final String[] cssClasses;
 
   public DecimalCell(DecimalFormat format, Function<T, T> roundingFunction, String... cssClasses) {
     this.format = format;
     this.roundingFunction = roundingFunction;
-    this.cssClasses = cssClasses;
+    getStyleClass().addAll(cssClasses);
   }
 
   @Override
@@ -26,7 +25,7 @@ public class DecimalCell<S, T extends Number> extends TableCell<S, T> {
       setGraphic(null);
     } else {
       setText(format.format(roundingFunction.apply(item)));
-      getStyleClass().addAll(cssClasses);
+
     }
   }
 }

--- a/src/main/java/com/faforever/client/fx/DualStringListCell.java
+++ b/src/main/java/com/faforever/client/fx/DualStringListCell.java
@@ -28,13 +28,13 @@ public class DualStringListCell<T> extends ListCell<T> {
       } else {
         if (dualStringListCellController == null) {
           dualStringListCellController = uiService.loadFxml("theme/dual_string_list_cell.fxml");
+          // copy font styles
+          dualStringListCellController.applyFont(getFont());
+          dualStringListCellController.applyStyleClass(styleClasses);
         }
         dualStringListCellController.setLeftText(functionLeft.apply(item));
         dualStringListCellController.setWebViewToolTip(functionWebViewToolTip.apply(item));
         dualStringListCellController.setRightText(functionRight.apply(item));
-        // copy font styles
-        dualStringListCellController.applyFont(getFont());
-        dualStringListCellController.applyStyleClass(styleClasses);
         setGraphic(dualStringListCellController.getRoot());
       }
     });

--- a/src/main/java/com/faforever/client/fx/IconCell.java
+++ b/src/main/java/com/faforever/client/fx/IconCell.java
@@ -12,17 +12,12 @@ import java.util.function.Function;
 public class IconCell<S, T> extends TableCell<S, T> {
 
   private final Function<T, String> iconCssClassFunction;
-  private final String[] containerCssClasses;
-
-  public IconCell(Function<T, String> iconCssClassFunction) {
-    this(iconCssClassFunction, new String[0]);
-  }
 
   @Override
   protected void updateItem(T item, boolean empty) {
     super.updateItem(item, empty);
-
     setText(null);
+
     if (empty || item == null) {
       setGraphic(null);
     } else {
@@ -33,10 +28,8 @@ public class IconCell<S, T> extends TableCell<S, T> {
       }
 
       Region region = new Region();
-      region.getStyleClass().add(UiService.CSS_CLASS_ICON);
-      region.getStyleClass().add(cssClass);
+      region.getStyleClass().addAll(UiService.CSS_CLASS_ICON, cssClass);
       setGraphic(region);
-      getStyleClass().addAll(containerCssClasses);
     }
   }
 }

--- a/src/main/java/com/faforever/client/fx/NodeListCell.java
+++ b/src/main/java/com/faforever/client/fx/NodeListCell.java
@@ -8,11 +8,10 @@ import java.util.function.Function;
 public class NodeListCell<T> extends ListCell<T> {
 
   private final Function<T, ? extends Node> function;
-  private String[] cssClasses;
 
   public NodeListCell(Function<T, ? extends Node> function, String... cssClasses) {
     this.function = function;
-    this.cssClasses = cssClasses;
+    getStyleClass().addAll(cssClasses);
   }
 
   @Override
@@ -26,7 +25,6 @@ public class NodeListCell<T> extends ListCell<T> {
       setGraphic(null);
     } else {
       setGraphic(function.apply(item));
-      getStyleClass().addAll(cssClasses);
     }
   }
 }

--- a/src/main/java/com/faforever/client/fx/NodeTableCell.java
+++ b/src/main/java/com/faforever/client/fx/NodeTableCell.java
@@ -8,15 +8,10 @@ import java.util.function.Function;
 public class NodeTableCell<S, T> extends TableCell<S, T> {
 
   private final Function<T, ? extends Node> function;
-  private final String[] cssClasses;
-
-  public NodeTableCell(Function<T, ? extends Node> function) {
-    this(function, new String[0]);
-  }
 
   public NodeTableCell(Function<T, ? extends Node> function, String... cssClasses) {
     this.function = function;
-    this.cssClasses = cssClasses;
+    getStyleClass().addAll(cssClasses);
   }
 
   @Override
@@ -29,7 +24,6 @@ public class NodeTableCell<S, T> extends TableCell<S, T> {
         setGraphic(null);
       } else {
         setGraphic(function.apply(item));
-        getStyleClass().addAll(cssClasses);
       }
     });
   }

--- a/src/main/java/com/faforever/client/fx/StringCell.java
+++ b/src/main/java/com/faforever/client/fx/StringCell.java
@@ -9,11 +9,6 @@ import java.util.function.Function;
 public class StringCell<S, T> extends TableCell<S, T> {
 
   private final Function<T, String> function;
-  private final String[] cssClasses;
-
-  public StringCell(Function<T, String> function) {
-    this(function, new String[0]);
-  }
 
   @Override
   protected void updateItem(T item, boolean empty) {
@@ -24,7 +19,6 @@ public class StringCell<S, T> extends TableCell<S, T> {
       setGraphic(null);
     } else {
       setText(function.apply(item));
-      getStyleClass().addAll(cssClasses);
     }
   }
 }

--- a/src/main/java/com/faforever/client/fx/StringListCell.java
+++ b/src/main/java/com/faforever/client/fx/StringListCell.java
@@ -12,7 +12,6 @@ public class StringListCell<T> extends ListCell<T> {
   private final Function<T, Node> graphicFunction;
   private final Function<T, String> function;
   private final Pos alignment;
-  private final String[] cssClasses;
 
   public StringListCell(Function<T, String> function) {
     this(function, null);
@@ -25,7 +24,7 @@ public class StringListCell<T> extends ListCell<T> {
   public StringListCell(Function<T, String> function, Function<T, Node> graphicFunction, Pos alignment, String... cssClasses) {
     this.function = function;
     this.alignment = alignment;
-    this.cssClasses = cssClasses;
+    getStyleClass().addAll(cssClasses);
     this.graphicFunction = graphicFunction;
   }
 
@@ -43,7 +42,6 @@ public class StringListCell<T> extends ListCell<T> {
         }
         setText(Objects.toString(function.apply(item), ""));
         setAlignment(alignment);
-        getStyleClass().addAll(cssClasses);
       }
     });
   }


### PR DESCRIPTION
I connected the profiler to the client.
As you can see from the graph, memory consumption increases dramatically during each minute, until the garbage collector starts its work. It looks like a memory leak.
After analyzing the code, I came to the conclusion that the `styleClasses` object is not a hash collection, which is why `styleClasses` contains many identical class names, which in turn triggers many monotonous actions (unexplained CPU spikes)

Before fix:
![image](https://user-images.githubusercontent.com/38242291/149314831-0f8b9781-7559-4baf-a49b-82bd12580993.png)

After fix:
![image](https://user-images.githubusercontent.com/38242291/149314860-3401274a-1bdb-41d3-aa8a-41294dd12fb2.png)
