### PR TITLE
Fix: Check APPDATA path for Cyrillic characters and show pop up warning #1333

### DIFF
--- a/src/main/java/com/faforever/client/FafClientApplication.java
+++ b/src/main/java/com/faforever/client/FafClientApplication.java
@@ -81,28 +81,23 @@ public class FafClientApplication extends Application {
 
     OperatingSystem operatingSystem = applicationContext.getBean(OperatingSystem.class);
 
-    try {
-      String preferencesDirectoryString = String.valueOf(operatingSystem.getPreferencesDirectory());
-      log.debug("Current preferences directory " + preferencesDirectoryString);
-      if (preferencesDirectoryString.matches(".*[а-яА-ЯёЁ].*")) {
-        I18n i18n = applicationContext.getBean(I18n.class);
-        String warningMessage = i18n.get("home.directory.warning.cyrillic");
-        String closeText = i18n.get("close");
-        ButtonType closeButton = new ButtonType(closeText, ButtonData.CANCEL_CLOSE);
-        CountDownLatch waitForUserInput = new CountDownLatch(1);
-
-        JavaFxUtil.runLater(() -> {
-          Alert alert = new Alert(AlertType.WARNING, warningMessage, closeButton);
-          Optional<ButtonType> buttonType = alert.showAndWait();
-          if (buttonType.filter(button -> button == closeButton).isPresent()) {
-            System.exit(EXIT_STATUS_CYRILLIC_CHARACTER_PREFERENCES_DIRECTORY);
-          }
-          waitForUserInput.countDown();
-        });
-        waitForUserInput.await();
-      }
-    } catch (InterruptedException e) {
-      e.printStackTrace();
+    String preferencesDirectoryString = String.valueOf(operatingSystem.getPreferencesDirectory());
+    log.debug("Current preferences directory " + preferencesDirectoryString);
+    if (preferencesDirectoryString.matches(".*[а-яА-ЯёЁ].*")) {
+      I18n i18n = applicationContext.getBean(I18n.class);
+      String warningMessage = i18n.get("home.directory.warning.cyrillic");
+      String closeText = i18n.get("close");
+      ButtonType closeButton = new ButtonType(closeText, ButtonData.CANCEL_CLOSE);
+      CountDownLatch waitForUserInput = new CountDownLatch(1);
+      JavaFxUtil.runLater(() -> {
+        Alert alert = new Alert(AlertType.WARNING, warningMessage, closeButton);
+        Optional<ButtonType> buttonType = alert.showAndWait();
+        if (buttonType.filter(button -> button == closeButton).isPresent()) {
+          System.exit(EXIT_STATUS_CYRILLIC_CHARACTER_PREFERENCES_DIRECTORY);
+        }
+        waitForUserInput.countDown();
+      });
+      waitForUserInput.await();
     }
 
     if (operatingSystem.runsAsAdmin()) {

--- a/src/main/java/com/faforever/client/FafClientApplication.java
+++ b/src/main/java/com/faforever/client/FafClientApplication.java
@@ -21,6 +21,7 @@ import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.scene.control.Alert;
 import javafx.scene.control.Alert.AlertType;
+import javafx.scene.control.ButtonBar.ButtonData;
 import javafx.scene.control.ButtonType;
 import javafx.scene.text.Font;
 import javafx.stage.Stage;
@@ -60,6 +61,7 @@ public class FafClientApplication extends Application {
   public static final String PROFILE_LINUX = "linux";
   public static final String PROFILE_MAC = "mac";
   public static final int EXIT_STATUS_RAN_AS_ADMIN = 3;
+  public static final int EXIT_STATUS_CYRILLIC_CHARACTER_PREFERENCES_DIRECTORY = 4;
 
   private ConfigurableApplicationContext applicationContext;
 
@@ -78,6 +80,31 @@ public class FafClientApplication extends Application {
         .run(getParameters().getRaw().toArray(new String[0]));
 
     OperatingSystem operatingSystem = applicationContext.getBean(OperatingSystem.class);
+
+    try {
+      String preferencesDirectoryString = String.valueOf(operatingSystem.getPreferencesDirectory());
+      log.debug("Current preferences directory " + preferencesDirectoryString);
+      if (preferencesDirectoryString.matches(".*[а-яА-ЯёЁ].*")) {
+        I18n i18n = applicationContext.getBean(I18n.class);
+        String warningMessage = i18n.get("home.directory.warning.cyrillic");
+        String closeText = i18n.get("close");
+        ButtonType closeButton = new ButtonType(closeText, ButtonData.CANCEL_CLOSE);
+        CountDownLatch waitForUserInput = new CountDownLatch(1);
+
+        JavaFxUtil.runLater(() -> {
+          Alert alert = new Alert(AlertType.WARNING, warningMessage, closeButton);
+          Optional<ButtonType> buttonType = alert.showAndWait();
+          if (buttonType.filter(button -> button == closeButton).isPresent()) {
+            System.exit(EXIT_STATUS_CYRILLIC_CHARACTER_PREFERENCES_DIRECTORY);
+          }
+          waitForUserInput.countDown();
+        });
+        waitForUserInput.await();
+      }
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    }
+
     if (operatingSystem.runsAsAdmin()) {
       CountDownLatch waitForUserInput = new CountDownLatch(1);
       JavaFxUtil.runLater(() -> {

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -1244,3 +1244,4 @@ hideSingleGames = Hide games with 1 player
 showGamesWithFriends = Show only games with friends
 showGeneratedMaps = Show only generated maps
 filteredOutItemsCount = {0} from {1} items are filtered out
+home.directory.warning.cyrillic = Warning: Cyrillic characters in the home directory path will cause problems. Please, avoid using them.

--- a/src/main/resources/i18n/messages_de.properties
+++ b/src/main/resources/i18n/messages_de.properties
@@ -1262,3 +1262,4 @@ chat.userContext.changeColor = Farbe ändern
 chat.sendFailed = Nachricht wurde nicht verschickt
 userInfo.ratingHistory.lastWeek = Letzte Woche
 userInfo.ratingHistory.lastDay = Gestern
+home.directory.warning.cyrillic = Warnung: Kyrillische Zeichen im Benutzerverzeichnis können Probleme verursachen. Bitte deren Verwendung vermeiden.

--- a/src/main/resources/i18n/messages_ru.properties
+++ b/src/main/resources/i18n/messages_ru.properties
@@ -1297,3 +1297,4 @@ replay.deleteNotification.heading = Удалить реплей\: {0}
 replay.deleteNotification.info = Это действие приведет к окончательному удалению реплея с жесткого диска.
 replay.couldNotDeleteLocal = Не удалось удалить локальный файл реплея
 login.browser.success.title = Успешный вход\n\n
+home.directory.warning.cyrillic = Предупреждение: Кириллические символы в пути к домашнему каталогу приведут к проблемам. Пожалуйста, избегайте их использования.

--- a/src/main/resources/i18n/messages_uk.properties
+++ b/src/main/resources/i18n/messages_uk.properties
@@ -867,3 +867,4 @@ settings.date.dmy = День/Місяць/РІк
 settings.chat.dateFormat = Формат Дати
 settings.chat.dateFormat.description = В якому форматі показувати дату в чаті.
 chat.error.noHashTag = Назва Каналу повинна починатися з \# (Спробуйте\#{0})
+home.directory.warning.cyrillic = Попередження: Кириличні символи у шляху до домашнього каталогу можуть спричинити проблеми. Будь ласка, не використовуйте їх.


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/101107758/214272471-b285a10a-81d7-4b31-adf5-802327cf8271.png)

After some reading material, JDK18 has a bug with Cyrillic letters, and it won't get fixed, needs >JDK 19 (related https://bugs.openjdk.org/browse/JDK-8017274)

18< JDK assumes "System locale and User locale are set to the same language" for

`org.bridj.Platform.isWindows()
`

---
Unfortunately, the error message in FAF client is a bit bland and confusing on the user end.

`ava.lang.UnsatisfiedLinkError: org.bridj.Platform.sizeOf_ptrdiff_t()I
	at org.bridj.Platform.sizeOf_ptrdiff_t(Native Method)
	at org.bridj.Platform.<clinit>(Platform.java:232)
	at com.faforever.client.preferences.PreferencesService.<clinit>(PreferencesService.java:78)
	at com.faforever.client.FafClientApplication.main(FafClientApplication.java:55)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
	at java.base/java.lang.reflect.Method.invoke(Unknown Source)
	at com.exe4j.runtime.LauncherEngine.launch(LauncherEngine.java:85)
	at com.exe4j.runtime.WinLauncher.main(WinLauncher.java:94)
	at com.install4j.runtime.launcher.WinLauncher.main(WinLauncher.java:25)`



---
Workaround:

1. Check for Cyrillic characters in APPDATA when FAF starts
2. Show a pop-up message in EN/RU when it has found any and tell the user what the issue is

---
I have trouble with the test cases, because mocking APPDATA does not work. Junit 4 has PowerMockRunner, but needs different dependencies to make it run. Junit 5 has PowerMockExtension

Before I go even further that way, fiddling with all that test part:

1. Is the drafted code a suitable solution, or does it need to go back to the drawing board?
2. If suitable, what would be the best approach about the test cases?

---

Note: 

Check for Linux can be added later, but those cases are very, very rare.

In the project are 6 more instances with org.bridj.Platform.isWindows(), but they all should be already covered, when the first org.bridj.Platform.isWindows() works and the user has created a working environment.


@Sheikah45 Please, can I hear your thoughts on this draft, thanks in advance and take your time