### PR TITLE
Disable ICE adapter info window

### DIFF
--- a/src/main/java/com/faforever/client/fa/relay/ice/IceAdapterImpl.java
+++ b/src/main/java/com/faforever/client/fa/relay/ice/IceAdapterImpl.java
@@ -175,7 +175,6 @@ public class IceAdapterImpl implements IceAdapter, InitializingBean, DisposableB
 
       if (preferencesService.getPreferences().getForgedAlliance().isShowIceAdapterDebugWindow()) {
         cmd.add("--debug-window");
-        cmd.add("--info-window");
       }
 
       try {


### PR DESCRIPTION
Shows only the debug window when requested, no reason to inform the user about what that is after they specifically enabled it in the settings.