### PR TITLE
Live Replay Setting

### DIFF
--- a/src/main/java/com/faforever/client/config/PreferencesConfig.java
+++ b/src/main/java/com/faforever/client/config/PreferencesConfig.java
@@ -10,6 +10,7 @@ import com.faforever.client.preferences.ForgedAlliancePrefs;
 import com.faforever.client.preferences.GeneralPrefs;
 import com.faforever.client.preferences.GeneratorPrefs;
 import com.faforever.client.preferences.LastGamePrefs;
+import com.faforever.client.preferences.LiveReplaySearchPrefs;
 import com.faforever.client.preferences.LocalizationPrefs;
 import com.faforever.client.preferences.LoginPrefs;
 import com.faforever.client.preferences.MatchmakerPrefs;
@@ -152,6 +153,11 @@ public class PreferencesConfig implements DisposableBean {
   @Bean
   public VaultPrefs vault() {
     return preferences().getVault();
+  }
+
+  @Bean
+  public LiveReplaySearchPrefs liveReplaySearchPrefs() {
+    return preferences().getVault().getLiveReplaySearch();
   }
 
   @Bean

--- a/src/main/java/com/faforever/client/filter/LiveGamesFilterController.java
+++ b/src/main/java/com/faforever/client/filter/LiveGamesFilterController.java
@@ -11,7 +11,7 @@ import com.faforever.client.fx.ToStringOnlyConverter;
 import com.faforever.client.i18n.I18n;
 import com.faforever.client.map.generator.MapGeneratorService;
 import com.faforever.client.player.PlayerService;
-import com.faforever.client.preferences.Preferences;
+import com.faforever.client.preferences.LiveReplaySearchPrefs;
 import com.faforever.client.social.SocialService;
 import com.faforever.client.theme.UiService;
 import com.faforever.commons.lobby.GameType;
@@ -33,7 +33,8 @@ public class LiveGamesFilterController extends AbstractFilterController<GameInfo
   private final PlayerService playerService;
   private final FeaturedModService featuredModService;
   private final MapGeneratorService mapGeneratorService;
-  private final Preferences preferences;
+
+  private final LiveReplaySearchPrefs liveReplaySearchPrefs;
 
   private FilterCheckboxController<GameInfo> hideModdedGamesFilter;
   private FilterCheckboxController<GameInfo> hideSingleGamesFilter;
@@ -51,13 +52,13 @@ public class LiveGamesFilterController extends AbstractFilterController<GameInfo
                                    MapGeneratorService mapGeneratorService,
                                    FxApplicationThreadExecutor fxApplicationThreadExecutor,
                                    SocialService socialService,
-                                   Preferences preferences) {
+                                   LiveReplaySearchPrefs liveReplaySearchPrefs) {
     super(uiService, i18n, fxApplicationThreadExecutor);
     this.featuredModService = featuredModService;
     this.playerService = playerService;
     this.mapGeneratorService = mapGeneratorService;
     this.socialService = socialService;
-    this.preferences = preferences;
+    this.liveReplaySearchPrefs = liveReplaySearchPrefs;
   }
 
   @Override
