### PR TITLE
Load the ICE servers from the new faf-icebreaker API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -310,7 +310,9 @@ dependencies {
   implementation("com.neovisionaries:nv-i18n:1.29")
   implementation("com.nativelibs4java:bridj:0.7.0")
   implementation("org.luaj:luaj-jse:3.0.1")
-  implementation("commons-validator:commons-validator:1.7")
+  implementation("commons-validator:commons-validator:1.7") {
+    exclude module: 'commons-logging'
+  }
   implementation("com.github.micheljung:JJsonRpc:01a7fba5f4")
   implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
   implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
@@ -337,7 +339,9 @@ dependencies {
   implementation("com.github.1-alex98:discord-rpc:1.6.2-jna")
   implementation("org.controlsfx:controlsfx:11.1.2")
   implementation("org.fxmisc.flowless:flowless:0.7.1")
-  implementation("de.codecentric.centerdevice:javafxsvg:1.3.0")
+  implementation("de.codecentric.centerdevice:javafxsvg:1.3.0") {
+    exclude module: 'commons-logging'
+  }
 
   implementation("org.javassist:javassist:3.29.2-GA")
 

--- a/src/main/java/com/faforever/client/api/FafApiAccessor.java
+++ b/src/main/java/com/faforever/client/api/FafApiAccessor.java
@@ -157,9 +157,15 @@ public class FafApiAccessor implements InitializingBean {
         .doOnNext(object -> log.trace("Retrieved {} from /me with type MeResult", object));
   }
 
+  public Flux<IceServer> getIceServers() {
+    return retrieveMonoWithErrorHandling(IceServerResponse.class, apiWebClient.get().uri("/ice/server"))
+        .flatMapIterable(IceServerResponse::servers)
+        .doOnNext(object -> log.trace("Retrieved {} from /ice/server with type IceServer", object));
+  }
+
   public Mono<IceSession> getIceSession(int gameId) {
     return retrieveMonoWithErrorHandling(IceSession.class, apiWebClient.get().uri("/ice/session/game/" + gameId))
-        .doOnNext(object -> log.trace("Retrieved {} from /ice/session/game/{} with type MeResult", object, gameId));
+        .doOnNext(object -> log.trace("Retrieved {} from /ice/session/game/{} with type IceSession", object, gameId));
   }
 
   public Mono<Void> uploadFile(String endpoint, Path file, ByteCountListener listener,

--- a/src/main/java/com/faforever/client/api/FafApiAccessor.java
+++ b/src/main/java/com/faforever/client/api/FafApiAccessor.java
@@ -157,6 +157,11 @@ public class FafApiAccessor implements InitializingBean {
         .doOnNext(object -> log.trace("Retrieved {} from /me with type MeResult", object));
   }
 
+  public Mono<IceSession> getIceSession(int gameId) {
+    return retrieveMonoWithErrorHandling(IceSession.class, apiWebClient.get().uri("/ice/session/game/" + gameId))
+        .doOnNext(object -> log.trace("Retrieved {} from /ice/session/game/{} with type MeResult", object, gameId));
+  }
+
   public Mono<Void> uploadFile(String endpoint, Path file, ByteCountListener listener,
                                java.util.Map<String, java.util.Map<String, ?>> params) {
     MultiValueMap<String, Object> multipartContent = createFileMultipart(file, listener);

--- a/src/main/java/com/faforever/client/api/FafApiAccessor.java
+++ b/src/main/java/com/faforever/client/api/FafApiAccessor.java
@@ -52,6 +52,7 @@ import org.springframework.util.CollectionUtils;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClient.RequestHeadersSpec;
 import org.springframework.web.util.UriComponents;
 import org.springframework.web.util.UriComponentsBuilder;
 import reactor.core.publisher.Flux;
@@ -153,19 +154,18 @@ public class FafApiAccessor implements InitializingBean {
   }
 
   public Mono<MeResult> getMe() {
-    return retrieveMonoWithErrorHandling(MeResult.class, apiWebClient.get().uri("/me"))
-        .doOnNext(object -> log.trace("Retrieved {} from /me with type MeResult", object));
+    return retrieveMonoWithErrorHandling(MeResult.class, apiWebClient.get()
+        .uri("/me")).doOnNext(object -> log.trace("Retrieved {} from /me with type MeResult", object));
   }
 
-  public Flux<IceServer> getIceServers() {
-    return retrieveMonoWithErrorHandling(IceServerResponse.class, apiWebClient.get().uri("/ice/server"))
-        .flatMapIterable(IceServerResponse::servers)
-        .doOnNext(object -> log.trace("Retrieved {} from /ice/server with type IceServer", object));
+  public <T> Mono<T> getApiObject(String path, Class<T> clazz) {
+    RequestHeadersSpec<?> requestSpec = apiWebClient.get().uri(path);
+    return retrieveMonoWithErrorHandling(clazz, requestSpec).doOnNext(object -> log.trace("Retrieved {} from {} with type {}", object, path, clazz));
   }
 
-  public Mono<IceSession> getIceSession(int gameId) {
-    return retrieveMonoWithErrorHandling(IceSession.class, apiWebClient.get().uri("/ice/session/game/" + gameId))
-        .doOnNext(object -> log.trace("Retrieved {} from /ice/session/game/{} with type IceSession", object, gameId));
+  public <T> Flux<T> getApiObjects(String path, Class<T> clazz) {
+    RequestHeadersSpec<?> requestSpec = apiWebClient.get().uri(path);
+    return retrieveFluxWithErrorHandling(clazz, requestSpec).doOnNext(object -> log.trace("Retrieved {} from {} with type {}", object, path, clazz));
   }
 
   public Mono<Void> uploadFile(String endpoint, Path file, ByteCountListener listener,

--- a/src/main/java/com/faforever/client/api/IceServer.java
+++ b/src/main/java/com/faforever/client/api/IceServer.java
@@ -1,4 +1,4 @@
 package com.faforever.client.api;
 
-public record IceServer(String name, String region) {
+public record IceServer(String id, String region) {
 }

--- a/src/main/java/com/faforever/client/api/IceServer.java
+++ b/src/main/java/com/faforever/client/api/IceServer.java
@@ -1,0 +1,4 @@
+package com.faforever.client.api;
+
+public record IceServer(String name, String region) {
+}

--- a/src/main/java/com/faforever/client/api/IceServerResponse.java
+++ b/src/main/java/com/faforever/client/api/IceServerResponse.java
@@ -1,0 +1,6 @@
+package com.faforever.client.api;
+
+import java.util.List;
+
+public record IceServerResponse(List<IceServer> servers) {
+}

--- a/src/main/java/com/faforever/client/api/IceSession.java
+++ b/src/main/java/com/faforever/client/api/IceSession.java
@@ -1,11 +1,9 @@
 package com.faforever.client.api;
 
 import com.faforever.commons.api.dto.CoturnServer;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 
-@JsonIgnoreProperties(ignoreUnknown = true)
 public record IceSession(@NotNull String id, @NotNull List<CoturnServer> servers) {
 }

--- a/src/main/java/com/faforever/client/api/IceSession.java
+++ b/src/main/java/com/faforever/client/api/IceSession.java
@@ -1,0 +1,11 @@
+package com.faforever.client.api;
+
+import com.faforever.commons.api.dto.CoturnServer;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record IceSession(@NotNull String id, @NotNull List<CoturnServer> servers) {
+}

--- a/src/main/java/com/faforever/client/fa/relay/ice/CoturnService.java
+++ b/src/main/java/com/faforever/client/fa/relay/ice/CoturnService.java
@@ -2,8 +2,8 @@ package com.faforever.client.fa.relay.ice;
 
 import com.faforever.client.api.FafApiAccessor;
 import com.faforever.client.api.IceServer;
+import com.faforever.client.api.IceServerResponse;
 import com.faforever.client.api.IceSession;
-import com.faforever.client.mapstruct.IceServerMapper;
 import com.faforever.client.preferences.ForgedAlliancePrefs;
 import com.faforever.commons.api.dto.CoturnServer;
 import lombok.RequiredArgsConstructor;
@@ -21,18 +21,18 @@ import java.util.concurrent.CompletableFuture;
 public class CoturnService {
 
   private final FafApiAccessor fafApiAccessor;
-  private final IceServerMapper iceServerMapper;
   private final ForgedAlliancePrefs forgedAlliancePrefs;
 
   public CompletableFuture<List<IceServer>> getActiveCoturns() {
-    return fafApiAccessor.getIceServers()
+    return fafApiAccessor.getApiObject("/ice/server", IceServerResponse.class)
+        .flatMapIterable(IceServerResponse::servers)
         .switchIfEmpty(Flux.error(new IllegalStateException("No Coturn Servers Available")))
         .collectList()
         .toFuture();
   }
 
   public CompletableFuture<List<CoturnServer>> getSelectedCoturns(int gameId) {
-    Flux<CoturnServer> coturnServerFlux = fafApiAccessor.getIceSession(gameId)
+    Flux<CoturnServer> coturnServerFlux = fafApiAccessor.getApiObject("/ice/session/game/" + gameId, IceSession.class)
         .flatMapIterable(IceSession::servers);
 
     Set<String> preferredCoturnIds = forgedAlliancePrefs.getPreferredCoturnIds();

--- a/src/main/java/com/faforever/client/fa/relay/ice/CoturnService.java
+++ b/src/main/java/com/faforever/client/fa/relay/ice/CoturnService.java
@@ -1,6 +1,7 @@
 package com.faforever.client.fa.relay.ice;
 
 import com.faforever.client.api.FafApiAccessor;
+import com.faforever.client.api.IceSession;
 import com.faforever.client.mapstruct.IceServerMapper;
 import com.faforever.client.preferences.ForgedAlliancePrefs;
 import com.faforever.commons.api.dto.CoturnServer;
@@ -31,9 +32,9 @@ public class CoturnService {
         .toFuture();
   }
 
-  public CompletableFuture<List<CoturnServer>> getSelectedCoturns() {
-    ElideNavigatorOnCollection<CoturnServer> navigator = ElideNavigator.of(CoturnServer.class).collection();
-    Flux<CoturnServer> coturnServerFlux = fafApiAccessor.getMany(navigator);
+  public CompletableFuture<List<CoturnServer>> getSelectedCoturns(int gameId) {
+    Flux<CoturnServer> coturnServerFlux = fafApiAccessor.getIceSession(gameId)
+        .flatMapIterable(IceSession::servers);
 
     Set<String> preferredCoturnIds = forgedAlliancePrefs.getPreferredCoturnIds();
 

--- a/src/main/java/com/faforever/client/fa/relay/ice/CoturnService.java
+++ b/src/main/java/com/faforever/client/fa/relay/ice/CoturnService.java
@@ -1,12 +1,11 @@
 package com.faforever.client.fa.relay.ice;
 
 import com.faforever.client.api.FafApiAccessor;
+import com.faforever.client.api.IceServer;
 import com.faforever.client.api.IceSession;
 import com.faforever.client.mapstruct.IceServerMapper;
 import com.faforever.client.preferences.ForgedAlliancePrefs;
 import com.faforever.commons.api.dto.CoturnServer;
-import com.faforever.commons.api.elide.ElideNavigator;
-import com.faforever.commons.api.elide.ElideNavigatorOnCollection;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
@@ -25,9 +24,9 @@ public class CoturnService {
   private final IceServerMapper iceServerMapper;
   private final ForgedAlliancePrefs forgedAlliancePrefs;
 
-  public CompletableFuture<List<CoturnServer>> getActiveCoturns() {
-    ElideNavigatorOnCollection<CoturnServer> navigator = ElideNavigator.of(CoturnServer.class).collection();
-    return fafApiAccessor.getMany(navigator)
+  public CompletableFuture<List<IceServer>> getActiveCoturns() {
+    return fafApiAccessor.getIceServers()
+        .switchIfEmpty(Flux.error(new IllegalStateException("No Coturn Servers Available")))
         .collectList()
         .toFuture();
   }

--- a/src/main/java/com/faforever/client/fa/relay/ice/IceAdapterImpl.java
+++ b/src/main/java/com/faforever/client/fa/relay/ice/IceAdapterImpl.java
@@ -223,11 +223,6 @@ public class IceAdapterImpl implements IceAdapter, InitializingBean, DisposableB
 
     cmd.addAll(standardIceOptions);
 
-    if (forgedAlliancePrefs.isForceRelay()) {
-      cmd.add("--force-relay");
-      log.info("Forcing ice adapter relay connection");
-    }
-
     if (forgedAlliancePrefs.isShowIceAdapterDebugWindow()) {
       cmd.add("--debug-window");
       cmd.add("--info-window");

--- a/src/main/java/com/faforever/client/game/GameService.java
+++ b/src/main/java/com/faforever/client/game/GameService.java
@@ -665,7 +665,7 @@ public class GameService implements InitializingBean {
           localReplayPort = port;
           return iceAdapter.start(gameParameters.getUid());
         })
-        .thenCompose(adapterPort -> coturnService.getSelectedCoturns()
+        .thenCompose(adapterPort -> coturnService.getSelectedCoturns(uid)
             .thenAccept(iceAdapter::setIceServers)
             .thenApply(aVoid -> adapterPort))
         .thenApply(adapterPort -> {

--- a/src/main/java/com/faforever/client/mapstruct/IceServerMapper.java
+++ b/src/main/java/com/faforever/client/mapstruct/IceServerMapper.java
@@ -14,7 +14,6 @@ public abstract class IceServerMapper {
     return Map.of(
         "urls", coturnServer.getUrls().stream().map(URI::toString).toList(),
         "credential", coturnServer.getCredential(),
-        "credentialType", coturnServer.getCredentialType(),
         "username", coturnServer.getUsername()
     );
   }

--- a/src/main/java/com/faforever/client/preferences/ForgedAlliancePrefs.java
+++ b/src/main/java/com/faforever/client/preferences/ForgedAlliancePrefs.java
@@ -24,7 +24,6 @@ public class ForgedAlliancePrefs {
   ObjectProperty<Path> preferencesFile = new SimpleObjectProperty<>();
   ObjectProperty<Path> vaultBaseDirectory = new SimpleObjectProperty<>();
   BooleanProperty warnNonAsciiVaultPath = new SimpleBooleanProperty(true);
-  BooleanProperty forceRelay = new SimpleBooleanProperty(false);
   BooleanProperty autoDownloadMaps = new SimpleBooleanProperty(true);
   BooleanProperty allowIpv6 = new SimpleBooleanProperty(false);
 
@@ -58,18 +57,6 @@ public class ForgedAlliancePrefs {
 
   public ObjectProperty<Path> preferencesFileProperty() {
     return preferencesFile;
-  }
-
-  public boolean isForceRelay() {
-    return forceRelay.get();
-  }
-
-  public void setForceRelay(boolean forceRelay) {
-    this.forceRelay.set(forceRelay);
-  }
-
-  public BooleanProperty forceRelayProperty() {
-    return forceRelay;
   }
 
   public boolean isAutoDownloadMaps() {

--- a/src/main/java/com/faforever/client/preferences/ui/SettingsController.java
+++ b/src/main/java/com/faforever/client/preferences/ui/SettingsController.java
@@ -17,7 +17,6 @@ import com.faforever.client.fx.StringListCell;
 import com.faforever.client.game.VaultPathHandler;
 import com.faforever.client.i18n.I18n;
 import com.faforever.client.main.event.NavigationItem;
-import com.faforever.client.mapstruct.IceServerMapper;
 import com.faforever.client.notification.Action;
 import com.faforever.client.notification.NotificationService;
 import com.faforever.client.notification.PersistentNotification;
@@ -107,7 +106,6 @@ public class SettingsController implements Controller<Node> {
   private final ClientUpdateService clientUpdateService;
   private final TaskService taskService;
   private final CoturnService coturnService;
-  private final IceServerMapper iceServerMapper;
   private final VaultPathHandler vaultPathHandler;
   private final Preferences preferences;
   private final ObjectFactory<MoveDirectoryTask> moveDirectoryTaskFactory;
@@ -121,7 +119,6 @@ public class SettingsController implements Controller<Node> {
   public Toggle randomColorsToggle;
   public Toggle defaultColorsToggle;
   public CheckBox hideFoeToggle;
-  public CheckBox forceRelayToggle;
   public CheckBox changeProcessPriorityToggle;
   public TextField dataLocationTextField;
   public TextField gameLocationTextField;

--- a/src/main/java/com/faforever/client/preferences/ui/SettingsController.java
+++ b/src/main/java/com/faforever/client/preferences/ui/SettingsController.java
@@ -310,7 +310,6 @@ public class SettingsController implements Controller<Node> {
 
   private void bindGamePreferences() {
     ForgedAlliancePrefs forgedAlliancePrefs = preferences.getForgedAlliance();
-    forceRelayToggle.selectedProperty().bindBidirectional(forgedAlliancePrefs.forceRelayProperty());
     changeProcessPriorityToggle.selectedProperty()
         .bindBidirectional(forgedAlliancePrefs.changeProcessPriorityProperty());
     gameLocationTextField.textProperty()

--- a/src/main/java/com/faforever/client/preferences/ui/SettingsController.java
+++ b/src/main/java/com/faforever/client/preferences/ui/SettingsController.java
@@ -1,6 +1,7 @@
 package com.faforever.client.preferences.ui;
 
 import ch.qos.logback.classic.Level;
+import com.faforever.client.api.IceServer;
 import com.faforever.client.chat.ChatColorMode;
 import com.faforever.client.chat.ChatFormat;
 import com.faforever.client.config.ClientProperties;
@@ -44,7 +45,6 @@ import com.faforever.client.ui.list.NoSelectionModelListView;
 import com.faforever.client.ui.preferences.event.GameDirectoryChooseEvent;
 import com.faforever.client.update.ClientUpdateService;
 import com.faforever.client.user.LoginService;
-import com.faforever.commons.api.dto.CoturnServer;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.eventbus.EventBus;
 import javafx.application.Platform;
@@ -177,7 +177,7 @@ public class SettingsController implements Controller<Node> {
   public Spinner<Integer> gameDataCacheTimeSpinner;
   public ComboBox<Level> logLevelComboBox;
   public CheckBox mapAndModAutoUpdateCheckBox;
-  public ListView<CoturnServer> preferredCoturnListView;
+  public ListView<IceServer> preferredCoturnListView;
 
   private final SimpleChangeListener<Theme> selectedThemeChangeListener = this::onThemeChanged;
   private final SimpleChangeListener<Theme> currentThemeChangeListener = newValue -> themeComboBox.getSelectionModel().select(newValue);;
@@ -339,12 +339,12 @@ public class SettingsController implements Controller<Node> {
     coturnService.getActiveCoturns().thenAcceptAsync(coturnServers -> {
       preferredCoturnListView.getSelectionModel().setSelectionMode(SelectionMode.MULTIPLE);
       preferredCoturnListView.setItems(FXCollections.observableList(coturnServers));
-      preferredCoturnListView.setCellFactory(param -> new StringListCell<>(CoturnServer::getRegion, fxApplicationThreadExecutor));
+      preferredCoturnListView.setCellFactory(param -> new StringListCell<>(IceServer::region, fxApplicationThreadExecutor));
       ObservableSet<String> preferredCoturnServers = preferences
           .getForgedAlliance()
           .getPreferredCoturnIds();
-      Map<String, CoturnServer> hostPortCoturnServerMap = coturnServers.stream()
-          .collect(Collectors.toMap(CoturnServer::getId, Function.identity()));
+      Map<String, IceServer> hostPortCoturnServerMap = coturnServers.stream()
+          .collect(Collectors.toMap(IceServer::name, Function.identity()));
 
       preferredCoturnServers.stream()
           .filter(hostPortCoturnServerMap::containsKey)
@@ -353,9 +353,9 @@ public class SettingsController implements Controller<Node> {
 
       JavaFxUtil.addAndTriggerListener(preferredCoturnListView.getSelectionModel()
           .getSelectedItems(), (InvalidationListener) observable -> {
-        List<CoturnServer> selectedCoturns = preferredCoturnListView.getSelectionModel().getSelectedItems();
+        List<IceServer> selectedCoturns = preferredCoturnListView.getSelectionModel().getSelectedItems();
         preferredCoturnServers.clear();
-        selectedCoturns.stream().map(CoturnServer::getId).forEach(preferredCoturnServers::add);
+        selectedCoturns.stream().map(IceServer::name).forEach(preferredCoturnServers::add);
       });
     }, fxApplicationThreadExecutor);
   }

--- a/src/main/java/com/faforever/client/preferences/ui/SettingsController.java
+++ b/src/main/java/com/faforever/client/preferences/ui/SettingsController.java
@@ -181,7 +181,8 @@ public class SettingsController implements Controller<Node> {
 
   private final SimpleChangeListener<Theme> selectedThemeChangeListener = this::onThemeChanged;
   private final SimpleChangeListener<Theme> currentThemeChangeListener = newValue -> themeComboBox.getSelectionModel().select(newValue);;
-  private SimpleInvalidationListener availableLanguagesListener = this::setAvailableLanguages;;
+  private final SimpleInvalidationListener availableLanguagesListener = this::setAvailableLanguages;
+  ;
 
   public void initialize() {
     JavaFxUtil.bindManagedToVisible(vaultLocationWarningLabel);
@@ -344,7 +345,7 @@ public class SettingsController implements Controller<Node> {
           .getForgedAlliance()
           .getPreferredCoturnIds();
       Map<String, IceServer> hostPortCoturnServerMap = coturnServers.stream()
-          .collect(Collectors.toMap(IceServer::name, Function.identity()));
+          .collect(Collectors.toMap(IceServer::id, Function.identity()));
 
       preferredCoturnServers.stream()
           .filter(hostPortCoturnServerMap::containsKey)
@@ -352,10 +353,10 @@ public class SettingsController implements Controller<Node> {
           .forEach(coturnServer -> preferredCoturnListView.getSelectionModel().select(coturnServer));
 
       JavaFxUtil.addAndTriggerListener(preferredCoturnListView.getSelectionModel()
-          .getSelectedItems(), (InvalidationListener) observable -> {
+          .getSelectedItems(), observable -> {
         List<IceServer> selectedCoturns = preferredCoturnListView.getSelectionModel().getSelectedItems();
         preferredCoturnServers.clear();
-        selectedCoturns.stream().map(IceServer::name).forEach(preferredCoturnServers::add);
+        selectedCoturns.stream().map(IceServer::id).forEach(preferredCoturnServers::add);
       });
     }, fxApplicationThreadExecutor);
   }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -81,6 +81,7 @@ spring:
   jackson:
     deserialization:
       read-unknown-enum-values-using-default-value: true
+      fail-on-unknown-properties: false
 
 logging:
   level:

--- a/src/main/resources/theme/settings/settings.fxml
+++ b/src/main/resources/theme/settings/settings.fxml
@@ -642,27 +642,6 @@
                             <content>
                                 <VBox styleClass="view-content">
                                     <children>
-                                        <GridPane styleClass="setting-container">
-                                            <columnConstraints>
-                                                <ColumnConstraints hgrow="ALWAYS" minWidth="10.0"/>
-                                                <ColumnConstraints halignment="RIGHT" hgrow="SOMETIMES"
-                                                                   minWidth="10.0"/>
-                                            </columnConstraints>
-                                            <rowConstraints>
-                                                <RowConstraints minHeight="10.0" valignment="TOP" vgrow="SOMETIMES"/>
-                                                <RowConstraints minHeight="10.0" vgrow="SOMETIMES"/>
-                                            </rowConstraints>
-                                            <children>
-                                                <Label contentDisplay="RIGHT" maxWidth="1.7976931348623157E308"
-                                                       styleClass="setting-title" text="%settings.fa.forceRelay"/>
-                                                <Label styleClass="setting-description"
-                                                       text="%settings.fa.forceRelay.description"
-                                                       GridPane.columnSpan="2147483647" GridPane.hgrow="ALWAYS"
-                                                       GridPane.rowIndex="1"/>
-                                                <CheckBox fx:id="forceRelayToggle" contentDisplay="GRAPHIC_ONLY"
-                                                          mnemonicParsing="false" GridPane.columnIndex="1"/>
-                                            </children>
-                                        </GridPane>
                                         <GridPane hgap="10.0" styleClass="setting-container">
                                             <columnConstraints>
                                                 <ColumnConstraints hgrow="ALWAYS" minWidth="10.0"/>

--- a/src/test/java/com/faforever/client/chat/ChatUserItemControllerTest.java
+++ b/src/test/java/com/faforever/client/chat/ChatUserItemControllerTest.java
@@ -180,9 +180,9 @@ public class ChatUserItemControllerTest extends PlatformTest {
     when(uiService.getThemeImage(UiService.CHAT_LIST_STATUS_HOSTING)).thenReturn(new Image(InputStream.nullInputStream()));
     when(mapService.loadPreview(game.getMapFolderName(), PreviewSize.SMALL)).thenReturn(new Image(InputStream.nullInputStream()));
     when(mapService.getMapLocallyFromName(mapFolderName)).thenReturn(Optional.of(mapVersion));
-    when(mapService.convertMapFolderNameToHumanNameIfPossible(mapFolderName)).thenReturn("map name");
+    when(mapService.convertMapFolderNameToHumanNameIfPossible(mapFolderName)).thenReturn("map id");
     when(i18n.get(eq("game.onMapFormat"), anyString())).thenReturn(mapVersion.getMap()
-        .getDisplayName(), "map name", "Neroxis Generated Map");
+        .getDisplayName(), "map id", "Neroxis Generated Map");
 
     runOnFxThreadAndWait(() -> instance.setChatUser(defaultUser));
     assertNotNull(instance.gameStatusImageView.getImage());

--- a/src/test/java/com/faforever/client/fa/relay/ice/CoturnServiceTest.java
+++ b/src/test/java/com/faforever/client/fa/relay/ice/CoturnServiceTest.java
@@ -1,6 +1,7 @@
 package com.faforever.client.fa.relay.ice;
 
 import com.faforever.client.api.FafApiAccessor;
+import com.faforever.client.api.IceSession;
 import com.faforever.client.mapstruct.IceServerMapper;
 import com.faforever.client.mapstruct.MapperSetup;
 import com.faforever.client.preferences.ForgedAlliancePrefs;
@@ -14,11 +15,13 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -53,26 +56,26 @@ public class CoturnServiceTest extends ServiceTest {
 
     CoturnServer otherServer = new CoturnServer();
     otherServer.setId("0");
-    when(fafApiAccessor.getMany(any())).thenReturn(Flux.just(otherServer));
+    when(fafApiAccessor.getIceSession(anyInt())).thenReturn(Mono.just(new IceSession("someSessionId", List.of(otherServer))));
 
-    List<CoturnServer> servers = instance.getSelectedCoturns().join();
+    List<CoturnServer> servers = instance.getSelectedCoturns(123).join();
 
     assertEquals(1, servers.size());
     assertEquals("0", servers.get(0).getId());
-    verify(fafApiAccessor).getMany(argThat(ElideMatchers.hasDtoClass(CoturnServer.class)));
+    verify(fafApiAccessor).getIceSession(123);
   }
 
   @Test
   public void testGetSelectedCoturnsNoneSelected() {
     CoturnServer otherServer = new CoturnServer();
     otherServer.setId("0");
-    when(fafApiAccessor.getMany(any())).thenReturn(Flux.just(otherServer));
+    when(fafApiAccessor.getIceSession(anyInt())).thenReturn(Mono.just(new IceSession("someSessionId", List.of(otherServer))));
 
-    List<CoturnServer> servers = instance.getSelectedCoturns().join();
+    List<CoturnServer> servers = instance.getSelectedCoturns(123).join();
 
     assertEquals(1, servers.size());
     assertEquals("0", servers.get(0).getId());
-    verify(fafApiAccessor).getMany(argThat(ElideMatchers.hasDtoClass(CoturnServer.class)));
+    verify(fafApiAccessor).getIceSession(123);
   }
 
   @Test
@@ -83,12 +86,12 @@ public class CoturnServiceTest extends ServiceTest {
     otherServer.setId("0");
     CoturnServer selectedServer = new CoturnServer();
     otherServer.setId("1");
-    when(fafApiAccessor.getMany(any())).thenReturn(Flux.just(otherServer, selectedServer));
+    when(fafApiAccessor.getIceSession(anyInt())).thenReturn(Mono.just(new IceSession("someSessionId", List.of(otherServer, selectedServer))));
 
-    List<CoturnServer> servers = instance.getSelectedCoturns().join();
+    List<CoturnServer> servers = instance.getSelectedCoturns(123).join();
 
     assertEquals(1, servers.size());
     assertEquals("1", servers.get(0).getId());
-    verify(fafApiAccessor).getMany(argThat(ElideMatchers.hasDtoClass(CoturnServer.class)));
+    verify(fafApiAccessor).getIceSession(123);
   }
 }

--- a/src/test/java/com/faforever/client/fa/relay/ice/CoturnServiceTest.java
+++ b/src/test/java/com/faforever/client/fa/relay/ice/CoturnServiceTest.java
@@ -1,6 +1,7 @@
 package com.faforever.client.fa.relay.ice;
 
 import com.faforever.client.api.FafApiAccessor;
+import com.faforever.client.api.IceServerResponse;
 import com.faforever.client.api.IceSession;
 import com.faforever.client.mapstruct.IceServerMapper;
 import com.faforever.client.mapstruct.MapperSetup;
@@ -13,7 +14,6 @@ import org.mapstruct.factory.Mappers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
-import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
@@ -44,9 +44,9 @@ public class CoturnServiceTest extends ServiceTest {
 
   @Test
   public void testGetActiveCoturns() {
-    when(fafApiAccessor.getApiObjects("/ice/server", IceServer.class)).thenReturn(Flux.empty());
+    when(fafApiAccessor.getApiObject("/ice/server", IceServerResponse.class)).thenReturn(Mono.empty());
     instance.getActiveCoturns();
-    verify(fafApiAccessor).getApiObjects("/ice/server", IceServer.class);
+    verify(fafApiAccessor).getApiObject("/ice/server", IceServerResponse.class);
   }
 
   @Test

--- a/src/test/java/com/faforever/client/fa/relay/ice/CoturnServiceTest.java
+++ b/src/test/java/com/faforever/client/fa/relay/ice/CoturnServiceTest.java
@@ -5,7 +5,6 @@ import com.faforever.client.api.IceSession;
 import com.faforever.client.mapstruct.IceServerMapper;
 import com.faforever.client.mapstruct.MapperSetup;
 import com.faforever.client.preferences.ForgedAlliancePrefs;
-import com.faforever.client.test.ElideMatchers;
 import com.faforever.client.test.ServiceTest;
 import com.faforever.commons.api.dto.CoturnServer;
 import org.junit.jupiter.api.BeforeEach;
@@ -21,8 +20,8 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.endsWith;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -45,9 +44,9 @@ public class CoturnServiceTest extends ServiceTest {
 
   @Test
   public void testGetActiveCoturns() {
-    when(fafApiAccessor.getMany(any())).thenReturn(Flux.empty());
+    when(fafApiAccessor.getApiObjects("/ice/server", IceServer.class)).thenReturn(Flux.empty());
     instance.getActiveCoturns();
-    verify(fafApiAccessor).getMany(argThat(ElideMatchers.hasDtoClass(CoturnServer.class)));
+    verify(fafApiAccessor).getApiObjects("/ice/server", IceServer.class);
   }
 
   @Test
@@ -56,26 +55,26 @@ public class CoturnServiceTest extends ServiceTest {
 
     CoturnServer otherServer = new CoturnServer();
     otherServer.setId("0");
-    when(fafApiAccessor.getIceSession(anyInt())).thenReturn(Mono.just(new IceSession("someSessionId", List.of(otherServer))));
+    when(fafApiAccessor.getApiObject(any(), any())).thenReturn(Mono.just(new IceSession("someSessionId", List.of(otherServer))));
 
     List<CoturnServer> servers = instance.getSelectedCoturns(123).join();
 
     assertEquals(1, servers.size());
     assertEquals("0", servers.get(0).getId());
-    verify(fafApiAccessor).getIceSession(123);
+    verify(fafApiAccessor).getApiObject(endsWith("123"), eq(IceSession.class));
   }
 
   @Test
   public void testGetSelectedCoturnsNoneSelected() {
     CoturnServer otherServer = new CoturnServer();
     otherServer.setId("0");
-    when(fafApiAccessor.getIceSession(anyInt())).thenReturn(Mono.just(new IceSession("someSessionId", List.of(otherServer))));
+    when(fafApiAccessor.getApiObject(any(), any())).thenReturn(Mono.just(new IceSession("someSessionId", List.of(otherServer))));
 
     List<CoturnServer> servers = instance.getSelectedCoturns(123).join();
 
     assertEquals(1, servers.size());
     assertEquals("0", servers.get(0).getId());
-    verify(fafApiAccessor).getIceSession(123);
+    verify(fafApiAccessor).getApiObject(endsWith("123"), eq(IceSession.class));
   }
 
   @Test
@@ -86,12 +85,12 @@ public class CoturnServiceTest extends ServiceTest {
     otherServer.setId("0");
     CoturnServer selectedServer = new CoturnServer();
     otherServer.setId("1");
-    when(fafApiAccessor.getIceSession(anyInt())).thenReturn(Mono.just(new IceSession("someSessionId", List.of(otherServer, selectedServer))));
+    when(fafApiAccessor.getApiObject(any(), any())).thenReturn(Mono.just(new IceSession("someSessionId", List.of(otherServer, selectedServer))));
 
     List<CoturnServer> servers = instance.getSelectedCoturns(123).join();
 
     assertEquals(1, servers.size());
     assertEquals("1", servers.get(0).getId());
-    verify(fafApiAccessor).getIceSession(123);
+    verify(fafApiAccessor).getApiObject(endsWith("123"), eq(IceSession.class));
   }
 }

--- a/src/test/java/com/faforever/client/fa/relay/ice/IceAdapterImplTest.java
+++ b/src/test/java/com/faforever/client/fa/relay/ice/IceAdapterImplTest.java
@@ -116,7 +116,6 @@ public class IceAdapterImplTest extends ServiceTest {
     when(operatingSystem.getJavaExecutablePath()).thenReturn(javaExecutablePath);
     PlayerBean currentPlayer = PlayerBeanBuilder.create().defaultValues().get();
     when(playerService.getCurrentPlayer()).thenReturn(currentPlayer);
-    forgedAlliancePrefs.setForceRelay(true);
     forgedAlliancePrefs.setShowIceAdapterDebugWindow(true);
 
     List<String> command = instance.buildCommand(Path.of("."), 0, 0, 4711);
@@ -148,7 +147,6 @@ public class IceAdapterImplTest extends ServiceTest {
 
     when(operatingSystem.getJavaExecutablePath()).thenReturn(javaExecutablePath);
     forgedAlliancePrefs.setAllowIpv6(true);
-    forgedAlliancePrefs.setForceRelay(true);
     forgedAlliancePrefs.setShowIceAdapterDebugWindow(true);
     PlayerBean currentPlayer = PlayerBeanBuilder.create().defaultValues().get();
     when(playerService.getCurrentPlayer()).thenReturn(currentPlayer);

--- a/src/test/java/com/faforever/client/fa/relay/ice/IceAdapterImplTest.java
+++ b/src/test/java/com/faforever/client/fa/relay/ice/IceAdapterImplTest.java
@@ -136,9 +136,8 @@ public class IceAdapterImplTest extends ServiceTest {
     assertEquals(String.valueOf(0), command.get(12));
     assertEquals("--gpgnet-port", command.get(13));
     assertEquals(String.valueOf(0), command.get(14));
-    assertEquals("--force-relay", command.get(15));
-    assertEquals("--debug-window", command.get(16));
-    assertEquals("--info-window", command.get(17));
+    assertEquals("--debug-window", command.get(15));
+    assertEquals("--info-window", command.get(16));
   }
 
   @Test
@@ -194,7 +193,6 @@ public class IceAdapterImplTest extends ServiceTest {
     Map<String, Object> iceMap = value.get(0);
 
     assertEquals(coturnServer.getUsername(), iceMap.get("username"));
-    assertEquals(coturnServer.getCredentialType(), iceMap.get("credentialType"));
     assertEquals(coturnServer.getCredential(), iceMap.get("credential"));
     assertEquals(List.of("turn://test.coturn.com?transport=tcp"), iceMap.get("urls"));
   }

--- a/src/test/java/com/faforever/client/game/GameServiceTest.java
+++ b/src/test/java/com/faforever/client/game/GameServiceTest.java
@@ -186,7 +186,7 @@ public class GameServiceTest extends ServiceTest {
 
     when(fxApplicationThreadExecutor.asScheduler()).thenReturn(Schedulers.immediate());
     when(fafServerAccessor.getEvents(GameInfo.class)).thenReturn(testPublisher.flux());
-    when(coturnService.getSelectedCoturns()).thenReturn(completedFuture(List.of()));
+    when(coturnService.getSelectedCoturns(anyInt())).thenReturn(completedFuture(List.of()));
     when(preferencesService.isValidGamePath()).thenReturn(true);
     when(fafServerAccessor.connectionStateProperty()).thenReturn(new SimpleObjectProperty<>());
     when(replayServer.start(anyInt(), any())).thenReturn(completedFuture(LOCAL_REPLAY_PORT));

--- a/src/test/java/com/faforever/client/preferences/ui/SettingsControllerTest.java
+++ b/src/test/java/com/faforever/client/preferences/ui/SettingsControllerTest.java
@@ -129,7 +129,7 @@ public class SettingsControllerTest extends PlatformTest {
     availableLanguages = new SimpleSetProperty<>(FXCollections.observableSet());
     when(i18n.getAvailableLanguages()).thenReturn(new ReadOnlySetWrapper<>(availableLanguages));
 
-    instance = new SettingsController(notificationService, loginService, preferenceService, uiService, i18n, eventBus, platformService, clientProperties, clientUpdateService, taskService, coturnService, iceServerMapper, vaultPathHandler, preferences, moveDirectoryTaskFactory, deleteDirectoryTaskFactory, downloadFAFDebuggerTaskFactory, fxApplicationThreadExecutor);
+    instance = new SettingsController(notificationService, loginService, preferenceService, uiService, i18n, eventBus, platformService, clientProperties, clientUpdateService, taskService, coturnService, vaultPathHandler, preferences, moveDirectoryTaskFactory, deleteDirectoryTaskFactory, downloadFAFDebuggerTaskFactory, fxApplicationThreadExecutor);
 
     loadFxml("theme/settings/settings.fxml", param -> instance);
   }

--- a/src/test/java/com/faforever/client/preferences/ui/SettingsControllerTest.java
+++ b/src/test/java/com/faforever/client/preferences/ui/SettingsControllerTest.java
@@ -1,5 +1,6 @@
 package com.faforever.client.preferences.ui;
 
+import com.faforever.client.api.IceServer;
 import com.faforever.client.config.ClientProperties;
 import com.faforever.client.fa.debugger.DownloadFAFDebuggerTask;
 import com.faforever.client.fa.relay.ice.CoturnService;
@@ -27,7 +28,6 @@ import com.faforever.client.theme.UiService;
 import com.faforever.client.ui.preferences.event.GameDirectoryChooseEvent;
 import com.faforever.client.update.ClientUpdateService;
 import com.faforever.client.user.LoginService;
-import com.faforever.commons.api.dto.CoturnServer;
 import com.google.common.eventbus.EventBus;
 import javafx.beans.property.ReadOnlySetWrapper;
 import javafx.beans.property.SimpleObjectProperty;
@@ -122,9 +122,7 @@ public class SettingsControllerTest extends PlatformTest {
     when(uiService.currentThemeProperty()).thenReturn(new SimpleObjectProperty<>());
     when(uiService.getCurrentTheme()).thenReturn(FIRST_THEME);
     when(uiService.getAvailableThemes()).thenReturn(Arrays.asList(FIRST_THEME, SECOND_THEME));
-    CoturnServer coturnServer = new CoturnServer();
-    coturnServer.setId("0");
-    coturnServer.setRegion("Test");
+    IceServer coturnServer = new IceServer("0", "Test");
     when(coturnService.getActiveCoturns()).thenReturn(CompletableFuture.completedFuture(List.of(coturnServer)));
     when(gameService.isGamePrefsPatchedToAllowMultiInstances()).thenReturn(CompletableFuture.completedFuture(true));
 


### PR DESCRIPTION
Right now this is an MVP approach for fast testing. The turn selection window still loads the old API and no longer makes sense, because we might want to use Xirsys for everyone. Needs more thought once DDoS is resolved.