### PR TITLE
Remove the error when there are no Coturn servers

### DIFF
--- a/src/main/java/com/faforever/client/fa/relay/ice/CoturnService.java
+++ b/src/main/java/com/faforever/client/fa/relay/ice/CoturnService.java
@@ -24,7 +24,7 @@ public class CoturnService {
   public Flux<IceServer> getActiveCoturns() {
     return fafApiAccessor.getApiObject("/ice/server", IceServerResponse.class)
         .flatMapIterable(IceServerResponse::servers)
-                         .switchIfEmpty(Flux.error(new IllegalStateException("No Coturn Servers Available")));
+                         .switchIfEmpty(Flux.empty());
   }
 
   public Flux<CoturnServer> getSelectedCoturns(int gameId) {
@@ -35,6 +35,6 @@ public class CoturnService {
 
     return coturnServerFlux.filter(coturnServer -> preferredCoturnIds.contains(coturnServer.getId()))
         .switchIfEmpty(coturnServerFlux)
-                           .switchIfEmpty(Flux.error(new IllegalStateException("No Coturn Servers Available")));
+                           .switchIfEmpty(Flux.empty());
   }
 }


### PR DESCRIPTION
Since we added the server's public STUN to the ICE Adapter. Coturn servers are now optional.