@@ -112,13 +113,13 @@ public class LiveGamesFilterController extends AbstractFilterController<GameInfo
 
   @Override
   protected void afterBuilt() {
-    hideModdedGamesFilter.valueProperty().bindBidirectional(preferences.getVault().getLiveReplaySearch().getHideModdedGames());
-    hideSingleGamesFilter.valueProperty().bindBidirectional(preferences.getVault().getLiveReplaySearch().getHideSingleGames());
-    onlyGamesWithFriendsFilter.valueProperty().bindBidirectional(preferences.getVault().getLiveReplaySearch().getOnlyGamesWithFriends());
-    onlyGeneratedMapsFilter.valueProperty().bindBidirectional(preferences.getVault().getLiveReplaySearch().getOnlyGeneratedMaps());
-    gameTypeFilter.valueProperty().bindBidirectional(preferences.getVault().getLiveReplaySearch().getGameTypes());
-    featuredModFilter.valueProperty().bindBidirectional(preferences.getVault().getLiveReplaySearch().getModName());
-    playerFilter.valueProperty().bindBidirectional(preferences.getVault().getLiveReplaySearch().getPlayerName());
+    hideModdedGamesFilter.valueProperty().bindBidirectional(liveReplaySearchPrefs.hideModdedGamesProperty());
+    hideSingleGamesFilter.valueProperty().bindBidirectional(liveReplaySearchPrefs.hideSingleGamesProperty());
+    onlyGamesWithFriendsFilter.valueProperty().bindBidirectional(liveReplaySearchPrefs.onlyGamesWithFriendsProperty());
+    onlyGeneratedMapsFilter.valueProperty().bindBidirectional(liveReplaySearchPrefs.onlyGeneratedMapsProperty());
+    gameTypeFilter.valueProperty().bindBidirectional(liveReplaySearchPrefs.gameTypesProperty());
+    featuredModFilter.valueProperty().bindBidirectional(liveReplaySearchPrefs.modNameProperty());
+    playerFilter.valueProperty().bindBidirectional(liveReplaySearchPrefs.playerNameProperty());
   }
 
 }

--- a/src/main/java/com/faforever/client/filter/LiveGamesFilterController.java
+++ b/src/main/java/com/faforever/client/filter/LiveGamesFilterController.java
@@ -120,7 +120,6 @@ public class LiveGamesFilterController extends AbstractFilterController<GameInfo
     gameTypeFilter.valueProperty().bindBidirectional(liveReplaySearchPrefs.gameTypesProperty());
     featuredModFilter.valueProperty().bindBidirectional(liveReplaySearchPrefs.modNameProperty());
     playerFilter.valueProperty().bindBidirectional(liveReplaySearchPrefs.playerNameProperty());
-
   }
 
 }

--- a/src/main/java/com/faforever/client/filter/LiveGamesFilterController.java
+++ b/src/main/java/com/faforever/client/filter/LiveGamesFilterController.java
@@ -120,6 +120,7 @@ public class LiveGamesFilterController extends AbstractFilterController<GameInfo
     gameTypeFilter.valueProperty().bindBidirectional(liveReplaySearchPrefs.gameTypesProperty());
     featuredModFilter.valueProperty().bindBidirectional(liveReplaySearchPrefs.modNameProperty());
     playerFilter.valueProperty().bindBidirectional(liveReplaySearchPrefs.playerNameProperty());
+
   }
 
 }

--- a/src/main/java/com/faforever/client/filter/LiveGamesFilterController.java
+++ b/src/main/java/com/faforever/client/filter/LiveGamesFilterController.java
@@ -11,6 +11,7 @@ import com.faforever.client.fx.ToStringOnlyConverter;
 import com.faforever.client.i18n.I18n;
 import com.faforever.client.map.generator.MapGeneratorService;
 import com.faforever.client.player.PlayerService;
+import com.faforever.client.preferences.Preferences;
 import com.faforever.client.social.SocialService;
 import com.faforever.client.theme.UiService;
 import com.faforever.commons.lobby.GameType;
@@ -32,40 +33,58 @@ public class LiveGamesFilterController extends AbstractFilterController<GameInfo
   private final PlayerService playerService;
   private final FeaturedModService featuredModService;
   private final MapGeneratorService mapGeneratorService;
