### PR TITLE
Send division name to game on start for matchmaker games

### DIFF
--- a/src/main/java/com/faforever/client/fa/ForgedAllianceService.java
+++ b/src/main/java/com/faforever/client/fa/ForgedAllianceService.java
@@ -74,6 +74,7 @@ public class ForgedAllianceService {
         .mean(mean)
         .deviation(deviation)
         .division(gameParameters.getDivision())
+        .subdivision(gameParameters.getSubdivision())
         .additionalArgs(gameParameters.getAdditionalArgs())
         .logFile(loggingService.getNewGameLogFile(uid))
         .localGpgPort(gameParameters.getLocalGpgPort())

--- a/src/main/java/com/faforever/client/fa/GameParameters.java
+++ b/src/main/java/com/faforever/client/fa/GameParameters.java
@@ -1,0 +1,29 @@
+package com.faforever.client.fa;
+
+import com.faforever.commons.lobby.Faction;
+import com.faforever.commons.lobby.GameType;
+import lombok.Data;
+
+import java.util.List;
+import java.util.Map;
+
+@Data
+public class GameParameters {
+  private Integer uid;
+  private String name;
+  private String featuredMod;
+  private GameType gameType;
+  private String leaderboard;
+  private List<String> additionalArgs;
+  private String mapName;
+  private Integer expectedPlayers;
+  private Integer mapPosition;
+  private Map<String, String> gameOptions;
+  private Integer team;
+  private Faction faction;
+
+  private String division;
+  private Integer localGpgPort;
+  private Integer localReplayPort;
+  private boolean rehost;
+}

--- a/src/main/java/com/faforever/client/fa/GameParameters.java
+++ b/src/main/java/com/faforever/client/fa/GameParameters.java
@@ -23,6 +23,7 @@ public class GameParameters {
   private Faction faction;
 
   private String division;
+  private String subdivision;
   private Integer localGpgPort;
   private Integer localReplayPort;
   private boolean rehost;

--- a/src/main/java/com/faforever/client/fa/LaunchCommandBuilder.java
+++ b/src/main/java/com/faforever/client/fa/LaunchCommandBuilder.java
@@ -28,6 +28,7 @@ public class LaunchCommandBuilder {
   private Path debuggerExecutable;
   private Float mean;
   private Float deviation;
+  private String division;
   private String country;
   private String clan;
   private String username;
@@ -95,6 +96,11 @@ public class LaunchCommandBuilder {
 
   public LaunchCommandBuilder deviation(Float deviation) {
     this.deviation = deviation;
+    return this;
+  }
+
+  public LaunchCommandBuilder division(String division) {
+    this.division = division;
     return this;
   }
 
@@ -229,6 +235,11 @@ public class LaunchCommandBuilder {
     if (deviation != null) {
       command.add("/deviation");
       command.add(String.valueOf(deviation));
+    }
+
+    if (division != null) {
+      command.add("/division");
+      command.add(division);
     }
 
     if (replayFile != null) {

--- a/src/main/java/com/faforever/client/fa/LaunchCommandBuilder.java
+++ b/src/main/java/com/faforever/client/fa/LaunchCommandBuilder.java
@@ -29,6 +29,7 @@ public class LaunchCommandBuilder {
   private Float mean;
   private Float deviation;
   private String division;
+  private String subdivision;
   private String country;
   private String clan;
   private String username;
@@ -101,6 +102,11 @@ public class LaunchCommandBuilder {
 
   public LaunchCommandBuilder division(String division) {
     this.division = division;
+    return this;
+  }
+
+  public LaunchCommandBuilder subdivision(String subdivision) {
+    this.subdivision = subdivision;
     return this;
   }
 
@@ -240,6 +246,11 @@ public class LaunchCommandBuilder {
     if (division != null) {
       command.add("/division");
       command.add(division);
+    }
+
+    if (StringUtils.hasText(subdivision)) {
+      command.add("/subdivision");
+      command.add(subdivision);
     }
 
     if (replayFile != null) {

--- a/src/main/java/com/faforever/client/fa/LaunchCommandBuilder.java
+++ b/src/main/java/com/faforever/client/fa/LaunchCommandBuilder.java
@@ -3,8 +3,8 @@ package com.faforever.client.fa;
 import com.faforever.client.preferences.ForgedAlliancePrefs;
 import com.faforever.commons.lobby.Faction;
 import com.google.common.base.Strings;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.util.Assert;
-import org.springframework.util.StringUtils;
 
 import java.net.Inet4Address;
 import java.net.URI;
@@ -248,7 +248,7 @@ public class LaunchCommandBuilder {
       command.add(division);
     }
 
-    if (StringUtils.hasText(subdivision)) {
+    if (StringUtils.isNotBlank(subdivision)) {
       command.add("/subdivision");
       command.add(subdivision);
     }
@@ -271,7 +271,7 @@ public class LaunchCommandBuilder {
       command.add(country);
     }
 
-    if (StringUtils.hasText(clan)) {
+    if (StringUtils.isNotBlank(clan)) {
       command.add("/clan");
       command.add(clan);
     }
@@ -305,7 +305,7 @@ public class LaunchCommandBuilder {
       command.add(String.valueOf(mapPosition));
     }
 
-    if (StringUtils.hasText(map)) {
+    if (StringUtils.isNotBlank(map)) {
       command.add("/map");
       command.add(map);
     }

--- a/src/main/java/com/faforever/client/leaderboard/LeaderboardService.java
+++ b/src/main/java/com/faforever/client/leaderboard/LeaderboardService.java
@@ -179,6 +179,13 @@ public class LeaderboardService {
             .findFirst());
   }
 
+  public CompletableFuture<Optional<LeagueEntryBean>> getActiveLeagueEntryForPlayer(PlayerBean player, String leaderboardName) {
+    return getActiveLeagueEntriesForPlayer(player)
+        .thenApply(leagueEntries -> leagueEntries.stream()
+            .filter(leagueEntry -> Objects.equals(leagueEntry.getLeagueSeason().getLeaderboard().getTechnicalName(), leaderboardName))
+            .findFirst());
+  }
+
   @Cacheable(value = CacheNames.LEAGUE_ENTRIES, sync = true)
   public CompletableFuture<List<LeagueEntryBean>> getActiveLeagueEntriesForPlayer(PlayerBean player) {
     ElideNavigatorOnCollection<LeagueSeasonScore> navigator = ElideNavigator.of(LeagueSeasonScore.class).collection()

--- a/src/main/java/com/faforever/client/mapstruct/GameMapper.java
+++ b/src/main/java/com/faforever/client/mapstruct/GameMapper.java
@@ -1,8 +1,10 @@
 package com.faforever.client.mapstruct;
 
 import com.faforever.client.domain.GameBean;
+import com.faforever.client.fa.GameParameters;
 import com.faforever.client.util.TimeUtil;
 import com.faforever.commons.lobby.GameInfo;
+import com.faforever.commons.lobby.GameLaunchResponse;
 import org.mapstruct.CollectionMappingStrategy;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -15,6 +17,9 @@ import java.util.Map;
 @Mapper(collectionMappingStrategy = CollectionMappingStrategy.TARGET_IMMUTABLE, config = MapperConfiguration.class)
 public interface GameMapper {
   String OBSERVERS_TEAM = "-1";
+
+  @Mapping(target = "additionalArgs", source = "args")
+  GameParameters map(GameLaunchResponse dto);
 
   @Mapping(target = "id", source = "uid")
   @Mapping(target = "numPlayers", expression = "java(getNumPlayers(dto))")

--- a/src/main/java/com/faforever/client/player/PlayerInfoWindowController.java
+++ b/src/main/java/com/faforever/client/player/PlayerInfoWindowController.java
@@ -255,7 +255,7 @@ public class PlayerInfoWindowController implements Controller<Node> {
             controller.setLeaderboardInfo(player, leaderboard);
 
             if (leagueSeasonBeans.stream().anyMatch(season -> Objects.equals(season.getLeaderboard(), leaderboard))) {
-              leaderboardService.getActiveLeagueEntryForPlayer(player, leaderboard).thenAccept(leagueEntry ->
+              leaderboardService.getActiveLeagueEntryForPlayer(player, leaderboard.getTechnicalName()).thenAccept(leagueEntry ->
                   leagueEntry.ifPresentOrElse(controller::setLeagueInfo, controller::setUnlistedLeague));
             }
 

--- a/src/test/java/com/faforever/client/fa/ForgedAllianceServiceTest.java
+++ b/src/test/java/com/faforever/client/fa/ForgedAllianceServiceTest.java
@@ -1,6 +1,5 @@
 package com.faforever.client.fa;
 
-import com.faforever.client.builders.GameLaunchMessageBuilder;
 import com.faforever.client.builders.PlayerBeanBuilder;
 import com.faforever.client.builders.PreferencesBuilder;
 import com.faforever.client.logging.LoggingService;
@@ -8,7 +7,6 @@ import com.faforever.client.player.PlayerService;
 import com.faforever.client.preferences.Preferences;
 import com.faforever.client.preferences.PreferencesService;
 import com.faforever.client.test.ServiceTest;
-import com.faforever.commons.lobby.GameLaunchResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -55,22 +53,15 @@ public class ForgedAllianceServiceTest extends ServiceTest {
 
   @Test
   public void testStartGameOnline() throws Exception {
-    GameLaunchResponse gameLaunchMessage = GameLaunchMessageBuilder.create().defaultValues().get();
-    IOException throwable = assertThrows(IOException.class, () -> instance.startGameOnline(gameLaunchMessage, 0, 0, false));
+    GameParameters gameParameters = new GameParameters();
+    gameParameters.setUid(1);
+    gameParameters.setLocalGpgPort(0);
+    gameParameters.setLocalReplayPort(0);
+    IOException throwable = assertThrows(IOException.class, () -> instance.startGameOnline(gameParameters));
     assertThat(throwable.getCause().getMessage(), containsString("error=2"));
 
     verify(playerService).getCurrentPlayer();
-    verify(loggingService).getNewGameLogFile(gameLaunchMessage.getUid());
-  }
-
-  @Test
-  public void testStartGameOnlineWithDivision() throws Exception {
-    GameLaunchResponse gameLaunchMessage = GameLaunchMessageBuilder.create().defaultValues().get();
-    IOException throwable = assertThrows(IOException.class, () -> instance.startGameOnlineWithDivision(gameLaunchMessage, 0, 0, false, "unlisted"));
-    assertThat(throwable.getCause().getMessage(), containsString("error=2"));
-
-    verify(playerService).getCurrentPlayer();
-    verify(loggingService).getNewGameLogFile(gameLaunchMessage.getUid());
+    verify(loggingService).getNewGameLogFile(gameParameters.getUid());
   }
 
   @Test

--- a/src/test/java/com/faforever/client/fa/ForgedAllianceServiceTest.java
+++ b/src/test/java/com/faforever/client/fa/ForgedAllianceServiceTest.java
@@ -64,6 +64,16 @@ public class ForgedAllianceServiceTest extends ServiceTest {
   }
 
   @Test
+  public void testStartGameOnlineWithDivision() throws Exception {
+    GameLaunchResponse gameLaunchMessage = GameLaunchMessageBuilder.create().defaultValues().get();
+    IOException throwable = assertThrows(IOException.class, () -> instance.startGameOnlineWithDivision(gameLaunchMessage, 0, 0, false, "unlisted"));
+    assertThat(throwable.getCause().getMessage(), containsString("error=2"));
+
+    verify(playerService).getCurrentPlayer();
+    verify(loggingService).getNewGameLogFile(gameLaunchMessage.getUid());
+  }
+
+  @Test
   public void testStartReplay() throws Exception {
     IOException throwable = assertThrows(IOException.class, () -> instance.startReplay(Path.of("."), 0));
     assertThat(throwable.getCause().getMessage(), containsString("error=2"));

--- a/src/test/java/com/faforever/client/fa/LaunchCommandBuilderTest.java
+++ b/src/test/java/com/faforever/client/fa/LaunchCommandBuilderTest.java
@@ -59,6 +59,11 @@ public class LaunchCommandBuilderTest extends ServiceTest {
   }
 
   @Test
+  public void testSubdivisionNullAllowed() throws Exception {
+    assertDoesNotThrow(() -> defaultBuilder().subdivision(null).build());
+  }
+
+  @Test
   public void testCountryNullAllowed() throws Exception {
     assertDoesNotThrow(() -> defaultBuilder().country(null).build());
   }
@@ -202,13 +207,26 @@ public class LaunchCommandBuilderTest extends ServiceTest {
   @Test
   public void testDivision() throws Exception {
     assertThat(
-        defaultBuilder().division("Gold II").build(),
+        defaultBuilder().division("Gold").build(),
         contains(
             Path.of("test.exe").toAbsolutePath().toString(),
             "/init", "init.lua",
             "/nobugreport",
             "/log", Path.of("preferences.log").toAbsolutePath().toString(),
-            "/division", "Gold II"
+            "/division", "Gold"
+        ));
+  }
+
+  @Test
+  public void testSubdivision() throws Exception {
+    assertThat(
+        defaultBuilder().subdivision("II").build(),
+        contains(
+            Path.of("test.exe").toAbsolutePath().toString(),
+            "/init", "init.lua",
+            "/nobugreport",
+            "/log", Path.of("preferences.log").toAbsolutePath().toString(),
+            "/subdivision", "II"
         ));
   }
 

--- a/src/test/java/com/faforever/client/fa/LaunchCommandBuilderTest.java
+++ b/src/test/java/com/faforever/client/fa/LaunchCommandBuilderTest.java
@@ -54,6 +54,11 @@ public class LaunchCommandBuilderTest extends ServiceTest {
   }
 
   @Test
+  public void testDivisionNullAllowed() throws Exception {
+    assertDoesNotThrow(() -> defaultBuilder().division(null).build());
+  }
+
+  @Test
   public void testCountryNullAllowed() throws Exception {
     assertDoesNotThrow(() -> defaultBuilder().country(null).build());
   }
@@ -195,7 +200,20 @@ public class LaunchCommandBuilderTest extends ServiceTest {
   }
 
   @Test
-  public void testCountryPort() throws Exception {
+  public void testDivision() throws Exception {
+    assertThat(
+        defaultBuilder().division("Gold II").build(),
+        contains(
+            Path.of("test.exe").toAbsolutePath().toString(),
+            "/init", "init.lua",
+            "/nobugreport",
+            "/log", Path.of("preferences.log").toAbsolutePath().toString(),
+            "/division", "Gold II"
+        ));
+  }
+
+  @Test
+  public void testCountry() throws Exception {
     assertThat(
         defaultBuilder().country("USA").build(),
         contains(

--- a/src/test/java/com/faforever/client/game/GameServiceTest.java
+++ b/src/test/java/com/faforever/client/game/GameServiceTest.java
@@ -567,7 +567,8 @@ public class GameServiceTest extends ServiceTest {
 
     FeaturedModBean featuredMod = FeaturedModBeanBuilder.create().defaultValues().get();
     GameParameters gameParameters = gameMapper.map(gameLaunchMessage);
-    gameParameters.setDivision("test_name I");
+    gameParameters.setDivision("test_name");
+    gameParameters.setSubdivision("I");
 
     mockStartGameProcess(gameParameters);
     LeagueEntryBean leagueEntry = LeagueEntryBeanBuilder.create().defaultValues().get();

--- a/src/test/java/com/faforever/client/game/GameServiceTest.java
+++ b/src/test/java/com/faforever/client/game/GameServiceTest.java
@@ -603,6 +603,7 @@ public class GameServiceTest extends ServiceTest {
 
     FeaturedModBean featuredMod = FeaturedModBeanBuilder.create().defaultValues().get();
     GameParameters gameParameters = gameMapper.map(gameLaunchMessage);
+    gameParameters.setDivision("unlisted");
 
     mockStartGameProcess(gameParameters);
     when(leaderboardService.getActiveLeagueEntryForPlayer(junitPlayer, LADDER_1v1_RATING_TYPE)).thenReturn(completedFuture(Optional.empty()));
@@ -791,7 +792,9 @@ public class GameServiceTest extends ServiceTest {
     gameOptions.put("Share", "ShareUntilDeath");
     gameOptions.put("UnitCap", "500");
     GameLaunchResponse gameLaunchMessage = GameLaunchMessageBuilder.create().defaultValues().team(1).expectedPlayers(4).mapPosition(3).gameOptions(gameOptions).get();
-    mockStartGameProcess(gameMapper.map(gameLaunchMessage));
+    GameParameters gameParameters = gameMapper.map(gameLaunchMessage);
+    gameParameters.setDivision("unlisted");
+    mockStartGameProcess(gameParameters);
     when(leaderboardService.getActiveLeagueEntryForPlayer(junitPlayer, "global")).thenReturn(completedFuture(Optional.empty()));
     when(gameUpdater.update(any(), any(), any(), any())).thenReturn(completedFuture(null));
     when(mapService.download(gameLaunchMessage.getMapName())).thenReturn(completedFuture(null));

--- a/src/test/java/com/faforever/client/leaderboard/LeaderboardServiceTest.java
+++ b/src/test/java/com/faforever/client/leaderboard/LeaderboardServiceTest.java
@@ -239,6 +239,24 @@ public class LeaderboardServiceTest extends ServiceTest {
   }
 
   @Test
+  public void testGetActiveLeagueEntryForPlayerWithLeaderboardName() {
+    LeaderboardBean leaderboard = LeaderboardBeanBuilder.create().defaultValues().id(2).technicalName("ladder").get();
+    LeagueSeasonBean season = LeagueSeasonBeanBuilder.create().defaultValues().leaderboard(leaderboard).get();
+    LeagueEntryBean leagueEntryBean1 = LeagueEntryBeanBuilder.create().defaultValues().get();
+    LeagueEntryBean leagueEntryBean2 = LeagueEntryBeanBuilder.create().defaultValues().leagueSeason(season).get();
+
+    Flux<ElideEntity> resultFlux = Flux.just(
+        leaderboardMapper.map(leagueEntryBean1, new CycleAvoidingMappingContext()),
+        leaderboardMapper.map(leagueEntryBean2, new CycleAvoidingMappingContext()));
+    when(fafApiAccessor.getMany(any())).thenReturn(resultFlux);
+
+    Optional<LeagueEntryBean> result = instance.getActiveLeagueEntryForPlayer(player, "ladder").toCompletableFuture().join();
+
+    verify(fafApiAccessor).getMany(argThat(ElideMatchers.hasFilter(qBuilder().intNum("loginId").eq(player.getId()))));
+    Assertions.assertEquals(leagueEntryBean2, result.orElse(null));
+  }
+
+  @Test
   public void testGetActiveLeagueEntriesForPlayer() {
     LeagueEntryBean leagueEntryBean1 = LeagueEntryBeanBuilder.create().defaultValues().get();
     LeagueEntryBean leagueEntryBean2 = LeagueEntryBeanBuilder.create().defaultValues().subdivision(null).get();

--- a/src/test/java/com/faforever/client/leaderboard/LeaderboardServiceTest.java
+++ b/src/test/java/com/faforever/client/leaderboard/LeaderboardServiceTest.java
@@ -222,24 +222,6 @@ public class LeaderboardServiceTest extends ServiceTest {
 
   @Test
   public void testGetActiveLeagueEntryForPlayer() {
-    LeaderboardBean leaderboard = LeaderboardBeanBuilder.create().defaultValues().id(2).get();
-    LeagueSeasonBean season = LeagueSeasonBeanBuilder.create().defaultValues().leaderboard(leaderboard).get();
-    LeagueEntryBean leagueEntryBean1 = LeagueEntryBeanBuilder.create().defaultValues().get();
-    LeagueEntryBean leagueEntryBean2 = LeagueEntryBeanBuilder.create().defaultValues().leagueSeason(season).get();
-
-    Flux<ElideEntity> resultFlux = Flux.just(
-        leaderboardMapper.map(leagueEntryBean1, new CycleAvoidingMappingContext()),
-        leaderboardMapper.map(leagueEntryBean2, new CycleAvoidingMappingContext()));
-    when(fafApiAccessor.getMany(any())).thenReturn(resultFlux);
-
-    Optional<LeagueEntryBean> result = instance.getActiveLeagueEntryForPlayer(player, leaderboard).toCompletableFuture().join();
-
-    verify(fafApiAccessor).getMany(argThat(ElideMatchers.hasFilter(qBuilder().intNum("loginId").eq(player.getId()))));
-    Assertions.assertEquals(leagueEntryBean2, result.orElse(null));
-  }
-
-  @Test
-  public void testGetActiveLeagueEntryForPlayerWithLeaderboardName() {
     LeaderboardBean leaderboard = LeaderboardBeanBuilder.create().defaultValues().id(2).technicalName("ladder").get();
     LeagueSeasonBean season = LeagueSeasonBeanBuilder.create().defaultValues().leaderboard(leaderboard).get();
     LeagueEntryBean leagueEntryBean1 = LeagueEntryBeanBuilder.create().defaultValues().get();
@@ -252,7 +234,8 @@ public class LeaderboardServiceTest extends ServiceTest {
 
     Optional<LeagueEntryBean> result = instance.getActiveLeagueEntryForPlayer(player, "ladder").toCompletableFuture().join();
 
-    verify(fafApiAccessor).getMany(argThat(ElideMatchers.hasFilter(qBuilder().intNum("loginId").eq(player.getId()))));
+    verify(fafApiAccessor).getMany(argThat(ElideMatchers.hasFilter(qBuilder().intNum("loginId").eq(player.getId())
+        .and().string("leagueSeason.leaderboard.technicalName").eq(leaderboard.getTechnicalName()))));
     Assertions.assertEquals(leagueEntryBean2, result.orElse(null));
   }
 

--- a/src/test/java/com/faforever/client/player/PlayerInfoWindowControllerTest.java
+++ b/src/test/java/com/faforever/client/player/PlayerInfoWindowControllerTest.java
@@ -147,7 +147,7 @@ public class PlayerInfoWindowControllerTest extends UITest {
     when(leaderboardService.getActiveSeasons()).thenReturn(CompletableFuture.completedFuture(List.of(
         LeagueSeasonBeanBuilder.create().defaultValues().leaderboard(leaderboard).get()
     )));
-    when(leaderboardService.getActiveLeagueEntryForPlayer(player, leaderboard)).thenReturn(
+    when(leaderboardService.getActiveLeagueEntryForPlayer(player, leaderboard.getTechnicalName())).thenReturn(
         CompletableFuture.completedFuture(Optional.empty()));
     when(userLeaderboardInfoController.getRoot()).thenReturn(new VBox());
     final LeaderboardRatingBean leaderboardRating = LeaderboardRatingBeanBuilder.create()


### PR DESCRIPTION
When starting a matchmaker game this sends the name of the division the player has for this leaderboard to the game.
This enables us to display the division instead of rating in the game score board, bringing us closer to establishing the league system as the default skill representation.