### PR TITLE
Docs: fix Linux install links in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -23,7 +23,7 @@ The official client for [Forged Alliance Forever (FAF)](https://www.faforever.co
 A video tutorial is available [here](https://youtu.be/6gsHnt02I_Y). Don't forget to `Enable annotation processing`.
 
 ### Linux
-Learn how to install the client on Linux [here](https://github.com/FAForever/downlords-faf-client/wiki/Install-on-Linux).
+Please see this [guide](https://wiki.faforever.com/en/Play/Linux-Install) for instructions on how to install FAF on Linux. Alternatively, a youtube [guide](https://www.youtube.com/watch?v=4Wm-yZpV_q8) is available.
 
 ## Open Source Licenses
 |                                                                                                                                                |                                                                                                                                                                                               |


### PR DESCRIPTION
Fixes the Linux install link in README to point to the current FAF Linux installation guide, and adds the up-to-date video link.\n\nRelated: #3133

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Linux installation guide references with a new guide page and added an alternative YouTube guide link for improved user choice.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->