### PR TITLE
Fix that player info was not displayed on side window when opening a private channel

### DIFF
--- a/src/main/java/com/faforever/client/chat/PrivateChatTabController.java
+++ b/src/main/java/com/faforever/client/chat/PrivateChatTabController.java
@@ -3,6 +3,7 @@ package com.faforever.client.chat;
 import com.faforever.client.avatar.AvatarService;
 import com.faforever.client.domain.server.PlayerInfo;
 import com.faforever.client.fx.JavaFxUtil;
+import com.faforever.client.player.PlayerService;
 import com.faforever.client.player.PrivatePlayerInfoController;
 import javafx.beans.value.ObservableValue;
 import javafx.scene.Node;
@@ -10,16 +11,19 @@ import javafx.scene.control.ScrollPane;
 import javafx.scene.control.Tab;
 import javafx.scene.image.ImageView;
 import javafx.scene.layout.Region;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
 public class PrivateChatTabController extends AbstractChatTabController {
 
   private final AvatarService avatarService;
+  private final PlayerService playerService;
 
   public Tab privateChatTabRoot;
   public ImageView avatarImageView;
@@ -29,9 +33,10 @@ public class PrivateChatTabController extends AbstractChatTabController {
   public ScrollPane gameDetailScrollPane;
 
   @Autowired
-  public PrivateChatTabController(ChatService chatService, AvatarService avatarService) {
+  public PrivateChatTabController(ChatService chatService, AvatarService avatarService, PlayerService playerService) {
     super(chatService);
     this.avatarService = avatarService;
+    this.playerService = playerService;
   }
 
   @Override
@@ -46,14 +51,10 @@ public class PrivateChatTabController extends AbstractChatTabController {
 
     privateChatTabRoot.textProperty().bind(channelName.when(attached));
 
-    ObservableValue<ChatChannelUser> chatUser = chatChannel.flatMap(
-        channel -> channelName.map(chanName -> channel.getUser(chanName).orElse(null)));
-    privatePlayerInfoController.chatUserProperty().bind(chatUser.when(showing));
+    ObservableValue<PlayerInfo> playerProperty = channelName.map(playerName -> playerService.getPlayerByNameIfOnline(playerName).orElse(null));
+    privatePlayerInfoController.getPlayerProperty().bind(playerProperty.when(showing));
 
-    avatarImageView.imageProperty().bind(chatUser
-                                             .flatMap(ChatChannelUser::playerProperty)
-                                             .flatMap(PlayerInfo::avatarProperty)
-                                             .map(avatarService::loadAvatar).when(showing));
+    avatarImageView.imageProperty().bind(playerProperty.flatMap(PlayerInfo::avatarProperty).map(avatarService::loadAvatar).when(showing));
   }
 
   @Override

--- a/src/main/java/com/faforever/client/chat/PrivateChatTabController.java
+++ b/src/main/java/com/faforever/client/chat/PrivateChatTabController.java
@@ -11,13 +11,11 @@ import javafx.scene.control.ScrollPane;
 import javafx.scene.control.Tab;
 import javafx.scene.image.ImageView;
 import javafx.scene.layout.Region;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
-@Slf4j
 @Component
 @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
 public class PrivateChatTabController extends AbstractChatTabController {
@@ -51,10 +49,12 @@ public class PrivateChatTabController extends AbstractChatTabController {
 
     privateChatTabRoot.textProperty().bind(channelName.when(attached));
 
-    ObservableValue<PlayerInfo> playerProperty = channelName.map(playerName -> playerService.getPlayerByNameIfOnline(playerName).orElse(null));
-    privatePlayerInfoController.getPlayerProperty().bind(playerProperty.when(showing));
+    ObservableValue<PlayerInfo> player = channelName.map(
+        playerName -> playerService.getPlayerByNameIfOnline(playerName).orElse(null));
+    privatePlayerInfoController.playerProperty().bind(player.when(showing));
 
-    avatarImageView.imageProperty().bind(playerProperty.flatMap(PlayerInfo::avatarProperty).map(avatarService::loadAvatar).when(showing));
+    avatarImageView.imageProperty()
+                   .bind(player.flatMap(PlayerInfo::avatarProperty).map(avatarService::loadAvatar).when(showing));
   }
 
   @Override

--- a/src/main/java/com/faforever/client/player/PrivatePlayerInfoController.java
+++ b/src/main/java/com/faforever/client/player/PrivatePlayerInfoController.java
@@ -1,7 +1,6 @@
 package com.faforever.client.player;
 
 import com.faforever.client.achievements.AchievementService;
-import com.faforever.client.chat.ChatChannelUser;
 import com.faforever.client.domain.api.Leaderboard;
 import com.faforever.client.domain.server.GameInfo;
 import com.faforever.client.domain.server.PlayerInfo;
@@ -25,6 +24,7 @@ import javafx.scene.control.Label;
 import javafx.scene.control.Separator;
 import javafx.scene.image.ImageView;
 import javafx.scene.layout.Pane;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
@@ -63,7 +63,8 @@ public class PrivatePlayerInfoController extends NodeController<Node> {
   public Label unlockedAchievementsLabel;
   public Separator separator;
 
-  private final ObjectProperty<ChatChannelUser> chatUser = new SimpleObjectProperty<>();
+  @Getter
+  private final ObjectProperty<PlayerInfo> playerProperty = new SimpleObjectProperty<>();
 
   private final ChangeListener<PlayerInfo> playerChangeListener = (observable, oldValue, newValue) -> {
     if (newValue != null && !Objects.equals(oldValue, newValue)) {
@@ -85,8 +86,7 @@ public class PrivatePlayerInfoController extends NodeController<Node> {
     gameDetailController.setPlaytimeVisible(true);
     gameDetailWrapper.setVisible(false);
 
-    ObservableValue<Boolean> playerExistsProperty = chatUser.flatMap(user -> user.playerProperty().isNotNull())
-                                                            .when(showing);
+    ObservableValue<Boolean> playerExistsProperty = playerProperty.isNotNull().when(showing);
     userImageView.visibleProperty().bind(playerExistsProperty);
     country.visibleProperty().bind(playerExistsProperty);
     ratingsLabels.visibleProperty().bind(playerExistsProperty);
@@ -96,36 +96,21 @@ public class PrivatePlayerInfoController extends NodeController<Node> {
     unlockedAchievements.visibleProperty().bind(playerExistsProperty);
     unlockedAchievementsLabel.visibleProperty().bind(playerExistsProperty);
 
-    ObservableValue<PlayerInfo> playerObservable = chatUser.flatMap(ChatChannelUser::playerProperty);
-
     gamesPlayed.textProperty()
-               .bind(playerObservable.flatMap(PlayerInfo::numberOfGamesProperty).map(i18n::number).when(showing));
+               .bind(playerProperty.flatMap(PlayerInfo::numberOfGamesProperty).map(i18n::number).when(showing));
 
-    username.textProperty().bind(chatUser.map(ChatChannelUser::getUsername).when(showing));
+    username.textProperty().bind(playerProperty.map(PlayerInfo::getUsername).when(showing));
     country.textProperty()
-           .bind(
-               playerObservable.flatMap(PlayerInfo::countryProperty).map(i18n::getCountryNameLocalized).when(showing));
+           .bind(playerProperty.flatMap(PlayerInfo::countryProperty).map(i18n::getCountryNameLocalized).when(showing));
     userImageView.imageProperty()
-                 .bind(playerObservable.map(PlayerInfo::getId).map(IdenticonUtil::createIdenticon).when(showing));
-    ObservableValue<GameInfo> gameObservable = playerObservable.flatMap(PlayerInfo::gameProperty);
+                 .bind(playerProperty.map(PlayerInfo::getId).map(IdenticonUtil::createIdenticon).when(showing));
+    ObservableValue<GameInfo> gameObservable = playerProperty.flatMap(PlayerInfo::gameProperty);
     gameDetailController.gameProperty().bind(gameObservable.when(showing));
     gameDetailWrapper.visibleProperty().bind(gameObservable.flatMap(GameInfo::statusProperty)
                                          .map(status -> status == GameStatus.OPEN || status == GameStatus.PLAYING)
                                          .orElse(false)
                                          .when(showing));
-    chatUser.flatMap(ChatChannelUser::playerProperty).addListener(playerChangeListener);
-  }
-
-  public void setChatUser(ChatChannelUser chatUser) {
-    this.chatUser.set(chatUser);
-  }
-
-  public ChatChannelUser getChatUser() {
-    return chatUser.get();
-  }
-
-  public ObjectProperty<ChatChannelUser> chatUserProperty() {
-    return chatUser;
+    playerProperty.addListener(playerChangeListener);
   }
 
   private void populateUnlockedAchievementsLabel(PlayerInfo player) {

--- a/src/main/java/com/faforever/client/player/PrivatePlayerInfoController.java
+++ b/src/main/java/com/faforever/client/player/PrivatePlayerInfoController.java
@@ -24,7 +24,6 @@ import javafx.scene.control.Label;
 import javafx.scene.control.Separator;
 import javafx.scene.image.ImageView;
 import javafx.scene.layout.Pane;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
@@ -63,8 +62,7 @@ public class PrivatePlayerInfoController extends NodeController<Node> {
   public Label unlockedAchievementsLabel;
   public Separator separator;
 
-  @Getter
-  private final ObjectProperty<PlayerInfo> playerProperty = new SimpleObjectProperty<>();
+  private final ObjectProperty<PlayerInfo> player = new SimpleObjectProperty<>();
 
   private final ChangeListener<PlayerInfo> playerChangeListener = (observable, oldValue, newValue) -> {
     if (newValue != null && !Objects.equals(oldValue, newValue)) {
@@ -86,7 +84,7 @@ public class PrivatePlayerInfoController extends NodeController<Node> {
     gameDetailController.setPlaytimeVisible(true);
     gameDetailWrapper.setVisible(false);
 
-    ObservableValue<Boolean> playerExistsProperty = playerProperty.isNotNull().when(showing);
+    ObservableValue<Boolean> playerExistsProperty = player.isNotNull().when(showing);
     userImageView.visibleProperty().bind(playerExistsProperty);
     country.visibleProperty().bind(playerExistsProperty);
     ratingsLabels.visibleProperty().bind(playerExistsProperty);
@@ -97,20 +95,24 @@ public class PrivatePlayerInfoController extends NodeController<Node> {
     unlockedAchievementsLabel.visibleProperty().bind(playerExistsProperty);
 
     gamesPlayed.textProperty()
-               .bind(playerProperty.flatMap(PlayerInfo::numberOfGamesProperty).map(i18n::number).when(showing));
+               .bind(player.flatMap(PlayerInfo::numberOfGamesProperty).map(i18n::number).when(showing));
 
-    username.textProperty().bind(playerProperty.map(PlayerInfo::getUsername).when(showing));
+    username.textProperty().bind(player.map(PlayerInfo::getUsername).when(showing));
     country.textProperty()
-           .bind(playerProperty.flatMap(PlayerInfo::countryProperty).map(i18n::getCountryNameLocalized).when(showing));
+           .bind(player.flatMap(PlayerInfo::countryProperty).map(i18n::getCountryNameLocalized).when(showing));
     userImageView.imageProperty()
-                 .bind(playerProperty.map(PlayerInfo::getId).map(IdenticonUtil::createIdenticon).when(showing));
-    ObservableValue<GameInfo> gameObservable = playerProperty.flatMap(PlayerInfo::gameProperty);
+                 .bind(player.map(PlayerInfo::getId).map(IdenticonUtil::createIdenticon).when(showing));
+    ObservableValue<GameInfo> gameObservable = player.flatMap(PlayerInfo::gameProperty);
     gameDetailController.gameProperty().bind(gameObservable.when(showing));
     gameDetailWrapper.visibleProperty().bind(gameObservable.flatMap(GameInfo::statusProperty)
                                          .map(status -> status == GameStatus.OPEN || status == GameStatus.PLAYING)
                                          .orElse(false)
                                          .when(showing));
-    playerProperty.addListener(playerChangeListener);
+    player.addListener(playerChangeListener);
+  }
+
+  public ObjectProperty<PlayerInfo> playerProperty() {
+    return player;
   }
 
   private void populateUnlockedAchievementsLabel(PlayerInfo player) {

--- a/src/main/java/com/faforever/client/player/PrivatePlayerInfoController.java
+++ b/src/main/java/com/faforever/client/player/PrivatePlayerInfoController.java
@@ -17,7 +17,6 @@ import com.faforever.commons.api.dto.PlayerAchievement;
 import com.faforever.commons.lobby.GameStatus;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
-import javafx.beans.value.ChangeListener;
 import javafx.beans.value.ObservableValue;
 import javafx.scene.Node;
 import javafx.scene.control.Label;
@@ -33,7 +32,6 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.function.TupleUtils;
 
-import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Component
@@ -63,13 +61,6 @@ public class PrivatePlayerInfoController extends NodeController<Node> {
   public Separator separator;
 
   private final ObjectProperty<PlayerInfo> player = new SimpleObjectProperty<>();
-
-  private final ChangeListener<PlayerInfo> playerChangeListener = (observable, oldValue, newValue) -> {
-    if (newValue != null && !Objects.equals(oldValue, newValue)) {
-      loadReceiverRatingInformation(newValue);
-      populateUnlockedAchievementsLabel(newValue);
-    }
-  };
 
   @Override
   public Node getRoot() {
@@ -108,7 +99,12 @@ public class PrivatePlayerInfoController extends NodeController<Node> {
                                          .map(status -> status == GameStatus.OPEN || status == GameStatus.PLAYING)
                                          .orElse(false)
                                          .when(showing));
-    player.addListener(playerChangeListener);
+    player.when(showing).subscribe((playerInfo) -> {
+        if (playerInfo != null) {
+          loadReceiverRatingInformation(playerInfo);
+          populateUnlockedAchievementsLabel(playerInfo);
+        }
+    });
   }
 
   public ObjectProperty<PlayerInfo> playerProperty() {

--- a/src/test/java/com/faforever/client/chat/PrivateChatTabControllerTest.java
+++ b/src/test/java/com/faforever/client/chat/PrivateChatTabControllerTest.java
@@ -13,6 +13,7 @@ import com.faforever.client.i18n.I18n;
 import com.faforever.client.navigation.NavigationHandler;
 import com.faforever.client.notification.NotificationService;
 import com.faforever.client.player.CountryFlagService;
+import com.faforever.client.player.PlayerService;
 import com.faforever.client.player.PrivatePlayerInfoController;
 import com.faforever.client.preferences.ChatPrefs;
 import com.faforever.client.replay.WatchButtonController;
@@ -33,6 +34,7 @@ import org.mockito.Mock;
 import org.mockito.Spy;
 
 import java.io.InputStream;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -76,6 +78,8 @@ public class PrivateChatTabControllerTest extends PlatformTest {
   @Mock
   private AvatarService avatarService;
   @Mock
+  private PlayerService playerService;
+  @Mock
   private ChatService chatService;
   @Spy
   private ChatPrefs chatPrefs;
@@ -88,22 +92,22 @@ public class PrivateChatTabControllerTest extends PlatformTest {
   @InjectMocks
   private PrivateChatTabController instance;
 
-  private String playerName;
   private PlayerInfo player;
 
   @BeforeEach
   public void setUp() throws Exception {
     player = PlayerInfoBuilder.create().defaultValues().get();
-    playerName = player.getUsername();
+    String playerName = player.getUsername();
 
+    lenient().when(playerService.getPlayerByNameIfOnline(playerName)).thenReturn(Optional.of(player));
     lenient().when(chatMessageViewController.chatChannelProperty()).thenReturn(new SimpleObjectProperty<>());
     lenient().when(chatService.getCurrentUsername()).thenReturn(playerName);
     lenient().when(themeService.getThemeFileUrl(any())).then(invocation -> getThemeFileUrl(invocation.getArgument(0)));
-    lenient().when(privatePlayerInfoController.chatUserProperty()).thenReturn(new SimpleObjectProperty<>());
+    lenient().when(privatePlayerInfoController.playerProperty()).thenReturn(new SimpleObjectProperty<>());
     lenient().when(avatarService.loadAvatar(player.getAvatar())).thenReturn(new Image(InputStream.nullInputStream()));
 
     ChatChannel chatChannel = new ChatChannel(playerName);
-    ChatChannelUser chatChannelUser = new ChatChannelUser(playerName, new ChatChannel(playerName));
+    ChatChannelUser chatChannelUser = new ChatChannelUser(playerName, chatChannel);
     chatChannelUser.setPlayer(player);
     chatChannel.addUser(chatChannelUser);
 

--- a/src/test/java/com/faforever/client/player/PrivatePlayerInfoControllerTest.java
+++ b/src/test/java/com/faforever/client/player/PrivatePlayerInfoControllerTest.java
@@ -19,7 +19,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.testfx.util.WaitForAsyncUtils;
 import reactor.core.publisher.Flux;
 
 import java.util.Map;
@@ -61,11 +60,7 @@ public class PrivatePlayerInfoControllerTest extends PlatformTest {
     playerInfo = PlayerInfoBuilder.create()
                                   .defaultValues()
                                   .game(null)
-                                  .leaderboardRatings(LeaderboardRatingMapBuilder.create()
-                                                                                 .put(leaderboard.technicalName(),
-                                                                                      Instancio.create(
-                                                                                          LeaderboardRating.class))
-                                                                                 .get())
+                                  .leaderboardRatings(generateRandomLeaderboardRatingMap(leaderboard))
                                   .get();
     player = new SimpleObjectProperty<>(playerInfo);
     instance.playerProperty().bind(player);
@@ -89,6 +84,12 @@ public class PrivatePlayerInfoControllerTest extends PlatformTest {
       }
       return instance;
     });
+  }
+
+  private Map<String, LeaderboardRating> generateRandomLeaderboardRatingMap(Leaderboard leaderboard) {
+    return LeaderboardRatingMapBuilder.create()
+                                      .put(leaderboard.technicalName(), Instancio.create(LeaderboardRating.class))
+                                      .get();
   }
 
   @Test
@@ -126,15 +127,11 @@ public class PrivatePlayerInfoControllerTest extends PlatformTest {
   }
 
   @Test
-  public void testSetChatUserLeavesGame() {
-    runOnFxThreadAndWait(() -> instance.playerProperty().setValue(playerInfo));
-    playerInfo.setGame(GameInfoBuilder.create().defaultValues().get());
-    WaitForAsyncUtils.waitForFxEvents();
-
+  public void testCheckGameInfoIfPlayerLeavesGame() {
+    runOnFxThreadAndWait(() -> playerInfo.setGame(GameInfoBuilder.create().defaultValues().get()));
     assertTrue(instance.gameDetailWrapper.isVisible());
 
-    playerInfo.setGame(null);
-
+    runOnFxThreadAndWait(() -> playerInfo.setGame(null));
     assertFalse(instance.gameDetailWrapper.isVisible());
   }
 
@@ -146,7 +143,7 @@ public class PrivatePlayerInfoControllerTest extends PlatformTest {
   }
 
   @Test
-  public void testSetChatUserWithNoPlayer() {
+  public void testCheckGameInfoIfPlayerIsNull() {
     runOnFxThreadAndWait(() -> player.setValue(null));
 
     assertFalse(instance.userImageView.isVisible());
@@ -160,7 +157,7 @@ public class PrivatePlayerInfoControllerTest extends PlatformTest {
   }
 
   @Test
-  public void testSetChatUserWithNoPlayerThenGetsPlayer() {
+  public void testCheckGameInfoWhenPlayerIsNullThenNewPlayerAppears() {
     runOnFxThreadAndWait(() -> player.setValue(null));
 
     assertFalse(instance.userImageView.isVisible());
@@ -172,11 +169,11 @@ public class PrivatePlayerInfoControllerTest extends PlatformTest {
     assertFalse(instance.unlockedAchievements.isVisible());
     assertFalse(instance.unlockedAchievementsLabel.isVisible());
 
-    playerInfo.setLeaderboardRatings(LeaderboardRatingMapBuilder.create()
-                                                                .put(leaderboard.technicalName(),
-                                                                 Instancio.create(LeaderboardRating.class))
-                                                                .get());
-    runOnFxThreadAndWait(() -> player.setValue(playerInfo));
+    runOnFxThreadAndWait(() -> player.setValue(PlayerInfoBuilder.create()
+                                                                .defaultValues()
+                                                                .leaderboardRatings(
+                                                                    generateRandomLeaderboardRatingMap(leaderboard))
+                                                                .get()));
 
     assertTrue(instance.userImageView.isVisible());
     assertTrue(instance.country.isVisible());

--- a/src/test/java/com/faforever/client/player/PrivatePlayerInfoControllerTest.java
+++ b/src/test/java/com/faforever/client/player/PrivatePlayerInfoControllerTest.java
@@ -1,12 +1,9 @@
 package com.faforever.client.player;
 
 import com.faforever.client.achievements.AchievementService;
-import com.faforever.client.builders.ChatChannelUserBuilder;
 import com.faforever.client.builders.GameInfoBuilder;
 import com.faforever.client.builders.LeaderboardRatingMapBuilder;
 import com.faforever.client.builders.PlayerInfoBuilder;
-import com.faforever.client.chat.ChatChannel;
-import com.faforever.client.chat.ChatChannelUser;
 import com.faforever.client.domain.api.Leaderboard;
 import com.faforever.client.domain.server.PlayerInfo;
 import com.faforever.client.game.GameDetailController;
@@ -14,7 +11,8 @@ import com.faforever.client.i18n.I18n;
 import com.faforever.client.leaderboard.LeaderboardService;
 import com.faforever.client.replay.WatchButtonController;
 import com.faforever.client.test.PlatformTest;
-import com.faforever.client.theme.UiService;
+import com.faforever.commons.lobby.GameStatus;
+import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import org.instancio.Instancio;
 import org.junit.jupiter.api.BeforeEach;
@@ -38,10 +36,7 @@ import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 
 public class PrivatePlayerInfoControllerTest extends PlatformTest {
-  private static final String USERNAME = "junit";
 
-  @Mock
-  private UiService uiService;
   @Mock
   private I18n i18n;
   @Mock
@@ -53,24 +48,30 @@ public class PrivatePlayerInfoControllerTest extends PlatformTest {
   @Mock
   private WatchButtonController watchButtonController;
 
-
   @InjectMocks
   private PrivatePlayerInfoController instance;
-  private PlayerInfo player;
-  private ChatChannelUser chatChannelUser;
+
+  private PlayerInfo playerInfo;
+  ObjectProperty<PlayerInfo> player;
   private Leaderboard leaderboard;
 
   @BeforeEach
   public void setUp() throws Exception {
     leaderboard = Instancio.of(Leaderboard.class).set(field(Leaderboard::technicalName), "global").create();
-    player = PlayerInfoBuilder.create().defaultValues().game(null).get();
-    chatChannelUser = ChatChannelUserBuilder.create(USERNAME, new ChatChannel("testChannel"))
-                                            .defaultValues()
-                                            .player(player)
-                                            .get();
+    playerInfo = PlayerInfoBuilder.create()
+                                  .defaultValues()
+                                  .game(null)
+                                  .leaderboardRatings(LeaderboardRatingMapBuilder.create()
+                                                                                 .put(leaderboard.technicalName(),
+                                                                                      Instancio.create(
+                                                                                          LeaderboardRating.class))
+                                                                                 .get())
+                                  .get();
+    player = new SimpleObjectProperty<>(playerInfo);
+    instance.playerProperty().bind(player);
 
     lenient().when(gameDetailController.gameProperty()).thenReturn(new SimpleObjectProperty<>());
-    lenient().when(achievementService.getPlayerAchievements(player.getId())).thenReturn(Flux.empty());
+    lenient().when(achievementService.getPlayerAchievements(playerInfo.getId())).thenReturn(Flux.empty());
     lenient().when(achievementService.getAchievementDefinitions()).thenReturn(Flux.empty());
     lenient().when(leaderboardService.getLeaderboards()).thenReturn(Flux.just(leaderboard));
     lenient().when(i18n.getOrDefault(leaderboard.technicalName(), leaderboard.nameKey()))
@@ -91,15 +92,7 @@ public class PrivatePlayerInfoControllerTest extends PlatformTest {
   }
 
   @Test
-  public void testSetChatUserWithPlayerNoGame() {
-    player.setLeaderboardRatings(LeaderboardRatingMapBuilder.create()
-                                                            .put(leaderboard.technicalName(),
-                                                                 Instancio.create(LeaderboardRating.class))
-                                                            .get());
-
-    instance.setChatUser(chatChannelUser);
-    WaitForAsyncUtils.waitForFxEvents();
-
+  public void testCheckGameInfoForIdlePlayer() {
     assertTrue(instance.userImageView.isVisible());
     assertTrue(instance.country.isVisible());
     assertTrue(instance.ratingsLabels.isVisible());
@@ -114,59 +107,47 @@ public class PrivatePlayerInfoControllerTest extends PlatformTest {
     assertTrue(instance.ratingsValues.getText().contains("123"));
     assertEquals("0/0", instance.unlockedAchievements.getText());
     assertEquals("123", instance.gamesPlayed.getText());
-    verify(achievementService).getPlayerAchievements(player.getId());
   }
 
   @Test
-  public void testSetChatUserWithPlayerWithGame() {
-    player.setGame(GameInfoBuilder.create().defaultValues().get());
-    instance.setChatUser(chatChannelUser);
-    WaitForAsyncUtils.waitForFxEvents();
+  public void testCheckGameInfoForPlayerWithGame() {
+    runOnFxThreadAndWait(() -> playerInfo.setGame(GameInfoBuilder.create().status(GameStatus.PLAYING).get()));
 
     assertTrue(instance.gameDetailWrapper.isVisible());
   }
 
   @Test
-  public void testSetChatUserWithPlayerNoGameThenJoinsGame() {
-    instance.setChatUser(chatChannelUser);
-    WaitForAsyncUtils.waitForFxEvents();
-
+  public void testCheckGameInfoPlayerNoGameThenJoinsGame() {
     assertFalse(instance.gameDetailWrapper.isVisible());
 
-    player.setGame(GameInfoBuilder.create().defaultValues().get());
+    runOnFxThreadAndWait(() -> playerInfo.setGame(GameInfoBuilder.create().defaultValues().get()));
 
     assertTrue(instance.gameDetailWrapper.isVisible());
   }
 
   @Test
   public void testSetChatUserLeavesGame() {
-    instance.setChatUser(chatChannelUser);
-    player.setGame(GameInfoBuilder.create().defaultValues().get());
+    runOnFxThreadAndWait(() -> instance.playerProperty().setValue(playerInfo));
+    playerInfo.setGame(GameInfoBuilder.create().defaultValues().get());
     WaitForAsyncUtils.waitForFxEvents();
 
     assertTrue(instance.gameDetailWrapper.isVisible());
 
-    player.setGame(null);
+    playerInfo.setGame(null);
 
     assertFalse(instance.gameDetailWrapper.isVisible());
   }
 
   @Test
   public void testRatingChange() {
-    instance.setChatUser(chatChannelUser);
-    WaitForAsyncUtils.waitForFxEvents();
-
-    player.setLeaderboardRatings(Map.of("test", Instancio.create(LeaderboardRating.class)));
-    WaitForAsyncUtils.waitForFxEvents();
+    runOnFxThreadAndWait(() -> playerInfo.setLeaderboardRatings(Map.of("test", Instancio.create(LeaderboardRating.class))));
 
     verify(leaderboardService).getLeaderboards();
   }
 
   @Test
   public void testSetChatUserWithNoPlayer() {
-    chatChannelUser.setPlayer(null);
-    instance.setChatUser(chatChannelUser);
-    WaitForAsyncUtils.waitForFxEvents();
+    runOnFxThreadAndWait(() -> player.setValue(null));
 
     assertFalse(instance.userImageView.isVisible());
     assertFalse(instance.country.isVisible());
@@ -180,9 +161,7 @@ public class PrivatePlayerInfoControllerTest extends PlatformTest {
 
   @Test
   public void testSetChatUserWithNoPlayerThenGetsPlayer() {
-    chatChannelUser.setPlayer(null);
-    instance.setChatUser(chatChannelUser);
-    WaitForAsyncUtils.waitForFxEvents();
+    runOnFxThreadAndWait(() -> player.setValue(null));
 
     assertFalse(instance.userImageView.isVisible());
     assertFalse(instance.country.isVisible());
@@ -193,12 +172,11 @@ public class PrivatePlayerInfoControllerTest extends PlatformTest {
     assertFalse(instance.unlockedAchievements.isVisible());
     assertFalse(instance.unlockedAchievementsLabel.isVisible());
 
-    player.setLeaderboardRatings(LeaderboardRatingMapBuilder.create()
-                                                            .put(leaderboard.technicalName(),
+    playerInfo.setLeaderboardRatings(LeaderboardRatingMapBuilder.create()
+                                                                .put(leaderboard.technicalName(),
                                                                  Instancio.create(LeaderboardRating.class))
-                                                            .get());
-    chatChannelUser.setPlayer(player);
-    WaitForAsyncUtils.waitForFxEvents();
+                                                                .get());
+    runOnFxThreadAndWait(() -> player.setValue(playerInfo));
 
     assertTrue(instance.userImageView.isVisible());
     assertTrue(instance.country.isVisible());
@@ -214,14 +192,16 @@ public class PrivatePlayerInfoControllerTest extends PlatformTest {
     assertTrue(instance.ratingsValues.getText().contains("123"));
     assertEquals("0/0", instance.unlockedAchievements.getText());
     assertEquals("123", instance.gamesPlayed.getText());
-    verify(achievementService).getPlayerAchievements(player.getId());
+  }
+
+  @Test
+  public void testLoadAchievementsIfPlayerIsNotNull() {
+    assertNotNull(instance.playerProperty().getValue());
+    verify(achievementService).getPlayerAchievements(playerInfo.getId());
   }
 
   @Test
   public void testGetRoot() {
-    instance.setChatUser(chatChannelUser);
-    WaitForAsyncUtils.waitForFxEvents();
-
     assertEquals(instance.privateUserInfoRoot, instance.getRoot());
   }
 }


### PR DESCRIPTION
Closes #3423 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Private chat now uses live player data, improving avatar, online-status, rating and achievement displays.
  * UI now reacts to player updates directly, so info refreshes reliably when the other player’s state changes.
* **Tests**
  * Tests updated to validate the new player-driven behavior and UI updates, including online player lookup and rating/achievement scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->