### PR TITLE
Turn settings window into a proper modal.

### DIFF
--- a/src/main/java/com/faforever/client/headerbar/MainMenuButtonController.java
+++ b/src/main/java/com/faforever/client/headerbar/MainMenuButtonController.java
@@ -12,6 +12,7 @@ import com.faforever.client.theme.ThemeService;
 import com.faforever.client.theme.UiService;
 import com.faforever.client.ui.StageHolder;
 import javafx.scene.control.MenuButton;
+import javafx.stage.Modality;
 import javafx.stage.Stage;
 import javafx.stage.WindowEvent;
 import lombok.RequiredArgsConstructor;
@@ -73,12 +74,13 @@ public class MainMenuButtonController {
     SettingsController settingsController = uiService.loadFxml("theme/settings/settings.fxml");
     FxStage fxStage = FxStage.create(settingsController.getRoot())
         .initOwner(menuButton.getScene().getWindow())
-                             .withSceneFactory(themeService::createScene)
+        .withSceneFactory(themeService::createScene)
         .allowMinimize(false)
         .apply()
         .setTitleBar(settingsController.settingsHeader);
 
     Stage stage = fxStage.getStage();
+    stage.initModality(Modality.WINDOW_MODAL);
 
     stage.setTitle(i18n.get("settings.windowTitle"));
     stage.show();


### PR DESCRIPTION
Simple one line change to turn the settings window into a modal.
This will prevent it from being opened multiple times at the same time.
This will prevent interaction with the rest of the client while it is active.

Fixes issue https://github.com/FAForever/downlords-faf-client/issues/3215