### PR TITLE
Remove issue hunt link from issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -24,7 +24,3 @@ If applicable, add screenshots to help explain your problem.
 
 **OS**
 Linux or Windows
-
-**Wanna have the bug fixed quickly?**
-Visit Issue hunt...
-[![Issue hunt](https://github.com/BoostIO/issuehunt-materials/raw/master/v1/issuehunt-button-v1.svg?sanitize=true)](https://issuehunt.io/r/FAForever/downlords-faf-client)

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -15,7 +15,3 @@ A clear and concise description of what you want to happen.
 
 **Describe alternatives you've considered**
 A clear and concise description of any alternative solutions or features you've considered.
-
-**Wanna have the bug fixed quickly?**
-Visit Issue hunt...
-[![Issue hunt](https://github.com/BoostIO/issuehunt-materials/raw/master/v1/issuehunt-button-v1.svg?sanitize=true)](https://issuehunt.io/r/FAForever/downlords-faf-client)


### PR DESCRIPTION
These haven't really been used and iirc we have decided that we are not interested in using money bounties.