### PR TITLE
Login page minimal size set

### DIFF
--- a/src/main/resources/theme/login/login.fxml
+++ b/src/main/resources/theme/login/login.fxml
@@ -16,7 +16,7 @@
 <?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
 <VBox fx:id="loginRoot" alignment="CENTER" spacing="20.0" styleClass="login-root" xmlns="http://javafx.com/javafx/15"
-      xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.faforever.client.login.LoginController">
+      xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.faforever.client.login.LoginController" minWidth="850" minHeight="400">
     <children>
         <VBox fx:id="messagesContainer" alignment="CENTER" maxWidth="500.0" prefWidth="500.0" spacing="5.0"/>
         <Pane maxHeight="1.7976931348623157E308" minHeight="0.0" VBox.vgrow="ALWAYS"/>


### PR DESCRIPTION
There was an issue - https://github.com/FAForever/downlords-faf-client/issues/2993 , where some users were having issue with login page being reset to very small size dimensions.
Set dim 850 width, 400 Height. It could go lower. However, in situation ,when an user gets error message, it will be hardly readable. This could somehow cover it.

Unfortunately, this solves after-effects not the root of cause. Hopefully, it was happening as side effect of update ...