### PR TITLE
Mask JWT in logs

### DIFF
--- a/src/main/java/com/faforever/client/api/TokenRetriever.java
+++ b/src/main/java/com/faforever/client/api/TokenRetriever.java
@@ -49,9 +49,9 @@ public class TokenRetriever implements InitializingBean {
 
   @Override
   public void afterPropertiesSet() throws Exception {
-    refreshTokenValue.set(loginPrefs.getRefreshToken());
     refreshTokenValue.addListener(
         (_, _, newValue) -> LogMaskingRegistry.update(SensitiveValueType.REFRESH_TOKEN, newValue));
+    refreshTokenValue.set(loginPrefs.getRefreshToken());
     loginPrefs.refreshTokenProperty()
               .bind(loginPrefs.rememberMeProperty().flatMap(remember -> remember ? refreshTokenValue : null));
   }

--- a/src/main/java/com/faforever/client/api/TokenRetriever.java
+++ b/src/main/java/com/faforever/client/api/TokenRetriever.java
@@ -5,6 +5,8 @@ import com.faforever.client.config.ClientProperties.Oauth;
 import com.faforever.client.login.NoRefreshTokenException;
 import com.faforever.client.login.TokenRetrievalException;
 import com.faforever.client.preferences.LoginPrefs;
+import com.faforever.client.util.LogMaskingRegistry;
+import com.faforever.client.util.LogMaskingRegistry.SensitiveValueType;
 import com.nimbusds.jwt.JWTParser;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
@@ -48,6 +50,8 @@ public class TokenRetriever implements InitializingBean {
   @Override
   public void afterPropertiesSet() throws Exception {
     refreshTokenValue.set(loginPrefs.getRefreshToken());
+    refreshTokenValue.addListener(
+        (_, _, newValue) -> LogMaskingRegistry.update(SensitiveValueType.REFRESH_TOKEN, newValue));
     loginPrefs.refreshTokenProperty()
               .bind(loginPrefs.rememberMeProperty().flatMap(remember -> remember ? refreshTokenValue : null));
   }
@@ -65,7 +69,8 @@ public class TokenRetriever implements InitializingBean {
   public Mono<String> getRefreshedHmacValue() {
     return getRefreshedTokenValue().flatMap(tokenValue -> {
       try {
-        return Mono.just(JWTParser.parse(tokenValue).getJWTClaimsSet().getJSONObjectClaim("ext").get("hmac").toString());
+        return Mono.just(JWTParser.parse(tokenValue).getJWTClaimsSet().getJSONObjectClaim("ext").get("hmac").toString())
+                   .doOnNext(value -> LogMaskingRegistry.update(SensitiveValueType.HMAC, value));
       } catch (Exception e) {
         return Mono.error(e);
       }
@@ -128,7 +133,10 @@ public class TokenRetriever implements InitializingBean {
                              refreshTokenValue.set(refreshToken != null ? refreshToken.getTokenValue() : null);
                            })
                            .map(OAuth2AccessTokenResponse::getAccessToken)
-                           .doOnNext(token -> log.info("Token valid until {}", token.getExpiresAt()));
+                           .doOnNext(token -> {
+                             LogMaskingRegistry.update(SensitiveValueType.ACCESS_TOKEN, token.getTokenValue());
+                             log.info("Token valid until {}", token.getExpiresAt());
+                           });
   }
 
   public void invalidateToken() {

--- a/src/main/java/com/faforever/client/preferences/LoginPrefs.java
+++ b/src/main/java/com/faforever/client/preferences/LoginPrefs.java
@@ -1,5 +1,7 @@
 package com.faforever.client.preferences;
 
+import com.faforever.client.util.LogMaskingRegistry;
+import com.faforever.client.util.LogMaskingRegistry.SensitiveValueType;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleStringProperty;
@@ -9,8 +11,13 @@ import javafx.beans.property.StringProperty;
 
 public class LoginPrefs {
   private final StringProperty endpoint = new SimpleStringProperty();
-  private final StringProperty refreshToken = new SimpleStringProperty();
+  private final StringProperty refreshToken;
   private final BooleanProperty rememberMe = new SimpleBooleanProperty(true);
+
+  public LoginPrefs() {
+    refreshToken = new SimpleStringProperty();
+    refreshToken.addListener((_, _, newValue) -> LogMaskingRegistry.update(SensitiveValueType.REFRESH_TOKEN, newValue));
+  }
 
   public String getEndpoint() {
     return endpoint.get();

--- a/src/main/java/com/faforever/client/preferences/LoginPrefs.java
+++ b/src/main/java/com/faforever/client/preferences/LoginPrefs.java
@@ -1,7 +1,5 @@
 package com.faforever.client.preferences;
 
-import com.faforever.client.util.LogMaskingRegistry;
-import com.faforever.client.util.LogMaskingRegistry.SensitiveValueType;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleStringProperty;
@@ -11,13 +9,8 @@ import javafx.beans.property.StringProperty;
 
 public class LoginPrefs {
   private final StringProperty endpoint = new SimpleStringProperty();
-  private final StringProperty refreshToken;
+  private final StringProperty refreshToken = new SimpleStringProperty();
   private final BooleanProperty rememberMe = new SimpleBooleanProperty(true);
-
-  public LoginPrefs() {
-    refreshToken = new SimpleStringProperty();
-    refreshToken.addListener((_, _, newValue) -> LogMaskingRegistry.update(SensitiveValueType.REFRESH_TOKEN, newValue));
-  }
 
   public String getEndpoint() {
     return endpoint.get();

--- a/src/main/java/com/faforever/client/util/LogMaskingRegistry.java
+++ b/src/main/java/com/faforever/client/util/LogMaskingRegistry.java
@@ -2,6 +2,7 @@ package com.faforever.client.util;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.List;
 import java.util.Map;
@@ -41,12 +42,13 @@ public final class LogMaskingRegistry {
    * Masks log message
    */
   static String maskMessage(String message) {
-    if (message == null || message.isEmpty()) {return message;}
+    if (StringUtils.isBlank(message)) {
+      return message;
+    }
 
     String maskedMessage = message;
     for (LogMaskingRegistry.SensitiveValueType type : LogMaskingRegistry.SensitiveValueType.values()) {
       List<String> secrets = LogMaskingRegistry.STORE.get(type).get();
-      if (secrets.isEmpty()) {continue;}
       for (String secret : secrets) {
         maskedMessage = maskedMessage.replace(secret, "%" + type.name() + "%");
       }

--- a/src/main/java/com/faforever/client/util/LogMaskingRegistry.java
+++ b/src/main/java/com/faforever/client/util/LogMaskingRegistry.java
@@ -1,0 +1,62 @@
+package com.faforever.client.util;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicReference;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class LogMaskingRegistry {
+  private static final Map<SensitiveValueType, AtomicReference<List<String>>> STORE = new ConcurrentHashMap<>();
+
+  static {
+    for (SensitiveValueType type : SensitiveValueType.values()) {
+      STORE.put(type, new AtomicReference<>(List.of()));
+    }
+  }
+
+  /**
+   * Replace the masked value for a given secret type. Keeps at most 2 values (current + previous).
+   */
+  public static void update(SensitiveValueType type, String newValue) {
+    if (newValue == null || newValue.isBlank()) {
+      return;
+    }
+
+    STORE.get(type).getAndUpdate(existing -> {
+      if (existing.isEmpty()) {
+        return List.of(newValue);
+      }
+      if (existing.getFirst().equals(newValue)) {
+        return existing;
+      }
+      return List.of(newValue, existing.getFirst());
+    });
+  }
+
+  /**
+   * Masks log message
+   */
+  static String maskMessage(String message) {
+    if (message == null || message.isEmpty()) {return message;}
+
+    String maskedMessage = message;
+    for (LogMaskingRegistry.SensitiveValueType type : LogMaskingRegistry.SensitiveValueType.values()) {
+      List<String> secrets = LogMaskingRegistry.STORE.get(type).get();
+      if (secrets.isEmpty()) {continue;}
+      for (String secret : secrets) {
+        maskedMessage = maskedMessage.replace(secret, "%" + type.name() + "%");
+      }
+    }
+    return maskedMessage;
+  }
+
+  public enum SensitiveValueType {
+    ACCESS_TOKEN, REFRESH_TOKEN, HMAC
+  }
+
+}
+

--- a/src/main/java/com/faforever/client/util/MaskPatternLayout.java
+++ b/src/main/java/com/faforever/client/util/MaskPatternLayout.java
@@ -30,9 +30,10 @@ public class MaskPatternLayout extends PatternLayout {
   }
 
   public String maskMessage(String message) {
-    return message
-        .replaceAll("(?i)" + Pattern.quote(userProfile), "%USER_PROFILE%")
-        .replaceAll("(?i)" + Pattern.quote(machineName), "%CPU_NAME%")
-        .replaceAll("(?i)" + Pattern.quote(user), "%USER%");
+    String masked = message.replaceAll("(?i)" + Pattern.quote(userProfile), "%USER_PROFILE%")
+                           .replaceAll("(?i)" + Pattern.quote(machineName), "%CPU_NAME%")
+                           .replaceAll("(?i)" + Pattern.quote(user), "%USER%");
+
+    return LogMaskingRegistry.maskMessage(masked);
   }
 }

--- a/src/test/java/com/faforever/client/util/TestMaskPatternLayout.java
+++ b/src/test/java/com/faforever/client/util/TestMaskPatternLayout.java
@@ -2,6 +2,7 @@ package com.faforever.client.util;
 
 
 import com.faforever.client.test.ServiceTest;
+import com.faforever.client.util.LogMaskingRegistry.SensitiveValueType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -31,13 +32,16 @@ public class TestMaskPatternLayout extends ServiceTest {
     } catch (UnknownHostException e) {
       machineName = "";
     }
+    String refreshToken = "refreshToken123";
+    LogMaskingRegistry.update(SensitiveValueType.REFRESH_TOKEN, refreshToken);
 
-    String logMessage = String.format("%ssdfe%segfd%seew", userProfile, userName, machineName);
+    String logMessage = String.format("%ssdfe%segfd%secwafasf%s", userProfile, userName, machineName, refreshToken);
     String cleanLogMessage = instance.maskMessage(logMessage);
 
     assertThat(cleanLogMessage, not(containsString(userProfile)));
     assertThat(cleanLogMessage, not(containsString(userName)));
     assertThat(cleanLogMessage, not(containsString(machineName)));
+    assertThat(cleanLogMessage, not(containsString(refreshToken)));
 
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Authentication secrets (access tokens, refresh tokens, HMACs) are automatically masked in application logs to prevent exposure.
  * Masking is applied consistently to all token-related log output.

* **Chores**
  * Logging infrastructure enhanced to support comprehensive token masking.
  * Test coverage extended to verify masking of refresh tokens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->