### PR TITLE
Update ice adapter to 3.3.10 (manual reconnect)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 version=unspecified
 javafxPlatform=unspecified
-iceAdapterVersion=3.3.9
+iceAdapterVersion=3.3.10


### PR DESCRIPTION
* In the Debug window there is a new column with a reconnect button to manually initiate a reconnect.
* Bugfix: If the debug window is opened later on, it now shows all peers