### PR TITLE
Fixed out of memory exception crash occurring by switching back-and-forth between replay tabs

### DIFF
--- a/src/main/java/com/faforever/client/replay/ReplayCardController.java
+++ b/src/main/java/com/faforever/client/replay/ReplayCardController.java
@@ -147,19 +147,27 @@ public class ReplayCardController extends VaultEntityCardController<Replay> {
                     .map(reviewsSummary -> reviewsSummary.score() / reviewsSummary.numReviews())
             .when(showing));
 
+    teams.bind(entity.map(Replay::teamPlayerStats).when(showing));
+    teams.orElse(java.util.Map.of()).addListener(teamsListener);
+  }
+
+  @Override
+  protected void onAttached()
+  {
     isReplayWatched.bind(replayHistory.watchedReplaysProperty()
                                       .flatMap(watchedReplays -> entity.map(Replay::id).map(watchedReplays::contains))
                                       .orElse(false));
-
-
     isReplayWatched.when(showing).subscribe((value) -> {
       if (value) {
         applyWatchedReplayHighlight();
       }
     });
+  }
 
-    teams.bind(entity.map(Replay::teamPlayerStats).when(showing));
-    teams.orElse(java.util.Map.of()).addListener(teamsListener);
+  @Override
+  protected void onDetached()
+  {
+    isReplayWatched.unbind();
   }
 
   private void populatePlayers(java.util.Map<String, List<GamePlayerStats>> newValue) {

--- a/src/main/java/com/faforever/client/replay/ReplayCardController.java
+++ b/src/main/java/com/faforever/client/replay/ReplayCardController.java
@@ -147,27 +147,18 @@ public class ReplayCardController extends VaultEntityCardController<Replay> {
                     .map(reviewsSummary -> reviewsSummary.score() / reviewsSummary.numReviews())
             .when(showing));
 
-    teams.bind(entity.map(Replay::teamPlayerStats).when(showing));
-    teams.orElse(java.util.Map.of()).addListener(teamsListener);
-  }
-
-  @Override
-  protected void onAttached()
-  {
     isReplayWatched.bind(replayHistory.watchedReplaysProperty()
                                       .flatMap(watchedReplays -> entity.map(Replay::id).map(watchedReplays::contains))
-                                      .orElse(false));
+                                      .orElse(false)
+                                      .when(showing));
     isReplayWatched.when(showing).subscribe((value) -> {
       if (value) {
         applyWatchedReplayHighlight();
       }
     });
-  }
 
-  @Override
-  protected void onDetached()
-  {
-    isReplayWatched.unbind();
+    teams.bind(entity.map(Replay::teamPlayerStats).when(showing));
+    teams.orElse(java.util.Map.of()).addListener(teamsListener);
   }
 
   private void populatePlayers(java.util.Map<String, List<GamePlayerStats>> newValue) {


### PR DESCRIPTION
Fixes #3380 

Fixed out of memory exception that occurs after switching a few times between a replay tab and another tab. ReplayCardControllers were held in memory with the binding to the replay history. With each switch the navigation to the other tab was getting progressively slower.

-- Before Fix --
Path to GC roots for ReplayCardController.
<img width="3840" height="2100" alt="kép" src="https://github.com/user-attachments/assets/9a4d690b-21f7-4fcb-a337-b91e6c823300" />

ReplayCardController Histogram right before final tab navigation to produce OOM exception crash. See excessive amounts of ReplayCardControllers held in memory after about 9 switches between FAF replays and Local Replays tabs.
<img width="3840" height="2100" alt="kép" src="https://github.com/user-attachments/assets/dea66be0-634c-4f1a-afd3-15d7e823899e" />

-- After Fix --
ReplayCardController Histogram after about 20 tab switches. Heap dump captured while the Local Replays Tab was selected.
<img width="3840" height="2100" alt="kép" src="https://github.com/user-attachments/assets/62d907f8-4088-46a5-825b-efc4ac4ff68e" />
