### PR TITLE
Fix Linux install documentation links (#3133)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -26,10 +26,10 @@ Post a bounty on Issue Hunt. You can reward and financially help developers that
 1. Select `Main` as run configuration next to the hammer button in the top right
 1. Compile and start the application by pressing the play button
 
-A video tutorial is available [here](https://youtu.be/6gsHnt02I_Y). Don't forget to `Enable annotation processing`.
+A video tutorial is available [here](https://www.youtube.com/watch?v=4Wm-yZpV_q8). Don't forget to `Enable annotation processing`.
 
 ### Linux
-Learn how to install the client on Linux [here](https://github.com/FAForever/downlords-faf-client/wiki/Install-on-Linux).
+Follow the official [FAF Linux installation guide](https://wiki.faforever.com/en/Linux-Install). It covers the recommended [`faf-linux` automation scripts](https://github.com/FAForever/faf-linux) and links to the latest video walkthrough.
 
 ## Open Source Licenses
 |                                                                                                                                                |                                                                                                                                                                                               |


### PR DESCRIPTION
## Summary\n- point the README's Linux section to the canonical FAF wiki guide\n- reference the faf-linux automation scripts and the current video walkthrough\n\n## Testing\n- not run (documentation-only change)\n\nFixes #3133


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#3133: Broken links in 'Install on Linux' page](https://oss.issuehunt.io/repos/32919066/issues/3133)
---
</details>
<!-- /Issuehunt content-->