### PR TITLE
Wait for map generator options longer

### DIFF
--- a/src/main/java/com/faforever/client/map/generator/GeneratorOptionsTask.java
+++ b/src/main/java/com/faforever/client/map/generator/GeneratorOptionsTask.java
@@ -74,7 +74,7 @@ public class GeneratorOptionsTask extends CompletableTask<List<String>> {
         }
       });
       OsUtils.gobbleLines(process.getErrorStream(), generatorLogger::error);
-      process.waitFor(2, TimeUnit.SECONDS);
+      process.waitFor(6, TimeUnit.SECONDS);
       if (process.isAlive()) {
         process.destroyForcibly();
         log.warn("Map generator option run timed out");


### PR DESCRIPTION
I saw that some other people were also having the issue when all of the MapGen options, that are taken from the MapGen itself by running dedicated commands, were not present with only `RANDOM` being available.
Looks like the reason is that `GeneratorOptionsTask` can't make it in only 2 seconds

I reliably received MapGen options multiple times by running the client with a 6-seconds GeneratorOptionsTask's process timeout on the 1.5 GHz processor in a VM on HDD

Maybe in some cases 6 is also not enough, but at least it is known now what needs to be tweaked