### PR TITLE
Bugfix/#3353 apple silicon startup

### DIFF
--- a/.idea/runConfigurations/Main.xml
+++ b/.idea/runConfigurations/Main.xml
@@ -7,7 +7,7 @@
     </envs>
     <option name="MAIN_CLASS_NAME" value="com.faforever.client.Main" />
     <module name="faf-client.main" />
-    <option name="VM_PARAMETERS" value="-Dio.netty.allocator.type=unpooled -DnativeDir=build/resources/native -Dprism.forceGPU=true -Xmx1g -XX:MinHeapFreeRatio=15 -XX:MaxHeapFreeRatio=33 -XX:+HeapDumpOnOutOfMemoryError -XX:+UseZGC -XX:+ZGenerational -Djava.net.preferIPv4Stack=true -XX:TieredStopAtLevel=1 --add-opens=java.base/java.lang=ALL-UNNAMED" />
+    <option name="VM_PARAMETERS" value="-Dio.netty.allocator.type=unpooled -DnativeDir=build/resources/native -Dprism.forceGPU=true -Xmx1g -XX:MinHeapFreeRatio=15 -XX:MaxHeapFreeRatio=33 -XX:+HeapDumpOnOutOfMemoryError -XX:+UseZGC -XX:+ZGenerational -Djava.awt.headless=false -Djava.net.preferIPv4Stack=true -XX:TieredStopAtLevel=1 --add-opens=java.base/java.lang=ALL-UNNAMED" />
     <RunnerSettings RunnerId="Profile ">
       <option name="myExternalizedOptions" value="additional-options2=onexit\=snapshot,_no_java_version_check" />
     </RunnerSettings>

--- a/src/main/java/com/faforever/client/discord/DiscordEventHandler.java
+++ b/src/main/java/com/faforever/client/discord/DiscordEventHandler.java
@@ -12,10 +12,14 @@ import net.arikia.dev.drpc.DiscordEventHandlers;
 import net.arikia.dev.drpc.DiscordRPC;
 import net.arikia.dev.drpc.DiscordRPC.DiscordReply;
 import net.arikia.dev.drpc.DiscordUser;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
+
+import static com.faforever.client.FafClientApplication.PROFILE_MAC;
 
 @Slf4j
 @Component
