### PR TITLE
For Linux this launches proton using steam ID 9420 to launch FA when protontricks-launch is detected.

### DIFF
--- a/src/main/java/com/faforever/client/FafClientApplication.java
+++ b/src/main/java/com/faforever/client/FafClientApplication.java
@@ -53,13 +53,14 @@ public class FafClientApplication extends Application {
   public static final String PROFILE_PROD = "prod";
   public static final String PROFILE_TEST = "test";
   /**
-   * Does always reload root tabs in the MainController. This is useful if you do hot swap and you want to see your
+   * Does always reload root tabs in the MainController. This is useful if you do hot swap, and you want to see your
    * changes.
    */
   public static final String PROFILE_RELOAD = "reload";
   public static final String PROFILE_LOCAL = "local";
   public static final String PROFILE_WINDOWS = "windows";
   public static final String PROFILE_LINUX = "linux";
+  public static final String PROFILE_PROTON = "proton";
   public static final String PROFILE_MAC = "mac";
   public static final int EXIT_STATUS_RAN_AS_ADMIN = 3;
 
@@ -70,13 +71,23 @@ public class FafClientApplication extends Application {
     launch(args);
   }
 
-    public static String[] getAdditionalProfiles() {
+  public static String[] getAdditionalProfiles() {
     List<String> additionalProfiles = new ArrayList<>();
 
     if (org.bridj.Platform.isWindows()) {
       additionalProfiles.add(PROFILE_WINDOWS);
     } else if (org.bridj.Platform.isLinux()) {
       additionalProfiles.add(PROFILE_LINUX);
+      try {
+        Process start = new ProcessBuilder("protontricks-launch", "-h").start();
+          start.getInputStream().readAllBytes();
+         int i= start  .waitFor();
+        if (0 == i) {
+          additionalProfiles.add(PROFILE_PROTON);
+        }
+      } catch (IOException | InterruptedException e) {
+        e.printStackTrace();
+      }
     } else if (org.bridj.Platform.isMacOSX()) {
       additionalProfiles.add(PROFILE_MAC);
     }
@@ -195,4 +206,5 @@ public class FafClientApplication extends Application {
     timeoutThread.setDaemon(true);
     timeoutThread.start();
   }
+
 }

--- a/src/main/java/com/faforever/client/FafClientApplication.java
+++ b/src/main/java/com/faforever/client/FafClientApplication.java
@@ -35,6 +35,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 
+import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/src/main/java/com/faforever/client/FafClientApplication.java
+++ b/src/main/java/com/faforever/client/FafClientApplication.java
@@ -70,7 +70,7 @@ public class FafClientApplication extends Application {
     launch(args);
   }
 
-  private static String[] getAdditionalProfiles() {
+    public static String[] getAdditionalProfiles() {
     List<String> additionalProfiles = new ArrayList<>();
 
     if (org.bridj.Platform.isWindows()) {

--- a/src/main/java/com/faforever/client/fa/LaunchCommandBuilder.java
+++ b/src/main/java/com/faforever/client/fa/LaunchCommandBuilder.java
@@ -16,12 +16,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Stream;
 
 import static com.faforever.client.util.Assert.checkNullIllegalState;
 

--- a/src/main/java/com/faforever/client/fa/LaunchCommandBuilder.java
+++ b/src/main/java/com/faforever/client/fa/LaunchCommandBuilder.java
@@ -1,5 +1,6 @@
 package com.faforever.client.fa;
 
+import com.faforever.client.FafClientApplication;
 import com.faforever.client.preferences.ForgedAlliancePrefs;
 import com.faforever.commons.lobby.Faction;
 import com.google.common.base.Strings;
@@ -15,8 +16,12 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 import static com.faforever.client.util.Assert.checkNullIllegalState;
 
@@ -303,7 +308,9 @@ public class LaunchCommandBuilder {
   }
 
   public LaunchCommandBuilder executableDecorator(String executableDecorator) {
-    this.executableDecorator = Strings.isNullOrEmpty(executableDecorator) ? DEFAULT_EXECUTABLE_DECORATOR : executableDecorator;
+    boolean linuxProton = Arrays.asList(FafClientApplication.getAdditionalProfiles()).contains(FafClientApplication.PROFILE_LINUX);
+    String profileLauncher = (linuxProton ? "protontricks-launch --appid 9420 " : "") + DEFAULT_EXECUTABLE_DECORATOR;
+    this.executableDecorator = Strings.isNullOrEmpty(executableDecorator) ? profileLauncher : executableDecorator;
     return this;
   }
 }

--- a/src/main/java/com/faforever/client/fa/LaunchCommandBuilder.java
+++ b/src/main/java/com/faforever/client/fa/LaunchCommandBuilder.java
@@ -304,7 +304,7 @@ public class LaunchCommandBuilder {
   }
 
   public LaunchCommandBuilder executableDecorator(String executableDecorator) {
-    boolean linuxProton = Arrays.asList(FafClientApplication.getAdditionalProfiles()).contains(FafClientApplication.PROFILE_LINUX);
+    boolean linuxProton = Arrays.asList(FafClientApplication.getAdditionalProfiles()).contains(FafClientApplication.PROFILE_PROTON);
     String profileLauncher = (linuxProton ? "protontricks-launch --appid 9420 " : "") + DEFAULT_EXECUTABLE_DECORATOR;
     this.executableDecorator = Strings.isNullOrEmpty(executableDecorator) ? profileLauncher : executableDecorator;
     return this;


### PR DESCRIPTION
addresses/fixes #2586 on my linux faf install.  faf has always been linked to Steam to my recollection, so no further indirection seems relevant for linux.  standard faf installation wiki(s), and FA guides all involve protontricks, again, no=op relating to this patch.
--

there is OS profile information in main with no obvious access other than the static methods written to run the bridj library calls.

instead of calling the bridj API I stuck to the PROFILE_STRING convention written.

I also noted there is no code setting the executableDecorator and it is unclear if there is DI that intellij is not hinting for me.  I took no liberies to bridge the unreachable PROFILE strings with the single-constant-instance of the decorator in the hopes that I can be shown any hierarchies I have missed with this patch.