+  private final Preferences preferences;
+
+  private FilterCheckboxController<GameInfo> hideModdedGamesFilter;
+  private FilterCheckboxController<GameInfo> hideSingleGamesFilter;
+  private FilterCheckboxController<GameInfo> onlyGamesWithFriendsFilter;
+  private FilterCheckboxController<GameInfo> onlyGeneratedMapsFilter;
+
+  private FilterMultiCheckboxController<GameType,GameInfo> gameTypeFilter;
+  private FilterMultiCheckboxController<FeaturedMod, GameInfo> featuredModFilter;
+
+  private FilterTextFieldController<GameInfo> playerFilter;
+
 
   public LiveGamesFilterController(UiService uiService, I18n i18n, FeaturedModService featuredModService,
                                    PlayerService playerService,
                                    MapGeneratorService mapGeneratorService,
                                    FxApplicationThreadExecutor fxApplicationThreadExecutor,
-                                   SocialService socialService) {
+                                   SocialService socialService,
+                                   Preferences preferences) {
     super(uiService, i18n, fxApplicationThreadExecutor);
     this.featuredModService = featuredModService;
     this.playerService = playerService;
     this.mapGeneratorService = mapGeneratorService;
     this.socialService = socialService;
+    this.preferences = preferences;
   }
 
   @Override
   protected void build(FilterBuilder<GameInfo> filterBuilder) {
-    filterBuilder.checkbox(i18n.get("moddedGames"), new SimModsFilterFunction());
+    hideModdedGamesFilter = filterBuilder.checkbox(i18n.get("moddedGames"), new SimModsFilterFunction());
 
-    filterBuilder.checkbox(i18n.get("hideSingleGames"), (selected, game) -> !selected || game.getNumActivePlayers() != 1);
+    hideSingleGamesFilter = filterBuilder.checkbox(i18n.get("hideSingleGames"),
+                                                   (selected, game) -> !selected || game.getNumActivePlayers() != 1);
 
-    filterBuilder.checkbox(i18n.get("showGamesWithFriends"),
-                           (selected, game) -> !selected || socialService.areFriendsInGame(game));
+    onlyGamesWithFriendsFilter = filterBuilder.checkbox(i18n.get("showGamesWithFriends"),
+                                                        (selected, game) -> !selected || socialService.areFriendsInGame(
+                                                        game));
 
-    filterBuilder.checkbox(i18n.get("showGeneratedMaps"), (selected, game) -> !selected || mapGeneratorService.isGeneratedMap(game.getMapFolderName()));
+    onlyGeneratedMapsFilter = filterBuilder.checkbox(i18n.get("showGeneratedMaps"),
+                                                     (selected, game) -> !selected || mapGeneratorService.isGeneratedMap(
+                                                   game.getMapFolderName()));
 
-    filterBuilder.multiCheckbox(i18n.get("gameType"), List.of(GameType.CUSTOM, GameType.MATCHMAKER, GameType.COOP), gameTypeConverter,
+    gameTypeFilter = filterBuilder.multiCheckbox(i18n.get("gameType"), List.of(GameType.CUSTOM, GameType.MATCHMAKER, GameType.COOP), gameTypeConverter,
         (selectedGameTypes, game) -> selectedGameTypes.isEmpty() || selectedGameTypes.contains(game.getGameType()));
 
-    FilterMultiCheckboxController<FeaturedMod, GameInfo> featuredModFilter = filterBuilder.multiCheckbox(
+    featuredModFilter = filterBuilder.multiCheckbox(
         i18n.get("featuredMod.displayName"), new ToStringOnlyConverter<>(FeaturedMod::displayName),
         new FeaturedModFilterFunction());
 
     featuredModService.getFeaturedMods().collectList().subscribe(featuredModFilter::setItems);
 
-    filterBuilder.textField(i18n.get("game.player.username"), (text, game) -> text.isEmpty() || game.getTeams()
+    playerFilter = filterBuilder.textField(i18n.get("game.player.username"), (text, game) -> text.isEmpty() || game.getTeams()
         .values()
         .stream()
         .flatMap(Collection::stream)
@@ -90,4 +109,16 @@ public class LiveGamesFilterController extends AbstractFilterController<GameInfo
       throw new UnsupportedOperationException("Not supported");
     }
   };
+
+  @Override
+  protected void afterBuilt() {
+    hideModdedGamesFilter.valueProperty().bindBidirectional(preferences.getVault().getLiveReplaySearch().getHideModdedGames());
+    hideSingleGamesFilter.valueProperty().bindBidirectional(preferences.getVault().getLiveReplaySearch().getHideSingleGames());
+    onlyGamesWithFriendsFilter.valueProperty().bindBidirectional(preferences.getVault().getLiveReplaySearch().getOnlyGamesWithFriends());
+    onlyGeneratedMapsFilter.valueProperty().bindBidirectional(preferences.getVault().getLiveReplaySearch().getOnlyGeneratedMaps());
+    gameTypeFilter.valueProperty().bindBidirectional(preferences.getVault().getLiveReplaySearch().getGameTypes());
+    featuredModFilter.valueProperty().bindBidirectional(preferences.getVault().getLiveReplaySearch().getModName());
+    playerFilter.valueProperty().bindBidirectional(preferences.getVault().getLiveReplaySearch().getPlayerName());
+  }
+
 }

--- a/src/main/java/com/faforever/client/preferences/LiveReplaySearchPrefs.java
+++ b/src/main/java/com/faforever/client/preferences/LiveReplaySearchPrefs.java
@@ -9,11 +9,9 @@ import javafx.beans.property.SimpleListProperty;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
 import javafx.collections.FXCollections;
-import lombok.Getter;
-import lombok.Setter;
+import javafx.collections.ObservableList;
 
-@Getter
-@Setter
+
 public class LiveReplaySearchPrefs {
 
   private final BooleanProperty hideModdedGames = new SimpleBooleanProperty(false);
@@ -26,4 +24,51 @@ public class LiveReplaySearchPrefs {
 
   private final StringProperty playerName = new SimpleStringProperty("");
 
+  public boolean getHideModdedGames() {return hideModdedGames.get();}
+
+  public void setHideModdedGames(Boolean hideModdedGames) {this.hideModdedGames.set(hideModdedGames);}
+
+  public BooleanProperty hideModdedGamesProperty() {return hideModdedGames;}
+
+
+  public boolean getHideSingleGames() {return hideSingleGames.get();}
+
+  public void setHideSingleGames(Boolean hideSingleGames) {this.hideSingleGames.set(hideSingleGames);}
+
+  public BooleanProperty hideSingleGamesProperty() {return hideSingleGames;}
+
+
+  public boolean getOnlyGamesWithFriends() {return onlyGamesWithFriends.get();}
+
+  public void setOnlyGamesWithFriends(Boolean onlyGamesWithFriends) {this.onlyGamesWithFriends.set(onlyGamesWithFriends);}
+
+  public BooleanProperty onlyGamesWithFriendsProperty() {return onlyGamesWithFriends;}
+
+
+  public boolean getOnlyGeneratedMaps() {return onlyGeneratedMaps.get();}
+
+  public void setOnlyGeneratedMaps(Boolean onlyGeneratedMaps) {this.onlyGeneratedMaps.set(onlyGeneratedMaps);}
+
+  public BooleanProperty onlyGeneratedMapsProperty() {return onlyGeneratedMaps;}
+
+
+  public ObservableList<GameType> getGameTypes() {return gameTypes.get();}
+
+  public void setGameTypes(ObservableList<GameType> gameTypes) {this.gameTypes.set(gameTypes);}
+
+  public ListProperty<GameType> gameTypesProperty() {return gameTypes;}
+
+
+  public ObservableList<FeaturedMod> getModName() {return modName.get();}
+
+  public void setModName(ObservableList<FeaturedMod> modName) {this.modName.set(modName);}
+
+  public ListProperty<FeaturedMod> modNameProperty() {return modName;}
+
+
+  public String getPlayerName() {return playerName.get();}
+
+  public void setPlayerName(String playerName) {this.playerName.set(playerName);}
+
+  public StringProperty playerNameProperty() {return playerName;}
 }

--- a/src/main/java/com/faforever/client/preferences/LiveReplaySearchPrefs.java
+++ b/src/main/java/com/faforever/client/preferences/LiveReplaySearchPrefs.java
@@ -1,0 +1,29 @@
+package com.faforever.client.preferences;
+
+import com.faforever.client.domain.api.FeaturedMod;
+import com.faforever.commons.lobby.GameType;
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.ListProperty;
+import javafx.beans.property.SimpleBooleanProperty;
+import javafx.beans.property.SimpleListProperty;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.property.StringProperty;
+import javafx.collections.FXCollections;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class LiveReplaySearchPrefs {
+
+  private final BooleanProperty hideModdedGames = new SimpleBooleanProperty(false);
+  private final BooleanProperty hideSingleGames = new SimpleBooleanProperty(false);
+  private final BooleanProperty onlyGamesWithFriends = new SimpleBooleanProperty(false);
+  private final BooleanProperty onlyGeneratedMaps = new SimpleBooleanProperty(false);
+
+  private final ListProperty<GameType> gameTypes = new SimpleListProperty<>(FXCollections.observableArrayList());
+  private final ListProperty<FeaturedMod> modName = new SimpleListProperty<>(FXCollections.observableArrayList());
+
+  private final StringProperty playerName = new SimpleStringProperty("");
+
+}

--- a/src/main/java/com/faforever/client/preferences/VaultPrefs.java
+++ b/src/main/java/com/faforever/client/preferences/VaultPrefs.java
@@ -29,6 +29,9 @@ public class VaultPrefs {
   private final ReplaySearchPrefs replaySearch = new ReplaySearchPrefs();
   @JsonMerge
   @Getter
+  private final LiveReplaySearchPrefs liveReplaySearch = new LiveReplaySearchPrefs();
+  @JsonMerge
+  @Getter
   private final MapSearchPrefs mapSearch = new MapSearchPrefs();
   @JsonMerge
   @Getter

--- a/src/test/java/com/faforever/client/filter/LiveGamesFilterControllerTest.java
+++ b/src/test/java/com/faforever/client/filter/LiveGamesFilterControllerTest.java
@@ -1,16 +1,22 @@
 package com.faforever.client.filter;
 
 import com.faforever.client.builders.PlayerInfoBuilder;
+import com.faforever.client.domain.api.FeaturedMod;
 import com.faforever.client.domain.server.GameInfo;
 import com.faforever.client.domain.server.PlayerInfo;
 import com.faforever.client.featuredmod.FeaturedModService;
 import com.faforever.client.i18n.I18n;
 import com.faforever.client.map.generator.MapGeneratorService;
 import com.faforever.client.player.PlayerService;
+import com.faforever.client.preferences.LiveReplaySearchPrefs;
 import com.faforever.client.social.SocialService;
 import com.faforever.client.test.PlatformTest;
 import com.faforever.client.theme.UiService;
 import com.faforever.commons.lobby.GameType;
+import javafx.beans.property.SimpleBooleanProperty;
+import javafx.beans.property.SimpleListProperty;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.collections.FXCollections;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -28,7 +34,6 @@ import static com.faforever.client.builders.GameInfoBuilder.create;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -49,41 +54,62 @@ public class LiveGamesFilterControllerTest extends PlatformTest {
   private MapGeneratorService mapGeneratorService;
 
   @Mock
-  private FilterCheckboxController<GameInfo> singleGamesController;
+  private LiveReplaySearchPrefs liveReplaySearchPrefs;
+
   @Mock
-  private FilterCheckboxController<GameInfo> gamesWithFriendsController;
+  private FilterCheckboxController<GameInfo> hideModdedGamesFilter;
   @Mock
-  private FilterMultiCheckboxController<GameType, GameInfo> gameTypeController;
+  private FilterCheckboxController<GameInfo> hideSingleGamesFilter;
   @Mock
-  private FilterTextFieldController<GameInfo> playerNameController;
+  private FilterCheckboxController<GameInfo> onlyGamesWithFriendsFilter;
   @Mock
-  private FilterCheckboxController<GameInfo> generatedMapsController;
+  private FilterCheckboxController<GameInfo> onlyGeneratedMapsFilter;
+
+  @Mock
+  private FilterMultiCheckboxController<GameType, GameInfo> gameTypeFilter;
+  @Mock
+  private FilterMultiCheckboxController<FeaturedMod, GameInfo> featuredModFilter;
+
+  @Mock
+  private FilterTextFieldController<GameInfo> playerNameFilter;
+
 
   @InjectMocks
   private LiveGamesFilterController instance;
 
   @BeforeEach
   public void setUp() throws Exception {
-    // Order is important
     when(uiService.loadFxml(anyString())).thenReturn(
-        mock(FilterCheckboxController.class), // Sim mods
-        singleGamesController,
-        gamesWithFriendsController,
-        generatedMapsController,
-        gameTypeController,
-        mock(FilterMultiCheckboxController.class), // Featured mods
-        playerNameController
+        hideModdedGamesFilter, // Sim mods
+        hideSingleGamesFilter,
+        onlyGamesWithFriendsFilter,
+        onlyGeneratedMapsFilter,
+        gameTypeFilter,
+        featuredModFilter,
+        playerNameFilter
     );
     when(featuredModService.getFeaturedMods()).thenReturn(Flux.empty());
 
+    when(hideModdedGamesFilter.valueProperty()).thenReturn(new SimpleBooleanProperty());
+    when(hideSingleGamesFilter.valueProperty()).thenReturn(new SimpleBooleanProperty());
+    when(onlyGamesWithFriendsFilter.valueProperty()).thenReturn(new SimpleBooleanProperty());
+    when(onlyGeneratedMapsFilter.valueProperty()).thenReturn(new SimpleBooleanProperty());
+
+    when(gameTypeFilter.valueProperty()).thenReturn(new SimpleListProperty<>(FXCollections.observableArrayList()));
+    when(featuredModFilter.valueProperty()).thenReturn(new SimpleListProperty<>(FXCollections.observableArrayList()));
+
+    when(playerNameFilter.valueProperty()).thenReturn(new SimpleStringProperty());
+
     loadFxml("theme/filter/filter.fxml", clazz -> instance, instance);
+
+
   }
 
   @Test
   public void testGameTypeFilter() {
     ArgumentCaptor<BiFunction<List<GameType>, GameInfo, Boolean>> argumentCaptor = ArgumentCaptor.forClass(
         BiFunction.class);
-    verify(gameTypeController).registerListener(argumentCaptor.capture());
+    verify(gameTypeFilter).registerListener(argumentCaptor.capture());
 
     BiFunction<List<GameType>, GameInfo, Boolean> filter = argumentCaptor.getValue();
 
@@ -99,7 +125,7 @@ public class LiveGamesFilterControllerTest extends PlatformTest {
   @Test
   public void testPlayerNameFilter() {
     ArgumentCaptor<BiFunction<String, GameInfo, Boolean>> argumentCaptor = ArgumentCaptor.forClass(BiFunction.class);
-    verify(playerNameController).registerListener(argumentCaptor.capture());
+    verify(playerNameFilter).registerListener(argumentCaptor.capture());
 
     PlayerInfo player1 = PlayerInfoBuilder.create().defaultValues().id(1).username("player1").get();
     PlayerInfo player2 = PlayerInfoBuilder.create().defaultValues().id(2).username("player2").get();
@@ -122,7 +148,7 @@ public class LiveGamesFilterControllerTest extends PlatformTest {
   @Test
   public void testSingleGamesFilter() {
     ArgumentCaptor<BiFunction<Boolean, GameInfo, Boolean>> argumentCaptor = ArgumentCaptor.forClass(BiFunction.class);
-    verify(singleGamesController).registerListener(argumentCaptor.capture());
+    verify(hideSingleGamesFilter).registerListener(argumentCaptor.capture());
 
     BiFunction<Boolean, GameInfo, Boolean> filter = argumentCaptor.getValue();
 
@@ -135,7 +161,7 @@ public class LiveGamesFilterControllerTest extends PlatformTest {
   @Test
   public void testGameWithFriendsFilter() {
     ArgumentCaptor<BiFunction<Boolean, GameInfo, Boolean>> argumentCaptor = ArgumentCaptor.forClass(BiFunction.class);
-    verify(gamesWithFriendsController).registerListener(argumentCaptor.capture());
+    verify(onlyGamesWithFriendsFilter).registerListener(argumentCaptor.capture());
 
     GameInfo game = create().defaultValues().get();
 
@@ -151,7 +177,7 @@ public class LiveGamesFilterControllerTest extends PlatformTest {
   @Test
   public void testGeneratedMapsFilter() {
     ArgumentCaptor<BiFunction<Boolean, GameInfo, Boolean>> argumentCaptor = ArgumentCaptor.forClass(BiFunction.class);
-    verify(generatedMapsController).registerListener(argumentCaptor.capture());
+    verify(onlyGeneratedMapsFilter).registerListener(argumentCaptor.capture());
 
     GameInfo game = create().defaultValues().get();
 

--- a/src/test/java/com/faforever/client/filter/LiveGamesFilterControllerTest.java
+++ b/src/test/java/com/faforever/client/filter/LiveGamesFilterControllerTest.java
@@ -16,12 +16,12 @@ import com.faforever.commons.lobby.GameType;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleListProperty;
 import javafx.beans.property.SimpleStringProperty;
-import javafx.collections.FXCollections;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import reactor.core.publisher.Flux;
 
 import java.util.Collections;
@@ -41,41 +41,41 @@ import static org.mockito.Mockito.when;
 public class LiveGamesFilterControllerTest extends PlatformTest {
 
   @Mock
-  private UiService uiService;
+  protected UiService uiService;
   @Mock
-  private I18n i18n;
+  protected I18n i18n;
   @Mock
-  private FeaturedModService featuredModService;
+  protected FeaturedModService featuredModService;
   @Mock
-  private PlayerService playerService;
+  protected PlayerService playerService;
   @Mock
-  private SocialService socialService;
+  protected SocialService socialService;
   @Mock
-  private MapGeneratorService mapGeneratorService;
+  protected MapGeneratorService mapGeneratorService;
+
+  @Spy
+  protected LiveReplaySearchPrefs liveReplaySearchPrefs;
 
   @Mock
-  private LiveReplaySearchPrefs liveReplaySearchPrefs;
+  protected FilterCheckboxController<GameInfo> hideModdedGamesFilter;
+  @Mock
+  protected FilterCheckboxController<GameInfo> hideSingleGamesFilter;
+  @Mock
+  protected FilterCheckboxController<GameInfo> onlyGamesWithFriendsFilter;
+  @Mock
+  protected FilterCheckboxController<GameInfo> onlyGeneratedMapsFilter;
 
   @Mock
-  private FilterCheckboxController<GameInfo> hideModdedGamesFilter;
+  protected FilterMultiCheckboxController<GameType, GameInfo> gameTypeFilter;
   @Mock
-  private FilterCheckboxController<GameInfo> hideSingleGamesFilter;
-  @Mock
-  private FilterCheckboxController<GameInfo> onlyGamesWithFriendsFilter;
-  @Mock
-  private FilterCheckboxController<GameInfo> onlyGeneratedMapsFilter;
+  protected FilterMultiCheckboxController<FeaturedMod, GameInfo> featuredModFilter;
 
   @Mock
-  private FilterMultiCheckboxController<GameType, GameInfo> gameTypeFilter;
-  @Mock
-  private FilterMultiCheckboxController<FeaturedMod, GameInfo> featuredModFilter;
-
-  @Mock
-  private FilterTextFieldController<GameInfo> playerNameFilter;
+  protected FilterTextFieldController<GameInfo> playerNameFilter;
 
 
   @InjectMocks
-  private LiveGamesFilterController instance;
+  protected LiveGamesFilterController instance;
 
   @BeforeEach
   public void setUp() throws Exception {
@@ -95,14 +95,12 @@ public class LiveGamesFilterControllerTest extends PlatformTest {
     when(onlyGamesWithFriendsFilter.valueProperty()).thenReturn(new SimpleBooleanProperty());
     when(onlyGeneratedMapsFilter.valueProperty()).thenReturn(new SimpleBooleanProperty());
 
-    when(gameTypeFilter.valueProperty()).thenReturn(new SimpleListProperty<>(FXCollections.observableArrayList()));
-    when(featuredModFilter.valueProperty()).thenReturn(new SimpleListProperty<>(FXCollections.observableArrayList()));
+    when(gameTypeFilter.valueProperty()).thenReturn(new SimpleListProperty<>());
+    when(featuredModFilter.valueProperty()).thenReturn(new SimpleListProperty<>());
 
     when(playerNameFilter.valueProperty()).thenReturn(new SimpleStringProperty());
 
     loadFxml("theme/filter/filter.fxml", clazz -> instance, instance);
-
-
   }
 
   @Test

--- a/src/test/java/com/faforever/client/filter/LiveGamesFilterControllerTest.java
+++ b/src/test/java/com/faforever/client/filter/LiveGamesFilterControllerTest.java
@@ -41,37 +41,37 @@ import static org.mockito.Mockito.when;
 public class LiveGamesFilterControllerTest extends PlatformTest {
 
   @Mock
-  protected UiService uiService;
+  private UiService uiService;
   @Mock
-  protected I18n i18n;
+  private I18n i18n;
   @Mock
-  protected FeaturedModService featuredModService;
+  private FeaturedModService featuredModService;
   @Mock
-  protected PlayerService playerService;
+  private PlayerService playerService;
   @Mock
-  protected SocialService socialService;
+  private SocialService socialService;
   @Mock
-  protected MapGeneratorService mapGeneratorService;
+  private MapGeneratorService mapGeneratorService;
 
   @Spy
-  protected LiveReplaySearchPrefs liveReplaySearchPrefs;
+  private LiveReplaySearchPrefs liveReplaySearchPrefs;
 
   @Mock
-  protected FilterCheckboxController<GameInfo> hideModdedGamesFilter;
+  private FilterCheckboxController<GameInfo> hideModdedGamesFilter;
   @Mock
-  protected FilterCheckboxController<GameInfo> hideSingleGamesFilter;
+  private FilterCheckboxController<GameInfo> hideSingleGamesFilter;
   @Mock
-  protected FilterCheckboxController<GameInfo> onlyGamesWithFriendsFilter;
+  private FilterCheckboxController<GameInfo> onlyGamesWithFriendsFilter;
   @Mock
-  protected FilterCheckboxController<GameInfo> onlyGeneratedMapsFilter;
+  private FilterCheckboxController<GameInfo> onlyGeneratedMapsFilter;
 
   @Mock
-  protected FilterMultiCheckboxController<GameType, GameInfo> gameTypeFilter;
+  private FilterMultiCheckboxController<GameType, GameInfo> gameTypeFilter;
   @Mock
-  protected FilterMultiCheckboxController<FeaturedMod, GameInfo> featuredModFilter;
+  private FilterMultiCheckboxController<FeaturedMod, GameInfo> featuredModFilter;
 
   @Mock
-  protected FilterTextFieldController<GameInfo> playerNameFilter;
+  private FilterTextFieldController<GameInfo> playerNameFilter;
 
 
   @InjectMocks

--- a/src/test/java/com/faforever/client/filter/LiveGamesFilterControllerTest.java
+++ b/src/test/java/com/faforever/client/filter/LiveGamesFilterControllerTest.java
@@ -75,7 +75,7 @@ public class LiveGamesFilterControllerTest extends PlatformTest {
 
 
   @InjectMocks
-  protected LiveGamesFilterController instance;
+  private LiveGamesFilterController instance;
 
   @BeforeEach
   public void setUp() throws Exception {


### PR DESCRIPTION
Should solve issue https://github.com/FAForever/downlords-faf-client/issues/3093 , 
though I highly doubt it was working before.

@Sheikah45 Is it to your liking? While I was going through it thought that some refactoring is needed.

Currently there is VaultPrefs - Which contains:
* ReplaySearchPrefs 
* LiveReplaySearchPrefs ( newly created for this feature)

I see that VaultPrefs were firstly created then ReplaySea.. was added, though I'm not sure myself to which screen belongs which as there is FAF Replay and Local Replay (could debug it). Anyway, I think It would be good to get them all in the same level.

And when I would be doing it, I've have seen that there are prefs for filters in CustomGame(Filter)Controller , it could be also somehow nested and could increase readability.

The question is - should I proceed? Or are you fine with it being this way