+@Profile("!"+PROFILE_MAC)
 public class DiscordEventHandler extends DiscordEventHandlers {
   private final NotificationService notificationService;
   private final GameRunner gameRunner;

--- a/src/main/java/com/faforever/client/discord/DiscordRichPresenceService.java
+++ b/src/main/java/com/faforever/client/discord/DiscordRichPresenceService.java
@@ -14,6 +14,7 @@ import net.arikia.dev.drpc.DiscordRichPresence;
 import net.arikia.dev.drpc.DiscordRichPresence.Builder;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.InitializingBean;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 
 import java.text.MessageFormat;
@@ -22,8 +23,11 @@ import java.time.OffsetDateTime;
 import java.util.Timer;
 import java.util.TimerTask;
 
+import static com.faforever.client.FafClientApplication.PROFILE_MAC;
+
 @Slf4j
 @Service
+@Profile("!"+PROFILE_MAC)
 @RequiredArgsConstructor
 public class DiscordRichPresenceService implements DisposableBean, InitializingBean {
   private static final String HOSTING = "Hosting";

--- a/src/main/java/com/faforever/client/steam/SteamService.java
+++ b/src/main/java/com/faforever/client/steam/SteamService.java
@@ -7,10 +7,14 @@ import com.faforever.client.preferences.Preferences;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.InitializingBean;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
+
+import static com.faforever.client.FafClientApplication.PROFILE_MAC;
 
 @Service
 @Slf4j
+@Profile("!"+PROFILE_MAC)
 public class SteamService implements InitializingBean, DisposableBean {
 
   private final GeneralPrefs generalPrefs;

--- a/src/main/java/com/faforever/client/user/LoginService.java
+++ b/src/main/java/com/faforever/client/user/LoginService.java
@@ -20,6 +20,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
+import org.springframework.web.util.UriComponents;
+import org.springframework.web.util.UriComponentsBuilder;
 import reactor.core.publisher.Mono;
 import reactor.function.TupleUtils;
 
@@ -64,8 +66,17 @@ public class LoginService implements InitializingBean {
     String codeChallenge = BASE64_ENCODER.encodeToString(Hashing.sha256()
         .hashString(codeVerifier, StandardCharsets.US_ASCII)
         .asBytes());
-    return String.format("%s/oauth2/auth?response_type=code&client_id=%s&state=%s&redirect_uri=%s&scope=%s&code_challenge_method=S256&code_challenge=%s", oauth.getBaseUrl(), oauth.getClientId(), state, redirectUri.toASCIIString(),
-                         scopes, codeChallenge);
+
+    return UriComponentsBuilder.fromUriString(oauth.getBaseUrl())
+        .path("/oauth2/auth")
+        .queryParam("response_type", "code")
+        .queryParam("client_id", oauth.getClientId())
+        .queryParam("state", state)
+        .queryParam("redirect_uri", redirectUri.toASCIIString())
+        .queryParam("scope", scopes)
+        .queryParam("code_challenge_method", "S256")
+        .queryParam("code_challenge", codeChallenge)
+        .build().toUriString();
   }
 
   public Mono<Void> login(String code, String codeVerifier, URI redirectUri) {

--- a/src/main/java/com/faforever/client/user/LoginService.java
+++ b/src/main/java/com/faforever/client/user/LoginService.java
@@ -20,7 +20,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
-import org.springframework.web.util.UriComponentsBuilder;
 import reactor.core.publisher.Mono;
 import reactor.function.TupleUtils;
 
@@ -65,16 +64,8 @@ public class LoginService implements InitializingBean {
     String codeChallenge = BASE64_ENCODER.encodeToString(Hashing.sha256()
         .hashString(codeVerifier, StandardCharsets.US_ASCII)
         .asBytes());
-
-    return UriComponentsBuilder.fromUriString(oauth.getBaseUrl())
-        .path("/oauth2/auth")
-        .queryParam("response_type", "code")
-        .queryParam("client_id", oauth.getClientId())
-        .queryParam("state", state)
-        .queryParam("redirect_uri", redirectUri.toASCIIString())
-        .queryParam("scope", scopes)
-        .queryParam("code_challenge_method", codeChallenge)
-        .build().toUriString();
+    return String.format("%s/oauth2/auth?response_type=code&client_id=%s&state=%s&redirect_uri=%s&scope=%s&code_challenge_method=S256&code_challenge=%s", oauth.getBaseUrl(), oauth.getClientId(), state, redirectUri.toASCIIString(),
+                         scopes, codeChallenge);
   }
 
   public Mono<Void> login(String code, String codeVerifier, URI redirectUri) {

--- a/src/main/java/com/faforever/client/user/LoginService.java
+++ b/src/main/java/com/faforever/client/user/LoginService.java
@@ -20,6 +20,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
+import org.springframework.web.util.UriComponentsBuilder;
 import reactor.core.publisher.Mono;
 import reactor.function.TupleUtils;
 
@@ -64,8 +65,16 @@ public class LoginService implements InitializingBean {
     String codeChallenge = BASE64_ENCODER.encodeToString(Hashing.sha256()
         .hashString(codeVerifier, StandardCharsets.US_ASCII)
         .asBytes());
-    return String.format("%s/oauth2/auth?response_type=code&client_id=%s&state=%s&redirect_uri=%s&scope=%s&code_challenge_method=S256&code_challenge=%s", oauth.getBaseUrl(), oauth.getClientId(), state, redirectUri.toASCIIString(),
-                         scopes, codeChallenge);
+
+    return UriComponentsBuilder.fromUriString(oauth.getBaseUrl())
+        .path("/oauth2/auth")
+        .queryParam("response_type", "code")
+        .queryParam("client_id", oauth.getClientId())
+        .queryParam("state", state)
+        .queryParam("redirect_uri", redirectUri.toASCIIString())
+        .queryParam("scope", scopes)
+        .queryParam("code_challenge_method", codeChallenge)
+        .build().toUriString();
   }
 
   public Mono<Void> login(String code, String codeVerifier, URI redirectUri) {

--- a/src/main/java/com/faforever/client/user/LoginService.java
+++ b/src/main/java/com/faforever/client/user/LoginService.java
@@ -24,6 +24,7 @@ import reactor.core.publisher.Mono;
 import reactor.function.TupleUtils;
 
 import java.net.URI;
+import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Base64.Encoder;
@@ -59,10 +60,12 @@ public class LoginService implements InitializingBean {
 
   public String getHydraUrl(String state, String codeVerifier, URI redirectUri) {
     Oauth oauth = clientProperties.getOauth();
+    String scopes = URLEncoder.encode(oauth.getScopes(), StandardCharsets.UTF_8);
     String codeChallenge = BASE64_ENCODER.encodeToString(Hashing.sha256()
         .hashString(codeVerifier, StandardCharsets.US_ASCII)
         .asBytes());
-    return String.format("%s/oauth2/auth?response_type=code&client_id=%s&state=%s&redirect_uri=%s&scope=%s&code_challenge_method=S256&code_challenge=%s", oauth.getBaseUrl(), oauth.getClientId(), state, redirectUri.toASCIIString(), oauth.getScopes(), codeChallenge);
+    return String.format("%s/oauth2/auth?response_type=code&client_id=%s&state=%s&redirect_uri=%s&scope=%s&code_challenge_method=S256&code_challenge=%s", oauth.getBaseUrl(), oauth.getClientId(), state, redirectUri.toASCIIString(),
+                         scopes, codeChallenge);
   }
 
   public Mono<Void> login(String code, String codeVerifier, URI redirectUri) {


### PR DESCRIPTION
Adding the `java.awt.headless` run config param and the annotations from `mac-running` allow the client to start up on `develop`.  

~~Browser login button is still not functional/has no effect.~~ URL encoding the oauth scopes fixes the browser login functionality (reaches the success checkmark page) and continues to work on windows.   However, on macos it seems like the websocket connection times out without emitting in the [FafLobbyClient](https://github.com/FAForever/faf-java-commons/blob/a12989f68d8c5d5e461cdc71b5034d5528059da2/lobby/src/main/kotlin/com/faforever/commons/lobby/FafLobbyClient.kt#L138) (Same timeout behavior in mac-running with the fixes in this pr applied)

Fixes #3353