### PR TITLE
ICE Adapter 3.3.11 - Always use public STUN servers

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 version=unspecified
 javafxPlatform=unspecified
-iceAdapterVersion=3.3.10
+iceAdapterVersion=3.3.11


### PR DESCRIPTION
This allows all players who do not require a relayed connectio to continue playing despite of the current FAF turn server state.