### PR TITLE
Update java-commons to fix replay parser bug

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -256,7 +256,7 @@ dependencies {
     implementation("io.projectreactor.addons:reactor-extra")
     implementation("io.projectreactor:reactor-tools")
 
-    def commonsVersion = "20251008-e3f795c"
+    def commonsVersion = "20251112-0a26247"
 
     implementation("com.faforever.commons:data:${commonsVersion}") {
         exclude module: 'guava'

--- a/src/main/java/com/faforever/client/replay/ReplayService.java
+++ b/src/main/java/com/faforever/client/replay/ReplayService.java
@@ -34,7 +34,6 @@ import com.faforever.commons.api.elide.ElideNavigatorOnCollection;
 import com.faforever.commons.api.elide.ElideNavigatorOnId;
 import com.faforever.commons.replay.ReplayDataParser;
 import com.faforever.commons.replay.ReplayMetadata;
-import com.fasterxml.jackson.databind.util.ByteBufferBackedInputStream;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
@@ -49,11 +48,11 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.util.function.Tuple2;
 
+import java.io.ByteArrayInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.nio.ByteBuffer;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -370,12 +369,12 @@ public class ReplayService {
 
   private void runFafReplayFile(Path path) throws IOException {
     ReplayDataParser replayData = replayFileReader.parseReplay(path);
-    ByteBuffer rawReplayByteBuffer = replayData.getData();
+    byte[] rawReplayBytes = replayData.getRawReplayData();
 
     Path tempSupComReplayFile = dataPrefs.getCacheDirectory().resolve(TEMP_SCFA_REPLAY_FILE_NAME);
 
     Files.createDirectories(tempSupComReplayFile.getParent());
-    Files.copy(new ByteBufferBackedInputStream(rawReplayByteBuffer), tempSupComReplayFile,
+    Files.copy(new ByteArrayInputStream(rawReplayBytes), tempSupComReplayFile,
                StandardCopyOption.REPLACE_EXISTING);
 
     ReplayMetadata replayMetadata = replayData.getMetadata();

--- a/src/test/java/com/faforever/client/replay/ReplayFileReaderImplTest.java
+++ b/src/test/java/com/faforever/client/replay/ReplayFileReaderImplTest.java
@@ -28,6 +28,6 @@ public class ReplayFileReaderImplTest extends ServiceTest {
     try (InputStream inputStream = new BufferedInputStream(getClass().getResourceAsStream("/replay/test.fafreplay"))) {
       Files.copy(inputStream, tempFile);
     }
-    assertThat(instance.parseReplay(tempFile).getData().capacity(), is(197007));
+    assertThat(instance.parseReplay(tempFile).getRawReplayData().length, is(197007));
   }
 }

--- a/src/test/java/com/faforever/client/replay/ReplayServiceTest.java
+++ b/src/test/java/com/faforever/client/replay/ReplayServiceTest.java
@@ -51,7 +51,6 @@ import reactor.test.StepVerifier;
 import reactor.util.function.Tuple2;
 import reactor.util.function.Tuples;
 
-import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
@@ -186,7 +185,7 @@ public class ReplayServiceTest extends ServiceTest {
 
     lenient().when(replayFileReader.parseReplay(any())).thenReturn(replayDataParser);
     lenient().when(replayDataParser.getMetadata()).thenReturn(replayMetadata);
-    lenient().when(replayDataParser.getData()).thenReturn(ByteBuffer.wrap(REPLAY_FIRST_BYTES));
+    lenient().when(replayDataParser.getRawReplayData()).thenReturn(REPLAY_FIRST_BYTES);
     lenient().when(replayDataParser.getChatMessages()).thenReturn(List.of());
     lenient().when(replayDataParser.getGameOptions()).thenReturn(List.of());
     lenient().when(replayDataParser.getMods()).thenReturn(Map.of());


### PR DESCRIPTION
Closes #3434 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated core project commons dependency to a newer release for improved stability and maintenance.

* **Refactor**
  * Reworked internal replay file processing to improve memory handling and reliability during replay operations; associated tests updated to match the new processing approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->