### PR TITLE
Correction of the loss of the current matchmaking status.

### DIFF
--- a/src/main/java/com/faforever/client/preferences/MatchmakerPrefs.java
+++ b/src/main/java/com/faforever/client/preferences/MatchmakerPrefs.java
@@ -19,7 +19,6 @@ public class MatchmakerPrefs {
 
   private final ObservableSet<Integer> selectedQueueIds = observableSet();
 
-
   public ObservableList<Faction> getFactions() {
     return factions;
   }

--- a/src/main/java/com/faforever/client/preferences/MatchmakerPrefs.java
+++ b/src/main/java/com/faforever/client/preferences/MatchmakerPrefs.java
@@ -17,6 +17,9 @@ public class MatchmakerPrefs {
 
   private final ObservableMap<VetoKey, Integer> appliedVetoes = observableHashMap();
 
+  private final ObservableSet<Integer> selectedQueueIds = observableSet();
+
+
   public ObservableList<Faction> getFactions() {
     return factions;
   }
@@ -29,4 +32,7 @@ public class MatchmakerPrefs {
     return appliedVetoes;
   }
 
+  public ObservableSet<Integer> getSelectedQueueIds() {
+    return selectedQueueIds;
+  }
 }

--- a/src/main/java/com/faforever/client/teammatchmaking/TeamMatchmakingService.java
+++ b/src/main/java/com/faforever/client/teammatchmaking/TeamMatchmakingService.java
@@ -259,6 +259,27 @@ public class TeamMatchmakingService implements InitializingBean {
     matchmakerPrefs.getFactions().subscribe(this::sendFactions);
 
     partyMembersNotReady.bind(playersInGame.emptyProperty().map(empty -> !empty));
+
+    queues.forEach(queue -> listenToSelectedChange(queue));
+    queues.addListener((Change<? extends MatchmakerQueueInfo> change) -> {
+      while (change.next()) {
+        if (change.wasAdded()) {
+          change.getAddedSubList().forEach(this::listenToSelectedChange);
+        }
+      }
+    });
+  }
+
+  private void listenToSelectedChange(MatchmakerQueueInfo queue) {
+    queue.selectedProperty().addListener((obs, oldV, newV) -> {
+      if (newV != null) {
+        if (newV) {
+          matchmakerPrefs.getSelectedQueueIds().add(queue.getId());
+        } else {
+          matchmakerPrefs.getSelectedQueueIds().remove(queue.getId());
+        }
+      }
+    });
   }
 
   private void sendFactions() {
@@ -438,12 +459,20 @@ public class TeamMatchmakingService implements InitializingBean {
                                                                           .collection()
                                                                           .setFilter(qBuilder().string("technicalName")
                                                                                                .eq(matchmakerQueue.getName()));
-    return fafApiAccessor.getMany(navigator).next().map(matchmakerMapper::map)
+    return fafApiAccessor.getMany(navigator)
+                         .next()
+                         .map(matchmakerMapper::map)
                          .map(queue -> matchmakerMapper.update(matchmakerQueue, queue))
-                         .doOnNext(queue -> queue.setSelected(
-                             !matchmakerPrefs.getUnselectedQueueIds().contains(queue.getId())))
-                         .doOnNext(queue -> gameService.getGames().subscribe(() -> updateMatchmakerGameCount(queue)))
-                         .doOnNext(queue -> nameToQueue.put(queue.getTechnicalName(), queue));
+                         .doOnNext(queue -> {
+                           boolean isSelected = !matchmakerPrefs.getUnselectedQueueIds().contains(queue.getId());
+                           queue.setSelected(isSelected);
+                         })
+                         .doOnNext(queue -> {
+                           gameService.getGames().subscribe(() -> updateMatchmakerGameCount(queue));
+                         })
+                         .doOnNext(queue -> {
+                           nameToQueue.put(queue.getTechnicalName(), queue);
+                         });
   }
 
   public CompletableFuture<Boolean> joinQueues() {
@@ -463,6 +492,11 @@ public class TeamMatchmakingService implements InitializingBean {
       notificationService.addImmediateWarnNotification("teammatchmaking.notification.notPartyOwner.message");
       return CompletableFuture.completedFuture(false);
     }
+
+    validQueues.forEach(queue -> {
+      queue.setSelected(true);
+      matchmakerPrefs.getSelectedQueueIds().add(queue.getId());
+    });
 
     return featuredModService.updateFeaturedModToLatest(FAF.getTechnicalName(), false)
                              .thenCompose(aVoid -> validQueues.stream()

--- a/src/main/java/com/faforever/client/teammatchmaking/TeamMatchmakingService.java
+++ b/src/main/java/com/faforever/client/teammatchmaking/TeamMatchmakingService.java
@@ -260,7 +260,14 @@ public class TeamMatchmakingService implements InitializingBean {
 
     partyMembersNotReady.bind(playersInGame.emptyProperty().map(empty -> !empty));
 
-    queues.forEach(queue -> listenToSelectedChange(queue));
+    gameService.getGames().subscribe(() -> queues.forEach(this::updateMatchmakerGameCount));
+
+    queues.forEach(queue -> {
+      if (queue.isSelected()) {
+        matchmakerPrefs.getSelectedQueueIds().add(queue.getId());
+      }
+      listenToSelectedChange(queue);
+    });
     queues.addListener((Change<? extends MatchmakerQueueInfo> change) -> {
       while (change.next()) {
         if (change.wasAdded()) {
@@ -457,22 +464,15 @@ public class TeamMatchmakingService implements InitializingBean {
   private Mono<MatchmakerQueueInfo> getQueueFromApi(MatchmakerInfo.MatchmakerQueue matchmakerQueue) {
     ElideNavigatorOnCollection<MatchmakerQueue> navigator = ElideNavigator.of(MatchmakerQueue.class)
                                                                           .collection()
-                                                                          .setFilter(qBuilder().string("technicalName")
-                                                                                               .eq(matchmakerQueue.getName()));
-    return fafApiAccessor.getMany(navigator)
-                         .next()
+                                                                          .setFilter(qBuilder().string("technicalName").eq(matchmakerQueue.getName()));
+    return fafApiAccessor.getMany(navigator).next()
                          .map(matchmakerMapper::map)
                          .map(queue -> matchmakerMapper.update(matchmakerQueue, queue))
                          .doOnNext(queue -> {
                            boolean isSelected = !matchmakerPrefs.getUnselectedQueueIds().contains(queue.getId());
                            queue.setSelected(isSelected);
                          })
-                         .doOnNext(queue -> {
-                           gameService.getGames().subscribe(() -> updateMatchmakerGameCount(queue));
-                         })
-                         .doOnNext(queue -> {
-                           nameToQueue.put(queue.getTechnicalName(), queue);
-                         });
+                         .doOnNext(queue -> nameToQueue.put(queue.getTechnicalName(), queue));
   }
 
   public CompletableFuture<Boolean> joinQueues() {
@@ -495,7 +495,6 @@ public class TeamMatchmakingService implements InitializingBean {
 
     validQueues.forEach(queue -> {
       queue.setSelected(true);
-      matchmakerPrefs.getSelectedQueueIds().add(queue.getId());
     });
 
     return featuredModService.updateFeaturedModToLatest(FAF.getTechnicalName(), false)


### PR DESCRIPTION
There are cases when the UI and what is happening on the server are out of sync. You think you're on the queue, but in fact you're not even not in.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Matchmaking queue selection is now reliably tracked and preserved across UI changes and server updates.
  * Queue status and info stay synchronized with live server/game changes.

* **New Features**
  * Queue selections are auto-applied when joining matchmaking and queue game counts update in real time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->