### PR TITLE
Fix ICE adapter debug window on Linux

### DIFF
--- a/src/main/java/com/faforever/client/fa/relay/ice/IceAdapterImpl.java
+++ b/src/main/java/com/faforever/client/fa/relay/ice/IceAdapterImpl.java
@@ -12,6 +12,7 @@ import com.faforever.client.os.OsUtils;
 import com.faforever.client.player.PlayerService;
 import com.faforever.client.preferences.PreferencesService;
 import com.faforever.client.remote.FafServerAccessor;
+import com.faforever.client.util.JavaUtil;
 import com.faforever.commons.api.dto.CoturnServer;
 import com.faforever.commons.lobby.ConnectToPeerGpgCommand;
 import com.faforever.commons.lobby.DisconnectFromPeerGpgCommand;
@@ -191,15 +192,15 @@ public class IceAdapterImpl implements IceAdapter, InitializingBean, DisposableB
   List<String> buildCommand(Path workDirectory, int adapterPort, int gpgPort) {
     PlayerBean currentPlayer = playerService.getCurrentPlayer();
 
-    String classpath = getBinaryName(workDirectory);
-    if (preferencesService.getPreferences().getForgedAlliance().isShowIceAdapterDebugWindow()) {
-      classpath += ";" + getJavaFXClassPathJars();
-    }
+    String classpath = getBinaryName(workDirectory) + JavaUtil.CLASSPATH_SEPARATOR + getJavaFXClassPathJars();
 
     List<String> cmd = Lists.newArrayList(
-        Path.of(System.getProperty("java.home")).resolve("bin").resolve(org.bridj.Platform.isWindows() ? "java.exe" : "java").toAbsolutePath().toString(),
-        "-cp",
-        classpath,
+        Path.of(System.getProperty("java.home"))
+            .resolve("bin")
+            .resolve(org.bridj.Platform.isWindows() ? "java.exe" : "java")
+            .toAbsolutePath()
+            .toString(),
+        "-cp", classpath,
         "com.faforever.iceadapter.IceAdapter",
         "--id", String.valueOf(currentPlayer.getId()),
         "--login", currentPlayer.getUsername(),
@@ -220,9 +221,9 @@ public class IceAdapterImpl implements IceAdapter, InitializingBean, DisposableB
   }
 
   private String getJavaFXClassPathJars() {
-    String classPathOfClient = System.getProperty("java.class.path");
-    List<String> split = List.of(classPathOfClient.split(";"));
-    return split.stream().filter(s -> s.contains("javafx-")).collect(Collectors.joining(";"));
+    return JavaUtil.CLASS_PATH_LIST.stream()
+        .filter(s -> s.contains("javafx-"))
+        .collect(Collectors.joining(JavaUtil.CLASSPATH_SEPARATOR));
   }
 
   private String getBinaryName(Path workDirectory) {

--- a/src/main/java/com/faforever/client/util/JavaUtil.java
+++ b/src/main/java/com/faforever/client/util/JavaUtil.java
@@ -1,0 +1,13 @@
+package com.faforever.client.util;
+
+import java.util.List;
+
+public class JavaUtil {
+  public static final String CLASSPATH_SEPARATOR = System.getProperty("path.separator");
+  public static final List<String> CLASS_PATH_LIST = getClasspath();
+
+  private static List<String> getClasspath() {
+    String classPath = System.getProperty("java.class.path");
+    return List.of(classPath.split(CLASSPATH_SEPARATOR));
+  }
+}

--- a/src/main/resources/theme/settings/settings.fxml
+++ b/src/main/resources/theme/settings/settings.fxml
@@ -875,11 +875,6 @@
                                                 <Label contentDisplay="RIGHT" maxWidth="1.7976931348623157E308"
                                                        styleClass="setting-title"
                                                        text="%settings.fa.iceDebugWindow">
-                                                    <graphic>
-                                                        <Label styleClass="button-mini-label"
-                                                               text="%settings.experimental"
-                                                               GridPane.columnIndex="1"/>
-                                                    </graphic>
                                                 </Label>
                                                 <CheckBox fx:id="showIceAdapterDebugWindowToggle"
                                                           contentDisplay="GRAPHIC_ONLY"


### PR DESCRIPTION
Also makes the ICE adapter tray icon work if the user did not activate the feature.
Also promotes the feature to show the debug window to non-experimental.