### PR TITLE
Fix ugly hover effect on chat messages

### DIFF
--- a/src/main/java/com/faforever/client/chat/ChatMessageController.java
+++ b/src/main/java/com/faforever/client/chat/ChatMessageController.java
@@ -111,7 +111,7 @@ public class ChatMessageController extends NodeController<VBox> {
 
   @Override
   protected void onInitialize() {
-    JavaFxUtil.bindManagedToVisible(detailsContainer, replyContainer, message, messageActionsContainer);
+    JavaFxUtil.bindManagedToVisible(detailsContainer, replyContainer, message);
 
     mentionPattern = chatService.getMentionPattern();
 

--- a/src/main/resources/theme/chat/chat_message.fxml
+++ b/src/main/resources/theme/chat/chat_message.fxml
@@ -37,12 +37,12 @@
         <Label fx:id="timeLabel" styleClass="time" minWidth="75"/>
         <TextFlow fx:id="message" HBox.hgrow="ALWAYS"/>
         <HBox fx:id="messageActionsContainer" visible="false">
-            <Button fx:id="reactButton" onAction="#onReactButtonClicked" styleClass="window-button">
+            <Button fx:id="reactButton" onAction="#onReactButtonClicked" styleClass="chat-message-button">
                 <graphic>
                     <Region styleClass="icon, react-icon"/>
                 </graphic>
             </Button>
-            <Button fx:id="replyButton" styleClass="window-button">
+            <Button fx:id="replyButton" styleClass="chat-message-button">
                 <graphic>
                     <Region styleClass="icon, reply-icon"/>
                 </graphic>

--- a/src/main/resources/theme/icons.css
+++ b/src/main/resources/theme/icons.css
@@ -54,6 +54,34 @@
   -fx-padding: 0;
 }
 
+.chat-message-button.button {
+  -icon-paint: #A9A9A9;
+  -fx-cursor: default;
+  -fx-background-color: transparent;
+  -height: 100%;
+  -fx-min-width: 45;
+  -fx-max-width: 45;
+  -fx-margin: 0;
+  -fx-padding: 0;
+  -fx-background-radius: 0;
+}
+
+.chat-message-button .icon {
+  -fx-padding: 0;
+  -fx-background-color: -icon-paint;
+  -fx-max-width: 10;
+  -fx-max-height: 10;
+}
+
+.chat-message-button.button:hover {
+  -fx-background-color: #00000011;
+  -icon-paint: white;
+}
+
+.chat-message-button.button:pressed {
+  -fx-background-color: #00000022;
+}
+
 .login-logo,
 .icon-faf {
   -fx-shape: "M16 32c-8.837 0-16-7.163-16-16s7.163-16 16-16 16 7.163 16 16-7.163 16-16 16zM16 2.147c-7.651 0-13.853 6.202-13.853 13.853s6.202 13.853 13.853 13.853 13.853-6.202 13.853-13.853-6.202-13.853-13.853-13.853zM24.026 16.058l3.538 6.127h-2.256l-4.642-8.077h7.122l1.125 1.949h-4.886zM18.256 9.917h7.111l1.24 2.147h-7.117zM20.911 22.185l-1.684-2.917h-6.415l-1.684 2.917h-2.173l7.083-12.268h0.057l7.052 12.268h-2.235zM16.020 13.743l-1.78 3.083h3.56zM5.388 12.064l1.24-2.147h7.243l-1.24 2.147h-7.243zM6.787 22.185h-2.357l3.538-6.127h-4.886l1.125-1.949h7.243z";


### PR DESCRIPTION
Fixes [#3271](https://github.com/FAForever/downlords-faf-client/issues/3271)

Reduces the chat button sizes basically

We can alternatively make the chat buttons taller and correspondingly chat message container taller, but I think this looks pretty reasonable

![demo](https://github.com/user-attachments/assets/12a962d0-d3ca-486e-94c7-e705732b746e)
