### PR TITLE
basic UI scaling fix: 1.25x, 1.5x, 1.75x

### DIFF
--- a/src/main/java/com/faforever/client/teammatchmaking/TeamMatchmakingMapListController.java
+++ b/src/main/java/com/faforever/client/teammatchmaking/TeamMatchmakingMapListController.java
@@ -19,7 +19,6 @@ import javafx.beans.property.SimpleIntegerProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.value.ObservableValue;
 import javafx.scene.control.ScrollPane;
-import javafx.scene.layout.Region;
 import javafx.scene.layout.TilePane;
 import javafx.scene.layout.Pane;
 import javafx.scene.layout.VBox;
@@ -29,7 +28,6 @@ import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
-import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -91,18 +89,14 @@ public class TeamMatchmakingMapListController extends NodeController<Pane> {
 
   private void bindProperties() {
     JavaFxUtil.bindManagedToVisible(loadingPane);
+    tilesContainer.getChildren().subscribe(()->this.loadingPane.setVisible(false));
 
     this.queue.when(showing).subscribe(value -> {
       if (value == null) {
         return;
       }
       loadingPane.setVisible(true);
-      mapService.getMatchmakerBrackets(value).subscribe(rawBrackets -> {
-        loadingPane.setVisible(false);
-        this.scrollContainer.setPrefWidth(Region.USE_COMPUTED_SIZE);
-        this.scrollContainer.setPrefHeight(Region.USE_COMPUTED_SIZE);
-        this.brackets.set(rawBrackets);
-      });
+      mapService.getMatchmakerBrackets(value).subscribe(this.brackets::set);
     });
 
     playerRating.bind(playerService.currentPlayerProperty()

--- a/src/main/java/com/faforever/client/teammatchmaking/TeamMatchmakingMapListController.java
+++ b/src/main/java/com/faforever/client/teammatchmaking/TeamMatchmakingMapListController.java
@@ -19,8 +19,8 @@ import javafx.beans.property.SimpleIntegerProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.value.ObservableValue;
 import javafx.scene.control.ScrollPane;
-import javafx.scene.layout.TilePane;
 import javafx.scene.layout.Pane;
+import javafx.scene.layout.TilePane;
 import javafx.scene.layout.VBox;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -106,10 +106,14 @@ public class TeamMatchmakingMapListController extends NodeController<Pane> {
                                    .orElse(0)
                                    .when(showing));
 
-    this.maxWidth.subscribe(this::resizeToContent);
-    this.maxHeight.subscribe(this::resizeToContent);
     this.sortedMaps.when(showing).subscribe(this::updateContent);
     this.playerBracketIndex.when(showing).subscribe(this::updateContent);
+  }
+
+  @Override
+  protected void onShow() {
+    addShownSubscription(this.maxWidth.subscribe(this::resizeToContent));
+    addShownSubscription(this.maxHeight.subscribe(this::resizeToContent));
   }
 
   @Override

--- a/src/main/resources/theme/play/teammatchmaking/matchmaking_maplist_popup.fxml
+++ b/src/main/resources/theme/play/teammatchmaking/matchmaking_maplist_popup.fxml
@@ -8,7 +8,7 @@
 <?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.TilePane?>
 <VBox xmlns:fx="http://javafx.com/fxml/1" fx:id="root" styleClass="tmm-maplist" fx:controller="com.faforever.client.teammatchmaking.TeamMatchmakingMapListController">
-    <ScrollPane fx:id="scrollContainer" prefHeight="530" prefWidth="530" hbarPolicy="NEVER">
+    <ScrollPane fx:id="scrollContainer" hbarPolicy="NEVER">
         <StackPane styleClass="tmm-maplist-inner">
             <VBox prefWidth="530" prefHeight="530" fx:id="loadingPane" alignment="CENTER" maxHeight="1.7976931348623157E308"
                   maxWidth="1.7976931348623157E308" mouseTransparent="true" spacing="10.0">

--- a/src/main/resources/theme/play/teammatchmaking/matchmaking_maplist_popup.fxml
+++ b/src/main/resources/theme/play/teammatchmaking/matchmaking_maplist_popup.fxml
@@ -2,14 +2,14 @@
 
 <?import javafx.scene.layout.VBox?>
 <?import javafx.scene.control.ScrollPane?>
-<?import javafx.scene.layout.FlowPane?>
 
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.control.ProgressIndicator?>
 <?import javafx.scene.layout.StackPane?>
+<?import javafx.scene.layout.TilePane?>
 <VBox xmlns:fx="http://javafx.com/fxml/1" fx:id="root" styleClass="tmm-maplist" fx:controller="com.faforever.client.teammatchmaking.TeamMatchmakingMapListController">
-    <ScrollPane fx:id="scrollContainer" prefHeight="530" prefWidth="530">
-        <StackPane>
+    <ScrollPane fx:id="scrollContainer" prefHeight="530" prefWidth="530" hbarPolicy="NEVER">
+        <StackPane styleClass="tmm-maplist-inner">
             <VBox prefWidth="530" prefHeight="530" fx:id="loadingPane" alignment="CENTER" maxHeight="1.7976931348623157E308"
                   maxWidth="1.7976931348623157E308" mouseTransparent="true" spacing="10.0">
                 <Label contentDisplay="TOP" text="%loading">
@@ -18,7 +18,7 @@
                     </graphic>
                 </Label>
             </VBox>
-            <FlowPane fx:id="tilesContainer" vgap="10" hgap="10"/>
+            <TilePane fx:id="tilesContainer"  vgap="10" hgap="10" />
         </StackPane>
     </ScrollPane>
 </VBox>

--- a/src/main/resources/theme/style.css
+++ b/src/main/resources/theme/style.css
@@ -1131,9 +1131,12 @@
 }
 
 .tmm-maplist {
- -fx-padding: 20 20 20 20; //related to PADDING constant, do not change without adjusting it
+ -fx-padding: 20 8 20 20; //related to PADDING constant, do not change without adjusting it
 }
 
+.tmm-maplist-inner {
+ -fx-padding: 0 12 0 0; //related to PADDING constant, do not change without adjusting it
+}
 
 /***************** Faction buttons *****************/
 


### PR DESCRIPTION
Resolves issue when popup had wrong size when UI scaling is enabled:
![image](https://github.com/FAForever/downlords-faf-client/assets/55841348/d300d516-20a2-48b6-b8c3-d59095188133)

I did not find any meaningful explanation for the adjustment values which needed to be made. Probably some rounding error in javaFX, but maybe not.
Anyways, this works on 1.25x, 1.5x, 1.75x scaling and does nothing in any other case, so should be good enough.
