### PR TITLE
Add support for disabling leagues

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -299,7 +299,7 @@ dependencies {
   implementation("org.springframework:spring-websocket")
 
 
-  def commonsVersion = "7caebc1e96b498a0cbc53851b049c82f2def78cb"
+  def commonsVersion = "9500f372a65c083802be505db0b4ffa43b7d48ef"
 
   implementation("com.github.FAForever.faf-java-commons:faf-commons-data:${commonsVersion}") {
             exclude module: 'guava'

--- a/src/main/java/com/faforever/client/domain/LeagueBean.java
+++ b/src/main/java/com/faforever/client/domain/LeagueBean.java
@@ -1,6 +1,8 @@
 package com.faforever.client.domain;
 
+import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
@@ -16,6 +18,7 @@ import java.net.URL;
 public class LeagueBean extends AbstractEntityBean<LeagueBean> {
   @ToString.Include
   StringProperty technicalName = new SimpleStringProperty();
+  BooleanProperty enabled = new SimpleBooleanProperty();
   StringProperty nameKey = new SimpleStringProperty();
   StringProperty descriptionKey = new SimpleStringProperty();
   ObjectProperty<URL> imageUrl = new SimpleObjectProperty<>();
@@ -56,5 +59,17 @@ public class LeagueBean extends AbstractEntityBean<LeagueBean> {
 
   public StringProperty technicalNameProperty() {
     return technicalName;
+  }
+
+  public boolean getEnabled() {
+    return enabled.get();
+  }
+
+  public void setEnabled(boolean enabled) {
+    this.enabled.set(enabled);
+  }
+
+  public BooleanProperty enabledProperty() {
+    return enabled;
   }
 }

--- a/src/main/java/com/faforever/client/leaderboard/LeaderboardService.java
+++ b/src/main/java/com/faforever/client/leaderboard/LeaderboardService.java
@@ -78,7 +78,8 @@ public class LeaderboardService {
 
   @Cacheable(value = CacheNames.LEAGUE, sync = true)
   public CompletableFuture<List<LeagueBean>> getLeagues() {
-    ElideNavigatorOnCollection<League> navigator = ElideNavigator.of(League.class).collection();
+    ElideNavigatorOnCollection<League> navigator = ElideNavigator.of(League.class).collection()
+        .setFilter(qBuilder().bool("enabled").isTrue());
     return fafApiAccessor.getMany(navigator)
         .map(dto -> leaderboardMapper.map(dto, new CycleAvoidingMappingContext()))
         .collectList()

--- a/src/test/java/com/faforever/client/builders/LeagueBeanBuilder.java
+++ b/src/test/java/com/faforever/client/builders/LeagueBeanBuilder.java
@@ -13,6 +13,7 @@ public class LeagueBeanBuilder {
 
   public LeagueBeanBuilder defaultValues() {
     technicalName("test");
+    enabled(true);
     nameKey("test_description");
     descriptionKey("test_name");
     id(0);
@@ -21,6 +22,11 @@ public class LeagueBeanBuilder {
 
   public LeagueBeanBuilder technicalName(String technicalName) {
     leagueBean.setTechnicalName(technicalName);
+    return this;
+  }
+
+  public LeagueBeanBuilder enabled(boolean enabled) {
+    leagueBean.setEnabled(enabled);
     return this;
   }
 

--- a/src/test/java/com/faforever/client/leaderboard/LeaderboardServiceTest.java
+++ b/src/test/java/com/faforever/client/leaderboard/LeaderboardServiceTest.java
@@ -108,6 +108,7 @@ public class LeaderboardServiceTest extends ServiceTest {
     List<LeagueBean> results = instance.getLeagues().toCompletableFuture().join();
 
     verify(fafApiAccessor).getMany(any());
+    verify(fafApiAccessor).getMany(argThat(ElideMatchers.hasFilter(qBuilder().bool("enabled").isTrue())));
     assertThat(results, hasSize(1));
     assertThat(results.get(0), is(leagueBean));
   }


### PR DESCRIPTION
This removes the disabled 4v4 no share league from the leaderboard in the client.
At the moment this breaks the loading of the leaderboard. It will only become functional when the new api version is deployed that exposes the "enabled" field. So be careful with merging.