### PR TITLE
Copy map name in replay detail screen only

### DIFF
--- a/src/main/java/com/faforever/client/replay/ReplayDetailController.java
+++ b/src/main/java/com/faforever/client/replay/ReplayDetailController.java
@@ -227,7 +227,6 @@ public class ReplayDetailController extends NodeController<Node> {
     onMapLabel.textProperty()
               .bind(mapVersionObservable.flatMap(MapVersionBean::mapProperty)
                                         .flatMap(MapBean::displayNameProperty)
-                                        .map(displayName -> i18n.get("game.onMapFormat", displayName))
                                         .orElse(i18n.get("game.onUnknownMap"))
                                         .when(showing));
     durationLabel.visibleProperty()


### PR DESCRIPTION
Fix #2959 

Only copy the map name by removing the 'on' part. I don't know if this makes the most sense as it doesn't match the style in other windows (for example the 'FAF Replays' tab under Replays)  but it also looks nice. 



