### PR TITLE
Drop bridj dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -243,7 +243,6 @@ dependencies {
   implementation("net.java.dev.jna:jna-platform:5.17.0")
   implementation("org.jetbrains:annotations:26.0.2")
   implementation("com.neovisionaries:nv-i18n:1.29")
-  implementation("com.nativelibs4java:bridj:0.7.0")
   implementation("org.luaj:luaj-jse:3.0.1")
   implementation("commons-validator:commons-validator:1.9.0") {
     exclude module: 'commons-logging'

--- a/src/main/java/com/faforever/client/FafClientApplication.java
+++ b/src/main/java/com/faforever/client/FafClientApplication.java
@@ -13,7 +13,6 @@ import com.faforever.client.svg.SvgImageLoaderFactory;
 import com.faforever.client.theme.ThemeService;
 import com.faforever.client.theme.UiService;
 import com.faforever.client.ui.StageHolder;
-import com.faforever.client.ui.taskbar.WindowsTaskbarProgressUpdater;
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.scene.text.Font;
@@ -73,10 +72,6 @@ public class FafClientApplication extends Application {
       fxStage.getStage().setOnCloseRequest(this::closeMainWindow);
 
       showMainWindow(fxStage);
-
-      if (!applicationContext.getBeansOfType(WindowsTaskbarProgressUpdater.class).isEmpty()) {
-        applicationContext.getBean(WindowsTaskbarProgressUpdater.class).initTaskBar();
-      }
     } catch (Exception e) {
       log.error("Unable to start", e);
       throw e;

--- a/src/main/java/com/faforever/client/os/OsConfiguration.java
+++ b/src/main/java/com/faforever/client/os/OsConfiguration.java
@@ -2,6 +2,7 @@ package com.faforever.client.os;
 
 import com.faforever.client.FafClientApplication;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.SystemUtils;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -32,11 +33,11 @@ public class OsConfiguration {
   @Bean
   @ConditionalOnMissingBean
   public OperatingSystem runtimeDetection() {
-    if (org.bridj.Platform.isWindows()) {
+    if (SystemUtils.IS_OS_WINDOWS) {
       return new OsWindows();
-    } else if (org.bridj.Platform.isLinux()) {
+    } else if (SystemUtils.IS_OS_LINUX) {
       return new OsPosix();
-    } else if (org.bridj.Platform.isMacOSX()) {
+    } else if (SystemUtils.IS_OS_MAC_OSX) {
       return new OsPosix();
     } else {
       log.warn("Detected unsupported operating system. Feature may not work. Use on your own risk.");

--- a/src/test/java/com/faforever/client/update/CheckForUpdateTaskTest.java
+++ b/src/test/java/com/faforever/client/update/CheckForUpdateTaskTest.java
@@ -6,7 +6,8 @@ import com.faforever.client.test.ServiceTest;
 import com.faforever.client.util.FileSizeReader;
 import com.google.common.io.CharStreams;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.compress.utils.IOUtils;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.SystemUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
@@ -74,13 +75,13 @@ public class CheckForUpdateTaskTest extends ServiceTest {
     assertThat(updateInfo.name(), is("0.4.7-alpha"));
     assertThat(updateInfo.releaseNotesUrl(), is(new URL("https://www.example.com/")));
 
-    if (org.bridj.Platform.isWindows()) {
+    if (SystemUtils.IS_OS_WINDOWS) {
       assertThat(updateInfo.url(), is(new URL(
           "https://github.com/faforever/downlords-faf-client/releases/download/v0.4.7-alpha/dfaf_windows_0_4_7-alpha.exe")));
-    } else if (org.bridj.Platform.isLinux()) {
+    } else if (SystemUtils.IS_OS_LINUX) {
       assertThat(updateInfo.url(), is(new URL(
           "https://github.com/faforever/downlords-faf-client/releases/download/v0.4.7-alpha/dfaf_linux_0_4_7-alpha.tar.gz")));
-    } else if (org.bridj.Platform.isMacOSX()) {
+    } else if (SystemUtils.IS_OS_MAC_OSX) {
       assertThat(updateInfo.url(), is(new URL(
           "https://github.com/faforever/downlords-faf-client/releases/download/v0.4.7-alpha/dfaf_mac_0_4_7-alpha.dmg")));
     } else {


### PR DESCRIPTION
I couldn't test if the taskbar on Windows actually shows porgress correctly. But it's a new feature since Java 9.