### PR TITLE
Migrate to Hydra2 OAuth2 client ids

### DIFF
--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -28,7 +28,7 @@ faf-client:
   oauth:
     base-url: http://localhost:4444
     scopes: openid offline public_profile upload_map upload_mod lobby
-    client-id: faf-java-client
+    client-id: 2e8808cf-5889-469b-b2c3-01f0cc58c4af
 
 logging:
   level:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -22,7 +22,7 @@ faf-client:
   oauth:
     base-url: https://hydra.faforever.com
     scopes: openid offline public_profile upload_map upload_mod lobby
-    client-id: faf-java-client
+    client-id: 2e8808cf-5889-469b-b2c3-01f0cc58c4af
 
   forged-alliance:
     exe-url: https://content.faforever.com/faf/updaterNew/updates_faf_files/ForgedAlliance.exe

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -25,7 +25,7 @@ faf-client:
   oauth:
     base-url: https://hydra.faforever.xyz
     scopes: openid offline public_profile upload_map upload_mod lobby
-    client-id: faf-java-client
+    client-id: 2e8808cf-5889-469b-b2c3-01f0cc58c4af
 
   forged-alliance:
     exe-url: https://content.faforever.xyz/faf/updaterNew/updates_faf_files/ForgedAlliance.exe


### PR DESCRIPTION
With the upgrade to Ory Hydra 2.x series, by default all client ids are uuids. We want to stick to the default.


(The client ids already work for the current hydra 1.x.)