### PR TITLE
 Revert YouTube tutorial link to original version per maintainer feedback

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,11 +2,10 @@
   <a href="https://faforever.com" rel="noopener" target="_blank"><img width="250" src="https://faforever.com/images/faf-logo.png" alt="FAF logo"></a></p>
 </p>
 
-
 # FAF Client
+
 [![Checks](https://github.com/FAForever/downlords-faf-client/actions/workflows/checks.yml/badge.svg?branch=develop)](https://github.com/FAForever/downlords-faf-client/actions/workflows/checks.yml)
 [![Coverage Status](https://coveralls.io/repos/github/FAForever/downlords-faf-client/badge.svg?branch=develop)](https://coveralls.io/github/FAForever/downlords-faf-client?branch=develop)
-
 
 The official client for [Forged Alliance Forever (FAF)](https://www.faforever.com/)
 
@@ -17,30 +16,34 @@ Post a bounty on Issue Hunt. You can reward and financially help developers that
 [![Issue hunt](https://github.com/BoostIO/issuehunt-materials/raw/master/v1/issuehunt-button-v1.svg?sanitize=true)](https://issuehunt.io/r/FAForever/downlords-faf-client)
 
 ## How To Run
-1. Use [Temurin](https://adoptium.net/) 25 or Oracle JDK 25 (others might not work)
-1. Clone the project with Git
-    - using SSH: `git clone git@github.com:FAForever/downlords-faf-client.git`
-    - using HTTPS: `https://github.com/FAForever/downlords-faf-client.git`
-1. Open the project into [IntelliJ IDEA](https://www.jetbrains.com/idea/) Ultimate or Community (free)
-1. Make sure you have `Enable annotation processing` enabled in the settings
-1. Select `Main` as run configuration next to the hammer button in the top right
-1. Compile and start the application by pressing the play button
 
-A video tutorial is available [here](https://youtu.be/6gsHnt02I_Y). Don't forget to `Enable annotation processing`.
+1. Use [Temurin](https://adoptium.net/) 25 or Oracle JDK 25 (others might not work)
+2. Clone the project with Git
+
+   * using SSH: `git clone git@github.com:FAForever/downlords-faf-client.git`
+   * using HTTPS: `https://github.com/FAForever/downlords-faf-client.git`
+3. Open the project into [IntelliJ IDEA](https://www.jetbrains.com/idea/) Ultimate or Community (free)
+4. Make sure you have `Enable annotation processing` enabled in the settings
+5. Select `Main` as run configuration next to the hammer button in the top right
+6. Compile and start the application by pressing the play button
+
+A video tutorial is available [here](https://www.youtube.com/watch?v=4Wm-yZpV_q8). Don't forget to `Enable annotation processing`.
 
 ### Linux
+
 Learn how to install the client on Linux [here](https://github.com/FAForever/downlords-faf-client/wiki/Install-on-Linux).
 
 ## Open Source Licenses
+
 |                                                                                                                                                |                                                                                                                                                                                               |
-|----------------|-------------------------------|
+| ---------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | <img src="https://www.ej-technologies.com/images/product_banners/install4j_large.png" width="128">                                             | Thanks to [ej-technologies](https://www.ej-technologies.com) for their [open source license](https://www.ej-technologies.com/buy/install4j/openSource). We use Install4j to build installers. |
 | <img src="https://slack-files2.s3-us-west-2.amazonaws.com/avatars/2017-12-13/286651735269_a5ab3167acef52b0111e_512.png" width="128">           | Thanks to [bugsnag](https://www.bugsnag.com) for their [open source license](https://www.bugsnag.com/open-source/). We use bugsnag for our error reporting.                                   |
-|<img src="https://www.yourkit.com/images/yk_logo.svg" width="128">| Thanks to [YourKit](https://www.yourkit.com) for their open source license.|
+| <img src="https://www.yourkit.com/images/yk_logo.svg" width="128">                                                                             | Thanks to [YourKit](https://www.yourkit.com) for their open source license.                                                                                                                   |
 | <img src="https://cdn.cms-twdigitalassets.com/content/dam/about-twitter/en/brand-toolkit/brand-download-img-1.jpg.twimg.2560.jpg" width="128"> | Thanks to [Twemoji Twitter](https://twemoji.twitter.com/) for their open source license. We use and display emojis in the chats.                                                              |
 
-
 ## Contribute
+
 Please take a look at the [contribution guidelines](https://github.com/FAForever/java-guidelines/wiki/Contribution-Guidelines) before creating a pull request.
 
 Have a look at our [wiki](https://github.com/FAForever/downlords-faf-client/wiki).

--- a/readme.md
+++ b/readme.md
@@ -27,7 +27,7 @@ Post a bounty on Issue Hunt. You can reward and financially help developers that
 5. Select `Main` as run configuration next to the hammer button in the top right
 6. Compile and start the application by pressing the play button
 
-A video tutorial is available [here](https://www.youtube.com/watch?v=4Wm-yZpV_q8). Don't forget to `Enable annotation processing`.
+A video tutorial is available [here](https://www.youtube.com/watch?v=4Wm-yZpV_q). Don't forget to `Enable annotation processing`.
 
 ### Linux
 


### PR DESCRIPTION
This PR reverts the YouTube tutorial link in the README back to the original URL (https://www.youtube.com/watch?v=4Wm-yZpV_q) as requested by the maintainer.
The Linux installation link remains verified and correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Restructured README with improved badge-based navigation
  * Enhanced installation instructions with clearer formatting and updated tutorial link
  * Refined Linux subsection layout
  * Refreshed Open Source Licenses table formatting with updated attributions
  * Added contribution guidance section

<!-- end of auto-generated comment: release notes by coderabbit.ai -->