### PR TITLE
Enable more sort options

### DIFF
--- a/src/main/java/com/faforever/client/query/SearchablePropertyMappings.java
+++ b/src/main/java/com/faforever/client/query/SearchablePropertyMappings.java
@@ -46,14 +46,14 @@ public class SearchablePropertyMappings {
 
   public static final Map<String, Property> MAP_PROPERTY_MAPPING = ImmutableMap.<String, Property>builder()
       .put("displayName", new Property("map.name", true))
-      .put("author.login", new Property("map.author", false))
+      .put("author.login", new Property("map.author", true))
 
-      .put("gamesPlayed", new Property("map.playCount", false))
+      .put("gamesPlayed", new Property("map.playCount", true))
 
-      .put("latestVersion.createTime", new Property("map.uploadedDateTime", false))
-      .put("latestVersion.updateTime", new Property("map.updatedDateTime", false))
+      .put("latestVersion.createTime", new Property("map.uploadedDateTime", true))
+      .put("latestVersion.updateTime", new Property("map.updatedDateTime", true))
       .put("latestVersion.description", new Property("map.description", false))
-      .put("latestVersion.maxPlayers", new Property("map.maxPlayers", false))
+      .put("latestVersion.maxPlayers", new Property("map.maxPlayers", true))
       .put("latestVersion.width", new Property("map.widthPixels", false))
       .put("latestVersion.height", new Property("map.heightPixels", false))
       .put("latestVersion.folderName", new Property("map.folderName", false))
@@ -64,10 +64,10 @@ public class SearchablePropertyMappings {
 
   public static final Map<String, Property> MOD_PROPERTY_MAPPING = ImmutableMap.<String, Property>builder()
       .put("displayName", new Property("mod.displayName", true))
-      .put("author", new Property("mod.author", false))
+      .put("author", new Property("mod.author", true))
       .put("uploader.login", new Property("mod.uploader.login", false))
-      .put("latestVersion.createTime", new Property("mod.uploadedDateTime", false))
-      .put("latestVersion.updateTime", new Property("mod.updatedDateTime", false))
+      .put("latestVersion.createTime", new Property("mod.uploadedDateTime", true))
+      .put("latestVersion.updateTime", new Property("mod.updatedDateTime", true))
       .put("latestVersion.description", new Property("mod.description", false))
       .put("latestVersion.id", new Property("mod.id", false))
       .put("latestVersion.uid", new Property("mod.uid", false))

--- a/src/main/java/com/faforever/client/vault/VaultEntityController.java
+++ b/src/main/java/com/faforever/client/vault/VaultEntityController.java
@@ -131,9 +131,6 @@ public abstract class VaultEntityController<T> extends AbstractViewController<No
 
     initSearchController();
 
-    BooleanBinding inSearchableState = Bindings.createBooleanBinding(() -> state.get() != State.SEARCHING, state);
-    searchController.setSearchButtonDisabledCondition(inSearchableState);
-
     pagination.currentPageIndexProperty().addListener((observable, oldValue, newValue) -> {
       if (!oldValue.equals(newValue)) {
         SearchConfig searchConfig = searchController.getLastSearchConfig();

--- a/src/main/java/com/faforever/client/vault/VaultEntityController.java
+++ b/src/main/java/com/faforever/client/vault/VaultEntityController.java
@@ -131,6 +131,9 @@ public abstract class VaultEntityController<T> extends AbstractViewController<No
 
     initSearchController();
 
+    BooleanBinding inSearchableState = Bindings.createBooleanBinding(() -> state.get() != State.SEARCHING, state);
+    searchController.setSearchButtonDisabledCondition(inSearchableState);
+
     pagination.currentPageIndexProperty().addListener((observable, oldValue, newValue) -> {
       if (!oldValue.equals(newValue)) {
         SearchConfig searchConfig = searchController.getLastSearchConfig();

--- a/src/main/java/com/faforever/client/vault/search/SearchController.java
+++ b/src/main/java/com/faforever/client/vault/search/SearchController.java
@@ -429,6 +429,10 @@ public class SearchController implements Controller<Pane> {
     initialLogicalNodeController.specificationController.setRootType(rootType);
   }
 
+  public void setSearchButtonDisabledCondition(BooleanBinding inSearchableState) {
+    searchButton.disableProperty().bind(inSearchableState.not());
+  }
+
   public void setOnlyShowLastYearCheckBoxVisible(boolean visible) {
     showLastYearCheckBox = visible;
     onlyShowLastYearCheckBox.setSelected(visible);

--- a/src/main/java/com/faforever/client/vault/search/SearchController.java
+++ b/src/main/java/com/faforever/client/vault/search/SearchController.java
@@ -429,17 +429,6 @@ public class SearchController implements Controller<Pane> {
     initialLogicalNodeController.specificationController.setRootType(rootType);
   }
 
-  public void setSearchButtonDisabledCondition(BooleanBinding inSearchableState) {
-    Optional<Property> firstSortProperty = sortPropertyComboBox.getItems().stream().findFirst();
-    BooleanBinding isSortChanged = firstSortProperty.isEmpty()
-        ? Bindings.selectBoolean(false)
-        : sortPropertyComboBox.valueProperty().isNotEqualTo(firstSortProperty.get());
-    searchButton.disableProperty().bind(
-        queryTextField.textProperty().isEmpty().and(isSortChanged.not())
-        .or(inSearchableState.not())
-    );
-  }
-
   public void setOnlyShowLastYearCheckBoxVisible(boolean visible) {
     showLastYearCheckBox = visible;
     onlyShowLastYearCheckBox.setSelected(visible);

--- a/src/main/java/com/faforever/client/vault/search/SearchController.java
+++ b/src/main/java/com/faforever/client/vault/search/SearchController.java
@@ -20,6 +20,7 @@ import com.github.rutledgepaulv.qbuilders.builders.QBuilder;
 import com.github.rutledgepaulv.qbuilders.conditions.Condition;
 import com.github.rutledgepaulv.qbuilders.visitors.RSQLVisitor;
 import javafx.beans.InvalidationListener;
+import javafx.beans.binding.Bindings;
 import javafx.beans.binding.BooleanBinding;
 import javafx.beans.property.ObjectProperty;
 import javafx.collections.ObservableMap;
@@ -429,7 +430,14 @@ public class SearchController implements Controller<Pane> {
   }
 
   public void setSearchButtonDisabledCondition(BooleanBinding inSearchableState) {
-    searchButton.disableProperty().bind(queryTextField.textProperty().isEmpty().or(inSearchableState.not()));
+    Optional<Property> firstSortProperty = sortPropertyComboBox.getItems().stream().findFirst();
+    BooleanBinding isSortChanged = firstSortProperty.isEmpty()
+        ? Bindings.selectBoolean(false)
+        : sortPropertyComboBox.valueProperty().isNotEqualTo(firstSortProperty.get());
+    searchButton.disableProperty().bind(
+        queryTextField.textProperty().isEmpty().and(isSortChanged.not())
+        .or(inSearchableState.not())
+    );
   }
 
   public void setOnlyShowLastYearCheckBoxVisible(boolean visible) {


### PR DESCRIPTION
Currently you can only sort by name in mod and map search. This change enables sorting by additional properties. 

In making this change I noticed that if I just come to the map vault and change the sort by then the search button is still disabled, but if I want to search all maps but with a custom sort by then I'd like the search button enabled. This change will also enable the search button when it's not the first (or default) search option.