### PR TITLE
[3277] Dynamically changing the timeout for Reconnect

### DIFF
--- a/src/main/java/com/faforever/client/game/GameRunner.java
+++ b/src/main/java/com/faforever/client/game/GameRunner.java
@@ -373,6 +373,7 @@ public class GameRunner implements InitializingBean {
 
   private Process launchOnlineGame(GameParameters gameParameters, Integer gpgPort, Integer replayPort) {
     fafServerAccessor.setPingIntervalSeconds(5);
+    fafServerAccessor.setTimeoutLoginReconnectSeconds(5);
     gameKilled = false;
     return forgedAllianceLaunchService.launchOnlineGame(gameParameters, gpgPort, replayPort);
   }
@@ -400,6 +401,7 @@ public class GameRunner implements InitializingBean {
 
   private void handleTermination(Process finishedProcess) {
     fafServerAccessor.setPingIntervalSeconds(25);
+    fafServerAccessor.setTimeoutLoginReconnectSeconds(30);
     int exitCode = finishedProcess.exitValue();
     log.info("Forged Alliance terminated with exit code {}", exitCode);
     Optional<Path> logFile = loggingService.getMostRecentGameLogFile();

--- a/src/main/java/com/faforever/client/remote/FafServerAccessor.java
+++ b/src/main/java/com/faforever/client/remote/FafServerAccessor.java
@@ -35,6 +35,7 @@ import javafx.beans.property.ReadOnlyObjectProperty;
 import javafx.beans.property.ReadOnlyObjectWrapper;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.InitializingBean;
@@ -83,6 +84,9 @@ public class FafServerAccessor implements InitializingBean, DisposableBean, Life
   private boolean autoReconnect;
   @Getter
   private boolean running;
+  @Getter
+  @Setter
+  private int timeoutLoginReconnectSeconds;
 
   @Override
   public void afterPropertiesSet() throws Exception {
@@ -98,6 +102,7 @@ public class FafServerAccessor implements InitializingBean, DisposableBean, Life
                                  .subscribe();
 
       setPingIntervalSeconds(25);
+      setTimeoutLoginReconnectSeconds(30);
 
       lobbyClient.getConnectionStatus()
                  .map(connectionStatus -> switch (connectionStatus) {
@@ -161,7 +166,7 @@ public class FafServerAccessor implements InitializingBean, DisposableBean, Life
                                                                    clientProperties.getUserAgent(), lobbyUrl,
                                                                    this::tryGenerateUid, 1024 * 1024, false)))
                                .flatMap(lobbyClient::connectAndLogin)
-                               .timeout(Duration.ofSeconds(30))
+                               .timeout(Duration.ofSeconds(timeoutLoginReconnectSeconds))
                                .retryWhen(createRetrySpec(clientProperties.getServer()));
   }
 

--- a/src/test/java/com/faforever/client/game/GameRunnerTest.java
+++ b/src/test/java/com/faforever/client/game/GameRunnerTest.java
@@ -215,6 +215,7 @@ public class GameRunnerTest extends ServiceTest {
     Integer uid = gameParameters.uid();
 
     verify(fafServerAccessor).setPingIntervalSeconds(5);
+    verify(fafServerAccessor).setTimeoutLoginReconnectSeconds(5);
     verify(leaderboardService, never()).getActiveLeagueEntryForPlayer(any(), any());
     verify(mapService, never()).downloadIfNecessary(any());
     verify(replayServer).start(uid);
@@ -234,6 +235,7 @@ public class GameRunnerTest extends ServiceTest {
     verify(replayServer).stop();
     verify(fafServerAccessor).notifyGameEnded();
     verify(fafServerAccessor).setPingIntervalSeconds(25);
+    verify(fafServerAccessor).setTimeoutLoginReconnectSeconds(30);
     verify(notificationService).addNotification(any(PersistentNotification.class));
     assertFalse(instance.isRunning());
     assertNull(instance.getRunningProcessId());


### PR DESCRIPTION
I suggest making the dynamic connection timeout depends on whether you are currently in the game.

During the game, you need to try to reconnect a little faster. It has a positive effect on reconnect in ICE and in the game itself.