### PR TITLE
Fix leaderboard order

### DIFF
--- a/src/main/java/com/faforever/client/leaderboard/LeaderboardsController.java
+++ b/src/main/java/com/faforever/client/leaderboard/LeaderboardsController.java
@@ -56,11 +56,11 @@ public class LeaderboardsController extends AbstractViewController<Node> {
             controller.setSeason(season);
             controller.getRoot()
                 .setText(i18n.getOrDefault(league.getTechnicalName(), String.format("leaderboard.%s", league.getTechnicalName())));
-            controller.getRoot().setUserData(league.getId());
+            controller.getRoot().setUserData(league.getTechnicalName());
             fxApplicationThreadExecutor.execute(() -> leaderboardRoot.getTabs().add(controller.getRoot()));
             controllers.add(controller);
           }).thenRunAsync(() -> {
-            leaderboardRoot.getTabs().sort(Comparator.comparing(tab -> (int) tab.getUserData()));
+            leaderboardRoot.getTabs().sort(Comparator.comparing(tab -> tab.getUserData().toString()));
             leaderboardRoot.getSelectionModel().select(0);
             lastTab = leaderboardRoot.getTabs().get(0);
           }, fxApplicationThreadExecutor).exceptionally(throwable -> {


### PR DESCRIPTION
The 3v3 was listed last, because it has the highest id. So we have to switch to a different way to sort them, so they are in the order that you would expect.
![grafik](https://github.com/FAForever/downlords-faf-client/assets/52536103/d719cc05-579c-40d2-b4a9-1e8527e406d5)
