### PR TITLE
Improve local replays tab loading time

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -256,13 +256,13 @@ dependencies {
     implementation("io.projectreactor.addons:reactor-extra")
     implementation("io.projectreactor:reactor-tools")
 
-  def commonsVersion = "317e19f0757f78fc3ace0736697ad8829b010b0d"
+  def commonsVersion = "20250913-317e19f"
 
-    implementation("com.github.faforever.faf-java-commons:data:${commonsVersion}") {
+    implementation("com.faforever.commons:data:${commonsVersion}") {
         exclude module: 'guava'
     }
-    implementation("com.github.faforever.faf-java-commons:api:${commonsVersion}")
-    implementation("com.github.faforever.faf-java-commons:lobby:${commonsVersion}")
+    implementation("com.faforever.commons:api:${commonsVersion}")
+    implementation("com.faforever.commons:lobby:${commonsVersion}")
     implementation("com.google.guava:guava:33.5.0-jre")
     implementation("org.apache.commons:commons-compress:1.28.0")
     implementation("net.java.dev.jna:jna:5.18.1")

--- a/build.gradle
+++ b/build.gradle
@@ -247,7 +247,7 @@ dependencies {
   implementation("io.projectreactor.addons:reactor-extra")
   implementation("io.projectreactor:reactor-tools")
 
-  def commonsVersion = "07e30bcb925ff34273a9a4eb08c8c506b13d5d78"
+  def commonsVersion = "317e19f0757f78fc3ace0736697ad8829b010b0d"
 
   implementation("com.github.faforever.faf-java-commons:data:${commonsVersion}") {
             exclude module: 'guava'

--- a/src/main/java/com/faforever/client/replay/ReplayService.java
+++ b/src/main/java/com/faforever/client/replay/ReplayService.java
@@ -36,8 +36,11 @@ import com.faforever.commons.api.elide.ElideNavigatorOnId;
 import com.faforever.commons.replay.ReplayDataParser;
 import com.faforever.commons.replay.ReplayMetadata;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.beans.factory.ObjectFactory;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.context.annotation.Lazy;
@@ -58,12 +61,18 @@ import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.FileTime;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -103,6 +112,10 @@ public class ReplayService {
   private final DataPrefs dataPrefs;
   private final ObjectFactory<ReplayDownloadTask> replayDownloadTaskFactory;
   private final ReplayHistoryPrefs replayHistory;
+  private final Cache<@NotNull Path, @NotNull Replay> replayCache = CacheBuilder.newBuilder()
+                                                                                .maximumSize(1000)
+                                                                                .expireAfterWrite(2, TimeUnit.HOURS)
+                                                                                .build();
 
   @VisibleForTesting
   static Integer parseSupComVersion(ReplayDataParser parser) {
@@ -172,25 +185,46 @@ public class ReplayService {
 
       int numPages = filesList.size() / pageSize;
 
-      List<CompletableFuture<Replay>> replayFutures = filesList.stream()
-                                                               .skip(skippedReplays)
-                                                               .limit(pageSize)
-                                                               .map(this::tryLoadingLocalReplay)
-                                                               .filter(e -> !e.isCompletedExceptionally())
-                                                               .toList();
+      List<Replay> replays;
+      try (ExecutorService executor = Executors.newFixedThreadPool(4)) {
+        List<Callable<Replay>> tasks = new ArrayList<>();
+        int limit = Math.min(skippedReplays + pageSize, filesList.size());
+        for (int i = skippedReplays; i < limit; i++) {
+          var filePath = filesList.get(i);
+          var c = new Callable<Replay>() {
+            @Override
+            public Replay call() {
+              return tryLoadingLocalReplay(filePath).join();
+            }
+          };
+          tasks.add(c);
+        }
 
-      return Mono.fromFuture(CompletableFuture.allOf(replayFutures.toArray(new CompletableFuture[0]))
-                                              .thenApply(ignoredVoid -> replayFutures.stream()
-                                                                                     .map(CompletableFuture::join)
-                                                                                     .filter(Objects::nonNull)
-                                                                                     .collect(Collectors.toList())))
-                 .zipWith(Mono.just(numPages));
+        try {
+          replays = executor.invokeAll(tasks).stream().map(result -> {
+            try {
+              return result.get();
+            } catch (InterruptedException | ExecutionException e) {
+              throw new RuntimeException(e);
+            }
+          }).filter(Objects::nonNull).toList();
+        } catch (InterruptedException e) {
+          throw new RuntimeException(e);
+        }
+      }
+
+      return Mono.justOrEmpty(replays).zipWith(Mono.just(numPages));
     }
   }
 
 
   private CompletableFuture<Replay> tryLoadingLocalReplay(Path replayFile) {
     try {
+      final Replay cachedReplay = this.replayCache.getIfPresent(replayFile);
+      if (cachedReplay != null) {
+        return CompletableFuture.completedFuture(cachedReplay);
+      }
+
       ReplayDataParser replayData = replayFileReader.parseReplay(replayFile);
       ReplayMetadata replayMetadata = replayData.getMetadata();
 
@@ -205,7 +239,10 @@ public class ReplayService {
         if (mapVersion == null) {
           log.warn("Could not find map for replay file `{}`", replayFile);
         }
-        return replayMapper.map(replayData, replayFile, featuredMod, mapVersion);
+
+        final Replay replay = replayMapper.map(replayData, replayFile, featuredMod, mapVersion);
+        this.replayCache.put(replayFile, replay);
+        return replay;
       }).exceptionally(throwable -> {
         log.warn("Could not read replay file `{}`", replayFile, throwable);
         moveCorruptedReplayFile(replayFile);
@@ -289,7 +326,10 @@ public class ReplayService {
     List<ChatMessage> chatMessages = replayDataParser.getChatMessages().stream().map(replayMapper::map).toList();
     List<GameOption> gameOptions = Stream.concat(
         Stream.of(new GameOption("FAF Version", String.valueOf(parseSupComVersion(replayDataParser)))),
-        replayDataParser.getGameOptions().stream().map(replayMapper::map).sorted(Comparator.comparing(GameOption::key, String.CASE_INSENSITIVE_ORDER))).toList();
+        replayDataParser.getGameOptions()
+                        .stream()
+                        .map(replayMapper::map)
+                        .sorted(Comparator.comparing(GameOption::key, String.CASE_INSENSITIVE_ORDER))).toList();
 
     String mapFolderName = parseMapFolderName(replayDataParser);
     Map map = new Map(null, mapFolderName, 0, null, false, null, null);
@@ -447,8 +487,7 @@ public class ReplayService {
   @Cacheable(value = CacheNames.REPLAYS_SEARCH, sync = true)
   public Mono<Replay> findById(int id) {
     ElideNavigatorOnId<Game> navigator = ElideNavigator.of(Game.class).id(String.valueOf(id));
-    return fafApiAccessor.getOne(navigator).map(replayMapper::map)
-                         .cache();
+    return fafApiAccessor.getOne(navigator).map(replayMapper::map).cache();
   }
 
   @Cacheable(value = CacheNames.REPLAYS_MINE, sync = true)
@@ -469,10 +508,13 @@ public class ReplayService {
   }
 
   public Flux<LeagueScoreJournal> getLeagueScoreJournalForReplay(Replay replay) {
-    ElideNavigatorOnCollection<com.faforever.commons.api.dto.LeagueScoreJournal> navigator = ElideNavigator.of(com.faforever.commons.api.dto.LeagueScoreJournal.class).collection()
-        .setFilter(qBuilder().intNum("gameId").eq(replay.id()));
-    return fafApiAccessor.getMany(navigator)
-        .map(replayMapper::map)
-        .cache();
+    ElideNavigatorOnCollection<com.faforever.commons.api.dto.LeagueScoreJournal> navigator = ElideNavigator.of(
+                                                                                                               com.faforever.commons.api.dto.LeagueScoreJournal.class)
+                                                                                                           .collection()
+                                                                                                           .setFilter(
+                                                                                                               qBuilder().intNum(
+                                                                                                                             "gameId")
+                                                                                                                         .eq(replay.id()));
+    return fafApiAccessor.getMany(navigator).map(replayMapper::map).cache();
   }
 }

--- a/src/main/java/com/faforever/client/replay/ReplayService.java
+++ b/src/main/java/com/faforever/client/replay/ReplayService.java
@@ -61,17 +61,12 @@ import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.FileTime;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
-import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -185,35 +180,19 @@ public class ReplayService {
 
       int numPages = filesList.size() / pageSize;
 
-      List<Replay> replays;
-      try (ExecutorService executor = Executors.newFixedThreadPool(nThreads)) {
-        List<Callable<Replay>> tasks = new ArrayList<>();
-        int limit = Math.min(skippedReplays + pageSize, filesList.size());
-        for (int i = skippedReplays; i < limit; i++) {
-          var filePath = filesList.get(i);
-          var c = new Callable<Replay>() {
-            @Override
-            public Replay call() {
-              return tryLoadingLocalReplay(filePath).join();
-            }
-          };
-          tasks.add(c);
-        }
+      List<CompletableFuture<Replay>> replayFutures = filesList.stream()
+                                                               .skip(skippedReplays)
+                                                               .limit(pageSize)
+                                                               .map(this::tryLoadingLocalReplay)
+                                                               .filter(e -> !e.isCompletedExceptionally())
+                                                               .toList();
 
-        try {
-          replays = executor.invokeAll(tasks).stream().map(result -> {
-            try {
-              return result.get();
-            } catch (InterruptedException | ExecutionException e) {
-              throw new RuntimeException(e);
-            }
-          }).filter(Objects::nonNull).toList();
-        } catch (InterruptedException e) {
-          throw new RuntimeException(e);
-        }
-      }
-
-      return Mono.justOrEmpty(replays).zipWith(Mono.just(numPages));
+      return Mono.fromFuture(CompletableFuture.allOf(replayFutures.toArray(new CompletableFuture[0]))
+                                              .thenApply(_ -> replayFutures.stream()
+                                                                           .map(CompletableFuture::join)
+                                                                           .filter(Objects::nonNull)
+                                                                           .collect(Collectors.toList())))
+                 .zipWith(Mono.just(numPages));
     }
   }
 

--- a/src/main/java/com/faforever/client/replay/ReplayService.java
+++ b/src/main/java/com/faforever/client/replay/ReplayService.java
@@ -35,6 +35,7 @@ import com.faforever.commons.api.elide.ElideNavigatorOnCollection;
 import com.faforever.commons.api.elide.ElideNavigatorOnId;
 import com.faforever.commons.replay.ReplayDataParser;
 import com.faforever.commons.replay.ReplayMetadata;
+import com.fasterxml.jackson.databind.util.ByteBufferBackedInputStream;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
@@ -49,11 +50,11 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.util.function.Tuple2;
 
-import java.io.ByteArrayInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.ByteBuffer;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -393,12 +394,12 @@ public class ReplayService {
 
   private void runFafReplayFile(Path path) throws IOException {
     ReplayDataParser replayData = replayFileReader.parseReplay(path);
-    byte[] rawReplayBytes = replayData.getData();
+    ByteBuffer rawReplayByteBuffer = replayData.getData();
 
     Path tempSupComReplayFile = dataPrefs.getCacheDirectory().resolve(TEMP_SCFA_REPLAY_FILE_NAME);
 
     Files.createDirectories(tempSupComReplayFile.getParent());
-    Files.copy(new ByteArrayInputStream(rawReplayBytes), tempSupComReplayFile, StandardCopyOption.REPLACE_EXISTING);
+    Files.copy(new ByteBufferBackedInputStream(rawReplayByteBuffer), tempSupComReplayFile, StandardCopyOption.REPLACE_EXISTING);
 
     ReplayMetadata replayMetadata = replayData.getMetadata();
     String gameType = replayMetadata.getFeaturedMod();

--- a/src/main/java/com/faforever/client/replay/ReplayService.java
+++ b/src/main/java/com/faforever/client/replay/ReplayService.java
@@ -89,7 +89,6 @@ public class ReplayService {
   public static final String SUP_COM_REPLAY_FILE_ENDING = ".scfareplay";
   private static final String TEMP_SCFA_REPLAY_FILE_NAME = "temp.scfareplay";
   private static final Pattern invalidCharacters = Pattern.compile("[?@*%{}<>|\"]");
-  private static final int nThreads = Math.min(Runtime.getRuntime().availableProcessors(), 4);
 
   private final ClientProperties clientProperties;
   private final LoginService loginService;

--- a/src/main/java/com/faforever/client/replay/ReplayService.java
+++ b/src/main/java/com/faforever/client/replay/ReplayService.java
@@ -95,6 +95,7 @@ public class ReplayService {
   public static final String SUP_COM_REPLAY_FILE_ENDING = ".scfareplay";
   private static final String TEMP_SCFA_REPLAY_FILE_NAME = "temp.scfareplay";
   private static final Pattern invalidCharacters = Pattern.compile("[?@*%{}<>|\"]");
+  private static final int nThreads = Math.min(Runtime.getRuntime().availableProcessors(), 4);
 
   private final ClientProperties clientProperties;
   private final LoginService loginService;
@@ -114,8 +115,8 @@ public class ReplayService {
   private final ObjectFactory<ReplayDownloadTask> replayDownloadTaskFactory;
   private final ReplayHistoryPrefs replayHistory;
   private final Cache<@NotNull Path, @NotNull Replay> replayCache = CacheBuilder.newBuilder()
-                                                                                .maximumSize(1000)
-                                                                                .expireAfterWrite(2, TimeUnit.HOURS)
+                                                                                .maximumSize(500)
+                                                                                .expireAfterWrite(20, TimeUnit.MINUTES)
                                                                                 .build();
 
   @VisibleForTesting
@@ -187,7 +188,7 @@ public class ReplayService {
       int numPages = filesList.size() / pageSize;
 
       List<Replay> replays;
-      try (ExecutorService executor = Executors.newFixedThreadPool(4)) {
+      try (ExecutorService executor = Executors.newFixedThreadPool(nThreads)) {
         List<Callable<Replay>> tasks = new ArrayList<>();
         int limit = Math.min(skippedReplays + pageSize, filesList.size());
         for (int i = skippedReplays; i < limit; i++) {
@@ -217,7 +218,6 @@ public class ReplayService {
       return Mono.justOrEmpty(replays).zipWith(Mono.just(numPages));
     }
   }
-
 
   private CompletableFuture<Replay> tryLoadingLocalReplay(Path replayFile) {
     try {
@@ -399,7 +399,8 @@ public class ReplayService {
     Path tempSupComReplayFile = dataPrefs.getCacheDirectory().resolve(TEMP_SCFA_REPLAY_FILE_NAME);
 
     Files.createDirectories(tempSupComReplayFile.getParent());
-    Files.copy(new ByteBufferBackedInputStream(rawReplayByteBuffer), tempSupComReplayFile, StandardCopyOption.REPLACE_EXISTING);
+    Files.copy(new ByteBufferBackedInputStream(rawReplayByteBuffer), tempSupComReplayFile,
+               StandardCopyOption.REPLACE_EXISTING);
 
     ReplayMetadata replayMetadata = replayData.getMetadata();
     String gameType = replayMetadata.getFeaturedMod();

--- a/src/main/java/com/faforever/client/vault/VaultEntityController.java
+++ b/src/main/java/com/faforever/client/vault/VaultEntityController.java
@@ -264,14 +264,6 @@ public abstract class VaultEntityController<T> extends NodeController<Node> {
     return vaultEntityShowRoomController;
   }
 
-  protected void changePerPageCount() {
-    pageSize = perPageComboBox.getValue();
-    if (state.get() == State.RESULT) {
-      SearchConfig searchConfig = searchController.getLastSearchConfig();
-      onPageChange(searchConfig, true);
-    }
-  }
-
   protected void onPageChange(SearchConfig searchConfig, boolean firstLoad) {
     enterSearchingState();
     setSupplier(searchConfig);

--- a/src/main/java/com/faforever/client/vault/VaultEntityController.java
+++ b/src/main/java/com/faforever/client/vault/VaultEntityController.java
@@ -134,7 +134,6 @@ public abstract class VaultEntityController<T> extends NodeController<Node> {
                        ((observable, oldValue, newValue) -> onPerPageCountChanged(oldValue == null ? 0 : oldValue,
                                                                                   newValue)));
     perPageComboBox.setValue(20);
-    perPageComboBox.setOnAction((event -> changePerPageCount()));
     pageSize = perPageComboBox.getValue();
 
     initSearchController();

--- a/src/test/java/com/faforever/client/replay/ReplayFileReaderImplTest.java
+++ b/src/test/java/com/faforever/client/replay/ReplayFileReaderImplTest.java
@@ -28,6 +28,6 @@ public class ReplayFileReaderImplTest extends ServiceTest {
     try (InputStream inputStream = new BufferedInputStream(getClass().getResourceAsStream("/replay/test.fafreplay"))) {
       Files.copy(inputStream, tempFile);
     }
-    assertThat(instance.parseReplay(tempFile).getData().length, is(197007));
+    assertThat(instance.parseReplay(tempFile).getData().capacity(), is(197007));
   }
 }

--- a/src/test/java/com/faforever/client/replay/ReplayServiceTest.java
+++ b/src/test/java/com/faforever/client/replay/ReplayServiceTest.java
@@ -51,6 +51,7 @@ import reactor.test.StepVerifier;
 import reactor.util.function.Tuple2;
 import reactor.util.function.Tuples;
 
+import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
@@ -185,7 +186,7 @@ public class ReplayServiceTest extends ServiceTest {
 
     lenient().when(replayFileReader.parseReplay(any())).thenReturn(replayDataParser);
     lenient().when(replayDataParser.getMetadata()).thenReturn(replayMetadata);
-    lenient().when(replayDataParser.getData()).thenReturn(REPLAY_FIRST_BYTES);
+    lenient().when(replayDataParser.getData()).thenReturn(ByteBuffer.wrap(REPLAY_FIRST_BYTES));
     lenient().when(replayDataParser.getChatMessages()).thenReturn(List.of());
     lenient().when(replayDataParser.getGameOptions()).thenReturn(List.of());
     lenient().when(replayDataParser.getMods()).thenReturn(Map.of());

--- a/src/test/java/com/faforever/client/vault/VaultEntityControllerTest.java
+++ b/src/test/java/com/faforever/client/vault/VaultEntityControllerTest.java
@@ -70,7 +70,7 @@ public class VaultEntityControllerTest extends PlatformTest {
 
   private List<Integer> getMockPageElements(List<Integer> elements, int pageSize, int page) {
     return elements.subList(Math.min((page) * pageSize, elements.size()),
-        Math.min((page + 1) * pageSize, elements.size()));
+                            Math.min((page + 1) * pageSize, elements.size()));
   }
 
   private Mono<Tuple2<List<Integer>, Integer>> mocksAsMono(List<Integer> elements, int pageSize, int page) {
@@ -94,7 +94,8 @@ public class VaultEntityControllerTest extends PlatformTest {
     when(vaultEntityShowRoomController.getPane()).thenReturn(showRoomPane);
 
     items = IntStream.range(0, 50).boxed().toList();
-    instance = new VaultEntityController<>(uiService, notificationService, i18n, reportingService, vaultPrefs, fxApplicationThreadExecutor) {
+    instance = new VaultEntityController<>(uiService, notificationService, i18n, reportingService, vaultPrefs,
+                                           fxApplicationThreadExecutor) {
       @Override
       protected void initSearchController() {
         //Do Nothing
@@ -258,8 +259,6 @@ public class VaultEntityControllerTest extends PlatformTest {
     assertEquals(instance.pageSize, instance.searchResultPane.getChildren().size());
 
     instance.perPageComboBox.setValue(newPageSize);
-    WaitForAsyncUtils.waitForFxEvents();
-    instance.changePerPageCount();
     WaitForAsyncUtils.waitForFxEvents();
 
     moreButton.fire();


### PR DESCRIPTION
Fixes #3270  

Some respones to the issue

> Every time you select the local replays tab there is a signifant loading time. I guess this is because the client parses all the local replays, which can be a lot.

Upon selecting the Local replays tab the client does not parse all local replays, only those, which would be shown on the current page, which is 20 by default. I understand this guess, however it just took this much time to load 20.

> The loading time is understandable on the first opening, but then there should be some sort of caching to prevent this

I thought the loading time is too high for parsing and displaying just 20 replays even on the first opening, therefore I investigated if it could be improved. I created a companion issue https://github.com/FAForever/faf-java-commons/issues/250 and a corresponding pull request https://github.com/FAForever/faf-java-commons/pull/251 with my findings and improvements.

> Maybe the client could do some sort of check if a file was added to the folder instead of doing a time-based cache, which seems suboptimal

Since the assumption that all files are parsed turned out to be not true I don't think monitoring file changes is the way to go, so I went with the caching solution with size and time limits. I also parallelized replay loading.

### Description

Implemented replay caching for ReplayService

Parallelized local replay loading to improve performance

Fixed a bug, where two separate subscribed actions prompted the VaultEntityController to load the replays twice on changing the number of replays per page combobox.

### Measurements
I measured the performance of the parser improvements in faf-java-commons and the client with the help of VisualVM through the action of changing the local replay tab per page number combobox form 20 to 100. CPU: AMD Ryzen 9 5950x. I included my local repo of faf-java-commons in the client's gradle build settings, to gain access to my changes faster. These measurements are not that precise, since during measurements new local replays were added, whose parsing times are different than the ones, which were pushed out from the first 100 replays. Also in some cases I changed the faf-java-commons code in conjunction with the client code. Still I think these could serve as an adequate set of snapshots to properly protray the trajectory of the code changes and their results.

See attached measurements:
[Client Local Replay tab load profiling.zip](https://github.com/user-attachments/files/22199666/Client.Local.Replay.tab.load.profiling.zip)

Baseline
We can immediately notice, the bug, which makes the vault controller load the page twice.
**Client original 100.nps**
com.faforever.client.replay.ReplayService.loadLocalReplayPage ()	9 799 ms
com.faforever.client.replay.ReplayService.loadLocalReplayPage ()	9 609 ms

faf-java-commons changes state similar to measurement in companion task: **ByteBuffer full.nps**
(Replaced LittleEndianDataInputStream with ByteBuffer just in the tokenizer and used System.arraycopy() to extract TokenContent bytes
Used ByteBuffer instead of the LittleEndianDataInputStream everywhere throughout the parsing process.)
**Client improved 100.nps**
com.faforever.client.replay.ReplayService.loadLocalReplayPage ()	8 600 ms
com.faforever.client.replay.ReplayService.loadLocalReplayPage ()	8 199 ms

faf-java-commons changes state similar to measurement in companion task: **ByteBuffer full final.nps**
(Reused the initially created ByteBuffer everywhere to avoid buffer creation for individual tokens.)
**Client improved single buffer 100.nps**
com.faforever.client.replay.ReplayService.loadLocalReplayPage ()	7 398 ms
com.faforever.client.replay.ReplayService.loadLocalReplayPage ()	7 200 ms

Fix of double loading in client
**Client improved single buffer single changeload fix 100.nps**
com.faforever.client.replay.ReplayService.loadLocalReplayPage ()	7 096 ms

Implemented parallel loading of replays on a single page
**Client improved single buffer single changeload fix parallel 100.nps**
com.faforever.client.replay.ReplayService.loadLocalReplayPage ()	3 111 ms

Changed `loadLocalReplayPage` to only use one stream for filtering replay results and parallel completing the `CompletableFutures` from `tryLoadingLocalReplay`
**Client improved single buffer single changeload fix parallel 1stream 100.nps**
com.faforever.client.replay.ReplayService.loadLocalReplayPage ()	2 999 ms