### PR TITLE
Fix bug deleting  in managed maps dialog

### DIFF
--- a/src/main/java/com/faforever/client/map/MapService.java
+++ b/src/main/java/com/faforever/client/map/MapService.java
@@ -255,7 +255,9 @@ public class MapService implements InitializingBean, DisposableBean {
   }
 
   private void removeMap(Path mapFolder) {
-    mapsByFolderName.remove(mapFolder.getFileName().toString().toLowerCase(Locale.ROOT));
+    fxApplicationThreadExecutor.execute(
+      () -> mapsByFolderName.remove(mapFolder.getFileName().toString().toLowerCase(Locale.ROOT))
+    );
   }
 
   private void addInstalledMap(Path mapFolder) throws MapLoadException {


### PR DESCRIPTION
Fixes #3196 

Previously deleting a map resulted in an exception thrown:

java.lang.IllegalStateException: Not on FX application thread; currentThread = Thread-5
        at com.sun.javafx.tk.Toolkit.checkFxUserThread(Toolkit.java:294)
        at com.sun.javafx.tk.quantum.QuantumToolkit.checkFxUserThread(QuantumToolkit.java:475)
        ..........
        at com.faforever.client.map.MapService.removeMap(MapService.java:258)
        at com.faforever.client.map.MapService.lambda$startDirectoryWatcher$4(MapService.java:202)
        at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:184)
        at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:179)
        at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1708)
        at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
        at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
        at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:151)
        at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:174)
        at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
        at java.base/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:596)
        at com.faforever.client.map.MapService.lambda$startDirectoryWatcher$5(MapService.java:199)
        at java.base/java.lang.Thread.run(Thread.java:1583)

The culprit is a call that deletes UX elements that was not on the FX thread. Putting it on the FX thread fixes the issue