### PR TITLE
Remember last opened chat tab

### DIFF
--- a/src/main/java/com/faforever/client/chat/ChatController.java
+++ b/src/main/java/com/faforever/client/chat/ChatController.java
@@ -87,6 +87,7 @@ public class ChatController extends NodeController<AnchorPane> {
       connectingProgressPane.setVisible(false);
       tabPane.setVisible(false);
       openedTabs.removeIf(Tab::isClosable);
+      chatNavigation.clear();
     });
   }
 

--- a/src/main/java/com/faforever/client/chat/ChatController.java
+++ b/src/main/java/com/faforever/client/chat/ChatController.java
@@ -26,8 +26,6 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class ChatController extends NodeController<AnchorPane> {
 
-  public static String ADD_CHANNEL_TAB_ID = "_add_channel_tab_";
-
   private final ChatService chatService;
   private final UiService uiService;
   private final FxApplicationThreadExecutor fxApplicationThreadExecutor;
@@ -44,7 +42,6 @@ public class ChatController extends NodeController<AnchorPane> {
 
   public AnchorPane chatRoot;
   public TabPane tabPane;
-  public Tab addChannelTab;
   public Pane connectingProgressPane;
   public VBox noOpenTabsContainer;
   public TextField channelNameTextField;
@@ -55,14 +52,17 @@ public class ChatController extends NodeController<AnchorPane> {
   @Override
   protected void onInitialize() {
     super.onInitialize();
-    addChannelTab.setId(ADD_CHANNEL_TAB_ID);
     openedTabs = tabPane.getTabs();
 
     chatService.addChannelsListener(new WeakMapChangeListener<>(channelChangeListener));
     chatService.getChannels().forEach(this::onChannelJoined);
 
     chatService.connectionStateProperty().when(showing).subscribe(this::onConnectionStateChange);
-    tabPane.getSelectionModel().selectedItemProperty().subscribe(tab -> chatNavigation.setLastOpenedTabId(tab.getId()));
+    tabPane.getSelectionModel().selectedItemProperty().subscribe(tab -> {
+      if (tab.isClosable()) {
+        chatNavigation.setLastOpenedTabId(tab.getId());
+      }
+    });
   }
 
   private void onChannelLeft(ChatChannel chatChannel) {

--- a/src/main/java/com/faforever/client/chat/ChatController.java
+++ b/src/main/java/com/faforever/client/chat/ChatController.java
@@ -2,13 +2,11 @@ package com.faforever.client.chat;
 
 import com.faforever.client.exception.ProgrammingError;
 import com.faforever.client.fx.FxApplicationThreadExecutor;
-import com.faforever.client.fx.JavaFxUtil;
 import com.faforever.client.fx.NodeController;
 import com.faforever.client.net.ConnectionState;
 import com.faforever.client.theme.UiService;
-import javafx.collections.ListChangeListener;
 import javafx.collections.MapChangeListener;
-import javafx.collections.WeakListChangeListener;
+import javafx.collections.ObservableList;
 import javafx.collections.WeakMapChangeListener;
 import javafx.scene.control.Tab;
 import javafx.scene.control.TabPane;
@@ -22,25 +20,19 @@ import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
-import java.util.HashMap;
-import java.util.Map;
-
 @Slf4j
 @Component
 @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
 @RequiredArgsConstructor
 public class ChatController extends NodeController<AnchorPane> {
 
+  public static String ADD_CHANNEL_TAB_ID = "_add_channel_tab_";
+
   private final ChatService chatService;
   private final UiService uiService;
   private final FxApplicationThreadExecutor fxApplicationThreadExecutor;
+  private final ChatNavigation chatNavigation;
 
-  private final Map<ChatChannel, AbstractChatTabController> channelToChatTabController = new HashMap<>();
-  private final ListChangeListener<Tab> tabListChangeListener = change -> {
-    while (change.next()) {
-      change.getRemoved().forEach(tab -> channelToChatTabController.remove((ChatChannel) tab.getUserData()));
-    }
-  };
   private final MapChangeListener<String, ChatChannel> channelChangeListener = change -> {
     if (change.wasRemoved()) {
       onChannelLeft(change.getValueRemoved());
@@ -52,21 +44,25 @@ public class ChatController extends NodeController<AnchorPane> {
 
   public AnchorPane chatRoot;
   public TabPane tabPane;
+  public Tab addChannelTab;
   public Pane connectingProgressPane;
   public VBox noOpenTabsContainer;
   public TextField channelNameTextField;
   public VBox disconnectedPane;
 
+  private ObservableList<Tab> openedTabs;
+
   @Override
   protected void onInitialize() {
     super.onInitialize();
+    addChannelTab.setId(ADD_CHANNEL_TAB_ID);
+    openedTabs = tabPane.getTabs();
 
     chatService.addChannelsListener(new WeakMapChangeListener<>(channelChangeListener));
     chatService.getChannels().forEach(this::onChannelJoined);
 
     chatService.connectionStateProperty().when(showing).subscribe(this::onConnectionStateChange);
-
-    JavaFxUtil.addListener(tabPane.getTabs(), new WeakListChangeListener<>(tabListChangeListener));
+    tabPane.getSelectionModel().selectedItemProperty().subscribe(tab -> chatNavigation.setLastOpenedTabId(tab.getId()));
   }
 
   private void onChannelLeft(ChatChannel chatChannel) {
@@ -90,7 +86,7 @@ public class ChatController extends NodeController<AnchorPane> {
       disconnectedPane.setVisible(true);
       connectingProgressPane.setVisible(false);
       tabPane.setVisible(false);
-      tabPane.getTabs().removeIf(Tab::isClosable);
+      openedTabs.removeIf(Tab::isClosable);
     });
   }
 
@@ -112,40 +108,39 @@ public class ChatController extends NodeController<AnchorPane> {
   }
 
   private void removeTab(ChatChannel chatChannel) {
-    AbstractChatTabController controller = channelToChatTabController.remove(chatChannel);
-    if (controller != null) {
-      fxApplicationThreadExecutor.execute(() -> tabPane.getTabs().remove(controller.getRoot()));
-    }
+    fxApplicationThreadExecutor.execute(() -> {
+      String channelName = chatChannel.getName();
+      openedTabs.removeIf(tab -> channelName.equals(tab.getId()));
+      chatNavigation.removeTab(channelName);
+    });
   }
 
   private void addAndSelectTab(ChatChannel chatChannel) {
-    if (!channelToChatTabController.containsKey(chatChannel)) {
+    if (!containsTab(chatChannel)) {
       fxApplicationThreadExecutor.execute(() -> {
-        AbstractChatTabController tabController;
-        if (chatChannel.isPrivateChannel()) {
-          tabController = uiService.loadFxml("theme/chat/private_chat_tab.fxml");
-        } else {
-          tabController = uiService.loadFxml("theme/chat/channel_tab.fxml");
-        }
-        tabController.setChatChannel(chatChannel);
-        channelToChatTabController.put(chatChannel, tabController);
-        Tab tab = tabController.getRoot();
-        tab.setUserData(chatChannel);
+        Tab tab = createTab(chatChannel);
+        int index = chatService.isDefaultChannel(chatChannel) ? 0 : openedTabs.size() - 1; // Last index is `add channel` tab
+        openedTabs.add(index, tab);
 
-
-        if (chatService.isDefaultChannel(chatChannel)) {
-          tabPane.getTabs().addFirst(tab);
+        String channelName = chatChannel.getName();
+        if (chatNavigation.addTabIfMissing(channelName) || channelName.equals(chatNavigation.getLastOpenedTabId())) {
           tabPane.getSelectionModel().select(tab);
-        } else {
-          tabPane.getTabs().add(tabPane.getTabs().size() - 1, tab);
-
-          if (chatChannel.isPrivateChannel() || tabPane.getSelectionModel().getSelectedIndex() == tabPane.getTabs()
-                                                                                                         .size() - 1) {
-            tabPane.getSelectionModel().select(tab);
-          }
         }
       });
     }
+  }
+
+  private boolean containsTab(ChatChannel chatChannel) {
+    return openedTabs.stream().anyMatch(tab -> chatChannel.getName().equals(tab.getId()));
+  }
+
+  private Tab createTab(ChatChannel chatChannel) {
+    String fxmlFile = chatChannel.isPrivateChannel() ? "theme/chat/private_chat_tab.fxml" : "theme/chat/channel_tab.fxml";
+    AbstractChatTabController tabController = uiService.loadFxml(fxmlFile);
+    tabController.setChatChannel(chatChannel);
+    Tab tab = tabController.getRoot();
+    tab.setId(chatChannel.getName());
+    return tab;
   }
 
   private void onConnectionStateChange(ConnectionState newValue) {

--- a/src/main/java/com/faforever/client/chat/ChatMessageViewController.java
+++ b/src/main/java/com/faforever/client/chat/ChatMessageViewController.java
@@ -32,7 +32,6 @@ import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.VBox;
-import javafx.scene.web.WebView;
 import javafx.stage.Popup;
 import javafx.stage.PopupWindow.AnchorLocation;
 import lombok.RequiredArgsConstructor;
@@ -55,11 +54,6 @@ import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
-/**
- * A chat tab displays messages in a {@link WebView}. The WebView is used since text on a JavaFX canvas isn't
- * selectable, but text within a WebView is. This comes with some ugly implications; some logic has to be performed in
- * interaction with JavaScript, like when the user clicks a link.
- */
 @Slf4j
 @RequiredArgsConstructor
 @Component

--- a/src/main/java/com/faforever/client/chat/ChatNavigation.java
+++ b/src/main/java/com/faforever/client/chat/ChatNavigation.java
@@ -2,6 +2,7 @@ package com.faforever.client.chat;
 
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.Nullable;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
 
@@ -23,6 +24,7 @@ public class ChatNavigation { // TODO: Not a very good name of class
     currentTabs.removeIf(chatTab -> chatTab.getId().equals(tabId));
   }
 
+  @Nullable
   public String getLastOpenedTabId() {
     return currentTabs.stream().filter(ChatTab::isSelected).findFirst().map(ChatTab::getId).orElse(null);
   }
@@ -32,10 +34,6 @@ public class ChatNavigation { // TODO: Not a very good name of class
       return;
     }
 
-    currentTabs.stream()
-               .peek(chatTab -> chatTab.setSelected(false))
-               .filter(chatTab -> chatTab.getId().equals(tabId))
-               .findFirst()
-               .ifPresent(chatTab -> chatTab.setSelected(true));
+    currentTabs.forEach(tab -> tab.setSelected(tab.getId().equals(tabId)));
   }
 }

--- a/src/main/java/com/faforever/client/chat/ChatNavigation.java
+++ b/src/main/java/com/faforever/client/chat/ChatNavigation.java
@@ -1,7 +1,5 @@
 package com.faforever.client.chat;
 
-import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.Nullable;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
@@ -10,10 +8,8 @@ import java.util.LinkedHashSet;
 
 @Component
 @Lazy
-@Slf4j
 public class ChatNavigation { // TODO: Not a very good name of class
 
-  @Getter
   private final LinkedHashSet<ChatTab> currentTabs = new LinkedHashSet<>();
 
   public boolean addTabIfMissing(String tabId) {

--- a/src/main/java/com/faforever/client/chat/ChatNavigation.java
+++ b/src/main/java/com/faforever/client/chat/ChatNavigation.java
@@ -26,10 +26,6 @@ public class ChatNavigation {
   }
 
   public void setLastOpenedTabId(String tabId) {
-    if (ChatController.ADD_CHANNEL_TAB_ID.equals(tabId)) {
-      return;
-    }
-
     currentTabs.forEach(tab -> tab.setSelected(tab.getId().equals(tabId)));
   }
 

--- a/src/main/java/com/faforever/client/chat/ChatNavigation.java
+++ b/src/main/java/com/faforever/client/chat/ChatNavigation.java
@@ -1,0 +1,41 @@
+package com.faforever.client.chat;
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+
+import java.util.LinkedHashSet;
+
+@Component
+@Lazy
+@Slf4j
+public class ChatNavigation { // TODO: Not a very good name of class
+
+  @Getter
+  private final LinkedHashSet<ChatTab> currentTabs = new LinkedHashSet<>();
+
+  public boolean addTabIfMissing(String tabId) {
+    return currentTabs.add(new ChatTab(tabId));
+  }
+
+  public void removeTab(String tabId) {
+    currentTabs.removeIf(chatTab -> chatTab.getId().equals(tabId));
+  }
+
+  public String getLastOpenedTabId() {
+    return currentTabs.stream().filter(ChatTab::isSelected).findFirst().map(ChatTab::getId).orElse(null);
+  }
+
+  public void setLastOpenedTabId(String tabId) {
+    if (ChatController.ADD_CHANNEL_TAB_ID.equals(tabId)) {
+      return;
+    }
+
+    currentTabs.stream()
+               .peek(chatTab -> chatTab.setSelected(false))
+               .filter(chatTab -> chatTab.getId().equals(tabId))
+               .findFirst()
+               .ifPresent(chatTab -> chatTab.setSelected(true));
+  }
+}

--- a/src/main/java/com/faforever/client/chat/ChatNavigation.java
+++ b/src/main/java/com/faforever/client/chat/ChatNavigation.java
@@ -8,7 +8,7 @@ import java.util.LinkedHashSet;
 
 @Component
 @Lazy
-public class ChatNavigation { // TODO: Not a very good name of class
+public class ChatNavigation {
 
   private final LinkedHashSet<ChatTab> currentTabs = new LinkedHashSet<>();
 
@@ -31,5 +31,9 @@ public class ChatNavigation { // TODO: Not a very good name of class
     }
 
     currentTabs.forEach(tab -> tab.setSelected(tab.getId().equals(tabId)));
+  }
+
+  public void clear() {
+    currentTabs.clear();
   }
 }

--- a/src/main/java/com/faforever/client/chat/ChatTab.java
+++ b/src/main/java/com/faforever/client/chat/ChatTab.java
@@ -1,0 +1,17 @@
+package com.faforever.client.chat;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+@RequiredArgsConstructor
+@Getter
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+public class ChatTab {
+
+  @EqualsAndHashCode.Include
+  private final String id;
+  @Setter
+  private boolean selected;
+}

--- a/src/main/resources/theme/chat/chat.fxml
+++ b/src/main/resources/theme/chat/chat.fxml
@@ -14,7 +14,7 @@
     <children>
         <TabPane fx:id="tabPane" tabClosingPolicy="ALL_TABS" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0"
                  AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0" visible="false">
-            <Tab text="+" closable="false">
+            <Tab fx:id="addChannelTab" text="+" closable="false">
                 <VBox fx:id="noOpenTabsContainer" alignment="CENTER" fillWidth="false">
                     <children>
                         <Label styleClass="h2" text="%chat.joinAChannel">

--- a/src/main/resources/theme/chat/chat.fxml
+++ b/src/main/resources/theme/chat/chat.fxml
@@ -14,7 +14,7 @@
     <children>
         <TabPane fx:id="tabPane" tabClosingPolicy="ALL_TABS" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0"
                  AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0" visible="false">
-            <Tab fx:id="addChannelTab" text="+" closable="false">
+            <Tab text="+" closable="false">
                 <VBox fx:id="noOpenTabsContainer" alignment="CENTER" fillWidth="false">
                     <children>
                         <Label styleClass="h2" text="%chat.joinAChannel">

--- a/src/test/java/com/faforever/client/chat/ChatControllerTest.java
+++ b/src/test/java/com/faforever/client/chat/ChatControllerTest.java
@@ -23,6 +23,7 @@ import static javafx.collections.FXCollections.observableHashMap;
 import static javafx.collections.FXCollections.synchronizedObservableMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
@@ -124,6 +125,7 @@ public class ChatControllerTest extends PlatformTest {
     assertFalse(instance.connectingProgressPane.isVisible());
     assertFalse(instance.tabPane.isVisible());
     assertEquals(1, openedTabs.size());
+    assertNull(chatNavigation.getLastOpenedTabId());
   }
 
   @Test

--- a/src/test/java/com/faforever/client/chat/ChatControllerTest.java
+++ b/src/test/java/com/faforever/client/chat/ChatControllerTest.java
@@ -52,6 +52,8 @@ public class ChatControllerTest extends PlatformTest {
   private ChatService chatService;
   @Mock
   private NotificationService notificationService;
+  @Mock
+  private ChatNavigation chatNavigation;
   @Captor
   private ArgumentCaptor<MapChangeListener<String, ChatChannel>> channelsListener;
 

--- a/src/test/java/com/faforever/client/chat/ChatControllerTest.java
+++ b/src/test/java/com/faforever/client/chat/ChatControllerTest.java
@@ -1,145 +1,195 @@
 package com.faforever.client.chat;
 
 import com.faforever.client.net.ConnectionState;
-import com.faforever.client.notification.NotificationService;
 import com.faforever.client.test.PlatformTest;
 import com.faforever.client.theme.UiService;
-import com.faforever.client.user.LoginService;
-import com.faforever.commons.api.dto.MeResult;
-import javafx.beans.InvalidationListener;
+import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.collections.MapChangeListener;
+import javafx.collections.ObservableList;
+import javafx.collections.ObservableMap;
 import javafx.scene.control.Tab;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
+import java.util.Set;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasSize;
+import static javafx.collections.FXCollections.observableHashMap;
+import static javafx.collections.FXCollections.synchronizedObservableMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.doReturn;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-// TODO those unit tests need to be improved (missing verifications)
 public class ChatControllerTest extends PlatformTest {
 
-  public static final String TEST_USER_NAME = "junit";
-  private static final String TEST_CHANNEL_NAME = "#testChannel";
-
   @Mock
-  private ChannelTabController channelTabController;
-  @Mock
-  private PrivateChatTabController privateChatTabController;
-  @Mock
-  private LoginService loginService;
+  private AbstractChatTabController tabController;
   @Mock
   private UiService uiService;
   @Mock
   private ChatService chatService;
-  @Mock
-  private NotificationService notificationService;
-  @Mock
+  @Spy
   private ChatNavigation chatNavigation;
   @Captor
   private ArgumentCaptor<MapChangeListener<String, ChatChannel>> channelsListener;
+  private final ObservableMap<String, ChatChannel> channels = synchronizedObservableMap(observableHashMap());
 
+  private final ObjectProperty<ConnectionState> connectionState = new SimpleObjectProperty<>(ConnectionState.DISCONNECTED);
   @InjectMocks
   private ChatController instance;
-  private SimpleObjectProperty<ConnectionState> connectionState;
+  private ObservableList<Tab> openedTabs;
 
   @BeforeEach
   public void setUp() throws Exception {
-    connectionState = new SimpleObjectProperty<>(ConnectionState.DISCONNECTED);
-
-    lenient().when(uiService.loadFxml("theme/chat/private_chat_tab.fxml")).thenReturn(privateChatTabController);
-    lenient().when(uiService.loadFxml("theme/chat/channel_tab.fxml")).thenReturn(channelTabController);
-    lenient().when(loginService.getUsername()).thenReturn(TEST_USER_NAME);
-    lenient().when(loginService.getOwnUser()).thenReturn(new MeResult());
     lenient().when(chatService.connectionStateProperty()).thenReturn(connectionState);
+    lenient().when(uiService.loadFxml("theme/chat/private_chat_tab.fxml")).thenReturn(tabController);
+    lenient().when(uiService.loadFxml("theme/chat/channel_tab.fxml")).thenReturn(tabController);
+    lenient().when(tabController.getRoot()).thenAnswer(invocation -> new Tab());
+
 
     loadFxml("theme/chat/chat.fxml", clazz -> instance);
+    openedTabs = instance.tabPane.getTabs();
+  }
 
+  private void setChannelsListener() {
     verify(chatService).addChannelsListener(channelsListener.capture());
+    channels.addListener(channelsListener.getValue());
   }
 
   @Test
-  public void testOnDisconnected() throws Exception {
-    connectionState.set(ConnectionState.DISCONNECTED);
+  public void testOnlyOneAddChannelTabAfterInitialized() {
+    assertEquals(1, openedTabs.size());
+    assertEquals(ChatController.ADD_CHANNEL_TAB_ID, openedTabs.getFirst().getId());
   }
 
   @Test
-  public void testGetRoot() throws Exception {
-    assertThat(instance.getRoot(), is(instance.chatRoot));
-    assertThat(instance.getRoot().getParent(), is(nullValue()));
+  public void testOnChannelJoined() {
+    setChannelsListener();
+
+    requestChannel("aeolus", true);
+    requestChannel("channel");
+    requestChannel("player");
+
+    assertContainsTab("aeolus");
+    assertContainsTab("channel");
+    assertContainsTab("player");
   }
 
   @Test
-  public void testOnChannelsJoinedRequest() throws Exception {
-    channelJoined(TEST_CHANNEL_NAME);
+  public void testAddedTabShouldBeSelected() {
+    setChannelsListener();
+    requestChannel("channel");
 
-    connectionState.set(ConnectionState.DISCONNECTED);
-  }
-
-  private void channelJoined(String channel) {
-    MapChangeListener.Change<? extends String, ? extends ChatChannel> testChannelChange = mock(MapChangeListener.Change.class);
-    channelsListener.getValue().onChanged(testChannelChange);
+    assertEquals("channel", chatNavigation.getLastOpenedTabId());
+    assertEquals("channel", instance.tabPane.getSelectionModel().getSelectedItem().getId());
   }
 
   @Test
-  @Disabled("Flaky test")
-  public void testOnJoinChannelButtonClicked() throws Exception {
-    assertEquals(instance.tabPane.getTabs().size(), 1);
+  public void testSelectedTabShouldBeRemembered() {
+    setChannelsListener();
+    requestChannel("channel1");
+    requestChannel("channel2");
 
-    Tab tab = new Tab();
-    tab.setId(TEST_CHANNEL_NAME);
+    assertEquals("channel2", chatNavigation.getLastOpenedTabId());
+    assertEquals("channel2", instance.tabPane.getSelectionModel().getSelectedItem().getId());
 
-    when(channelTabController.getRoot()).thenReturn(tab);
-    when(loginService.getUsername()).thenReturn(TEST_USER_NAME);
-    doAnswer(invocation -> {
-      MapChangeListener.Change<? extends String, ? extends ChatChannel> change = mock(MapChangeListener.Change.class);
-      when(change.wasAdded()).thenReturn(true);
-      doReturn(new ChatChannel(invocation.getArgument(0))).when(change).getValueAdded();
-      channelsListener.getValue().onChanged(change);
-      return null;
-    }).when(chatService).joinChannel(anyString());
+    runOnFxThreadAndWait(() -> instance.tabPane.getSelectionModel().selectPrevious());
 
-    instance.channelNameTextField.setText(TEST_CHANNEL_NAME);
-    instance.onJoinChannelButtonClicked();
+    assertEquals("channel1", chatNavigation.getLastOpenedTabId());
+    assertEquals("channel1", instance.tabPane.getSelectionModel().getSelectedItem().getId());
+  }
 
-    verify(chatService).joinChannel(TEST_CHANNEL_NAME);
-
-    CountDownLatch tabAddedLatch = new CountDownLatch(1);
-    instance.tabPane.getTabs().addListener((InvalidationListener) observable -> tabAddedLatch.countDown());
-    tabAddedLatch.await(2, TimeUnit.SECONDS);
-
-    assertThat(instance.tabPane.getTabs(), hasSize(2));
-    assertThat(instance.tabPane.getTabs().getFirst().getId(), is(TEST_CHANNEL_NAME));
+  private void assertContainsTab(String channel) {
+    assertTrue(openedTabs.stream().anyMatch(tab -> tab.getId().equals(channel)));
   }
 
   @Test
-  public void testOnJoinChannelButtonClickedInvalidChannel() throws Exception {
-    assertEquals(instance.tabPane.getTabs().size(), 1);
+  public void testOnDisconnected() {
+    setChannelsListener();
 
-    Tab tab = new Tab();
-    tab.setId(TEST_CHANNEL_NAME);
+    connectionState.set(ConnectionState.CONNECTED);
+    requestChannel("aeolus", true);
 
-    instance.channelNameTextField.setText(TEST_CHANNEL_NAME.replace("#", ""));
-    instance.onJoinChannelButtonClicked();
+    runOnFxThreadAndWait(() -> connectionState.set(ConnectionState.DISCONNECTED));
+    assertTrue(instance.disconnectedPane.isVisible());
+    assertFalse(instance.connectingProgressPane.isVisible());
+    assertFalse(instance.tabPane.isVisible());
+    assertEquals(1, openedTabs.size());
+  }
 
-    verify(chatService).joinChannel(TEST_CHANNEL_NAME);
+  @Test
+  public void testOnConnected() {
+    assertEquals(ConnectionState.DISCONNECTED, connectionState.getValue());
+
+    ChatChannel chatChannelMock1 = mock(ChatChannel.class);
+    ChatChannel chatChannelMock2 = mock(ChatChannel.class);
+    when(chatChannelMock1.getName()).thenReturn("1");
+    when(chatChannelMock2.getName()).thenReturn("2");
+    when(chatService.getChannels()).thenReturn(Set.of(chatChannelMock1, chatChannelMock2));
+
+    runOnFxThreadAndWait(() -> connectionState.set(ConnectionState.CONNECTED));
+
+    assertFalse(instance.disconnectedPane.isVisible());
+    assertFalse(instance.connectingProgressPane.isVisible());
+    assertTrue(instance.tabPane.isVisible());
+    assertEquals(3, openedTabs.size());
+  }
+
+  @Test
+  public void testOnConnecting() {
+    assertEquals(ConnectionState.DISCONNECTED, connectionState.getValue());
+    runOnFxThreadAndWait(() -> connectionState.set(ConnectionState.CONNECTING));
+    assertFalse(instance.disconnectedPane.isVisible());
+    assertTrue(instance.connectingProgressPane.isVisible());
+    assertFalse(instance.tabPane.isVisible());
+  }
+
+  private void requestChannel(String channel) {
+    requestChannel(channel, false);
+  }
+
+  private void requestChannel(String channel, boolean isDefaultChannel) {
+    ChatChannel chatChannelMock = mock(ChatChannel.class);
+    when(chatChannelMock.getName()).thenReturn(channel);
+    when(chatService.isDefaultChannel(chatChannelMock)).thenReturn(isDefaultChannel);
+    channels.putIfAbsent(channel, chatChannelMock);
+    waitFxEvents();
+  }
+
+  @Test
+  public void testOnChannelLeft() {
+    setChannelsListener();
+    requestChannel("aeolus", true);
+    requestChannel("channel", false);
+
+    Tab tab = openedTabs.stream().filter(tab1 -> tab1.getId().equals("aeolus")).findFirst().orElseThrow();
+    runOnFxThreadAndWait(() -> openedTabs.remove(tab));
+    assertEquals(2, openedTabs.size());
+  }
+
+  @Test
+  public void testOnJoinChannelButtonClicked() {
+    runOnFxThreadAndWait(() -> {
+      instance.channelNameTextField.setText("newChannel");
+      instance.onJoinChannelButtonClicked();
+    });
+
+    verify(chatService).joinChannel("#newChannel");
+    assertTrue(instance.channelNameTextField.getText().isEmpty());
+  }
+
+  @Test
+  public void testOnConnectButtonClicked() {
+    runOnFxThreadAndWait(() -> instance.onConnectButtonClicked());
+    verify(chatService).connect();
   }
 }

--- a/src/test/java/com/faforever/client/chat/ChatControllerTest.java
+++ b/src/test/java/com/faforever/client/chat/ChatControllerTest.java
@@ -69,7 +69,7 @@ public class ChatControllerTest extends PlatformTest {
   @Test
   public void testOnlyOneAddChannelTabAfterInitialized() {
     assertEquals(1, openedTabs.size());
-    assertEquals(ChatController.ADD_CHANNEL_TAB_ID, openedTabs.getFirst().getId());
+    assertFalse(openedTabs.getFirst().isClosable());
   }
 
   @Test

--- a/src/test/java/com/faforever/client/test/PlatformTest.java
+++ b/src/test/java/com/faforever/client/test/PlatformTest.java
@@ -115,6 +115,10 @@ public abstract class PlatformTest {
 
   protected void runOnFxThreadAndWait(Runnable runnable) {
     Platform.runLater(runnable);
+    waitFxEvents();
+  }
+
+  protected void waitFxEvents() {
     WaitForAsyncUtils.waitForFxEvents();
   }
 


### PR DESCRIPTION
Since the main tabs are now recreated with each click, the last opened chat tab of the channel or player is no longer remembered.
This pull request will help bring this feature back.