### PR TITLE
Profile: Only load one month of games by default

### DIFF
--- a/src/main/java/com/faforever/client/player/PlayerInfoWindowController.java
+++ b/src/main/java/com/faforever/client/player/PlayerInfoWindowController.java
@@ -472,7 +472,7 @@ public class PlayerInfoWindowController extends NodeController<Node> {
   }
 
   private Mono<Void> loadStatistics(Leaderboard leaderboard) {
-    TimePeriod timePeriod = timePeriodComboBox.getValue();
+    TimePeriod timePeriod = timePeriodComboBox.getValue() != null ? timePeriodComboBox.getValue() : TimePeriod.ALL_TIME;
     OffsetDateTime since = timePeriod == TimePeriod.ALL_TIME
         ? null
         : OffsetDateTime.of(timePeriod.getDate(), ZoneOffset.UTC);

--- a/src/main/java/com/faforever/client/player/PlayerInfoWindowController.java
+++ b/src/main/java/com/faforever/client/player/PlayerInfoWindowController.java
@@ -179,7 +179,7 @@ public class PlayerInfoWindowController extends NodeController<Node> {
     timePeriodComboBox.setConverter(timePeriodStringConverter());
 
     timePeriodComboBox.getItems().addAll(TimePeriod.values());
-    timePeriodComboBox.setValue(TimePeriod.ALL_TIME);
+    timePeriodComboBox.setValue(TimePeriod.LAST_MONTH);
 
     ratingTypeComboBox.setConverter(leaderboardStringConverter());
 
@@ -472,7 +472,11 @@ public class PlayerInfoWindowController extends NodeController<Node> {
   }
 
   private Mono<Void> loadStatistics(Leaderboard leaderboard) {
-    return statisticsService.getRatingHistory(player, leaderboard)
+    TimePeriod timePeriod = timePeriodComboBox.getValue();
+    OffsetDateTime since = timePeriod == TimePeriod.ALL_TIME
+        ? null
+        : OffsetDateTime.of(timePeriod.getDate(), ZoneOffset.UTC);
+    return statisticsService.getRatingHistory(player, leaderboard, since)
                             .collectList()
                             .doOnNext(ratingHistory -> ratingData = ratingHistory)
                             .doOnError(throwable -> {

--- a/src/main/java/com/faforever/client/stats/StatisticsService.java
+++ b/src/main/java/com/faforever/client/stats/StatisticsService.java
@@ -8,11 +8,14 @@ import com.faforever.client.domain.server.PlayerInfo;
 import com.faforever.client.mapstruct.LeaderboardMapper;
 import com.faforever.commons.api.elide.ElideNavigator;
 import com.faforever.commons.api.elide.ElideNavigatorOnCollection;
+import jakarta.annotation.Nullable;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;
+
+import java.time.OffsetDateTime;
 
 import static com.faforever.commons.api.elide.ElideNavigator.qBuilder;
 
@@ -26,18 +29,33 @@ public class StatisticsService {
   private final LeaderboardMapper leaderboardMapper;
 
   @Cacheable(value = CacheNames.RATING_HISTORY, sync = true)
-  public Flux<LeaderboardRatingJournal> getRatingHistory(PlayerInfo player, Leaderboard leaderboard) {
+  public Flux<LeaderboardRatingJournal> getRatingHistory(PlayerInfo player, Leaderboard leaderboard,
+                                                         @Nullable OffsetDateTime since) {
     ElideNavigatorOnCollection<com.faforever.commons.api.dto.LeaderboardRatingJournal> navigator = ElideNavigator.of(
                                                                                                                      com.faforever.commons.api.dto.LeaderboardRatingJournal.class)
                                                                                                                  .collection()
                                                                                                                  .setFilter(
-                                                                                                                     qBuilder().intNum(
-                                                                                                                                   "gamePlayerStats.player.id")
-                                                                                                                               .eq(player.getId())
-                                                                                                                               .and()
-                                                                                                                               .intNum(
-                                                                                                                                   "leaderboard.id")
-                             .eq(leaderboard.id()))
+                                                                                                                     since != null
+                                                                                                                         ? qBuilder().instant(
+                                                                                                                                         "gamePlayerStats.scoreTime")
+                                                                                                                                     .after(
+                                                                                                                                         since.toInstant(),
+                                                                                                                                         false)
+                                                                                                                                     .and()
+                                                                                                                                     .intNum(
+                                                                                                                                         "gamePlayerStats.player.id")
+                                                                                                                                     .eq(player.getId())
+                                                                                                                                     .and()
+                                                                                                                                     .intNum(
+                                                                                                                                         "leaderboard.id")
+                                                                                                                                     .eq(leaderboard.id())
+                                                                                                                         : qBuilder().intNum(
+                                                                                                                                         "gamePlayerStats.player.id")
+                                                                                                                                     .eq(player.getId())
+                                                                                                                                     .and()
+                                                                                                                                     .intNum(
+                                                                                                                                         "leaderboard.id")
+                                                                                                                                     .eq(leaderboard.id()))
                                                                                                                  .pageSize(
                                                                                                                      fafApiAccessor.getMaxPageSize());
     return fafApiAccessor.getAll(navigator).map(leaderboardMapper::map).cache();

--- a/src/main/resources/theme/user_info_window.fxml
+++ b/src/main/resources/theme/user_info_window.fxml
@@ -57,7 +57,7 @@
                                       <Insets top="10.0"/>
                                   </padding>
                                   <children>
-                            <ComboBox fx:id="timePeriodComboBox" onAction="#plotPlayerRatingGraph"/>
+                            <ComboBox fx:id="timePeriodComboBox" onAction="#onRatingTypeChange"/>
                             <ComboBox fx:id="ratingTypeComboBox" onAction="#onRatingTypeChange"/>
                                   </children>
                               </HBox>

--- a/src/test/java/com/faforever/client/player/PlayerInfoWindowControllerTest.java
+++ b/src/test/java/com/faforever/client/player/PlayerInfoWindowControllerTest.java
@@ -97,7 +97,7 @@ public class PlayerInfoWindowControllerTest extends PlatformTest {
     lenient().when(leaderboardService.getLeaderboards()).thenReturn(Flux.just(leaderboard));
     lenient().when(leaderboardService.getEntriesForPlayer(eq(player)))
              .thenReturn(Flux.just(Instancio.create(LeaderboardEntry.class)));
-    lenient().when(statisticsService.getRatingHistory(eq(player), any()))
+    lenient().when(statisticsService.getRatingHistory(eq(player), any(), any()))
              .thenReturn(Flux.fromIterable(Instancio.ofList(LeaderboardRatingJournal.class)
                                                     .size(2)
                                                     .set(field(LeaderboardRatingJournal::meanBefore), 1500d)
@@ -183,6 +183,6 @@ public class PlayerInfoWindowControllerTest extends PlatformTest {
     testSetPlayerInfoBean();
     instance.ratingTypeComboBox.setValue(leaderboard);
     instance.onRatingTypeChange();
-    verify(statisticsService, times(2)).getRatingHistory(player, leaderboard);
+    verify(statisticsService, times(2)).getRatingHistory(eq(player), eq(leaderboard), any());
   }
 }

--- a/src/test/java/com/faforever/client/player/PlayerInfoWindowControllerTest.java
+++ b/src/test/java/com/faforever/client/player/PlayerInfoWindowControllerTest.java
@@ -32,6 +32,8 @@ import org.testfx.util.WaitForAsyncUtils;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+import java.util.Objects;
+
 import static org.instancio.Select.field;
 import static org.instancio.Select.scope;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -39,7 +41,10 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -184,5 +189,25 @@ public class PlayerInfoWindowControllerTest extends PlatformTest {
     instance.ratingTypeComboBox.setValue(leaderboard);
     instance.onRatingTypeChange();
     verify(statisticsService, times(2)).getRatingHistory(eq(player), eq(leaderboard), any());
+  }
+
+  @Test
+  public void testOnRatingTypeChangeWithLastMonthSuppliesNonNullSince() {
+    testSetPlayerInfoBean();
+    instance.timePeriodComboBox.setValue(TimePeriod.LAST_MONTH);
+    instance.ratingTypeComboBox.setValue(leaderboard);
+    instance.onRatingTypeChange();
+    waitForFxEvents();
+    verify(statisticsService, atLeastOnce()).getRatingHistory(eq(player), eq(leaderboard), argThat(Objects::nonNull));
+  }
+
+  @Test
+  public void testOnRatingTypeChangeWithAllTimeSuppliesNullSince() {
+    testSetPlayerInfoBean();
+    instance.timePeriodComboBox.setValue(TimePeriod.ALL_TIME);
+    instance.ratingTypeComboBox.setValue(leaderboard);
+    instance.onRatingTypeChange();
+    waitForFxEvents();
+    verify(statisticsService, atLeastOnce()).getRatingHistory(eq(player), eq(leaderboard), isNull());
   }
 }

--- a/src/test/java/com/faforever/client/stats/StatisticsServiceTest.java
+++ b/src/test/java/com/faforever/client/stats/StatisticsServiceTest.java
@@ -50,7 +50,7 @@ public class StatisticsServiceTest extends ServiceTest {
     PlayerInfo player = PlayerInfoBuilder.create().defaultValues().username("junit").get();
     Flux<ElideEntity> resultFlux = Flux.just(leaderboardMapper.map(leaderboardRatingJournal));
     when(fafApiAccessor.getAll(any())).thenReturn(resultFlux);
-    StepVerifier.create(instance.getRatingHistory(player, leaderboard)).expectNextCount(1)
+    StepVerifier.create(instance.getRatingHistory(player, leaderboard, null)).expectNextCount(1)
                 .expectComplete()
                 .verify();
     verify(fafApiAccessor).getAll(argThat(

--- a/src/test/java/com/faforever/client/stats/StatisticsServiceTest.java
+++ b/src/test/java/com/faforever/client/stats/StatisticsServiceTest.java
@@ -20,6 +20,8 @@ import org.mockito.Spy;
 import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
 
+import java.time.OffsetDateTime;
+
 import static com.faforever.commons.api.elide.ElideNavigator.qBuilder;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -55,6 +57,29 @@ public class StatisticsServiceTest extends ServiceTest {
                 .verify();
     verify(fafApiAccessor).getAll(argThat(
         ElideMatchers.hasFilter(qBuilder().intNum("gamePlayerStats.player.id").eq(player.getId()).and()
+                                          .intNum("leaderboard.id")
+                                          .eq(leaderboard.id()))
+    ));
+    verify(fafApiAccessor).getAll(argThat(ElideMatchers.hasPageSize(10000)));
+  }
+
+  @Test
+  public void testGetStatisticsForPlayerWithSince() throws Exception {
+    LeaderboardRatingJournal leaderboardRatingJournal = Instancio.create(LeaderboardRatingJournal.class);
+    PlayerInfo player = PlayerInfoBuilder.create().defaultValues().username("junit").get();
+    OffsetDateTime since = OffsetDateTime.now().minusDays(1);
+    Flux<ElideEntity> resultFlux = Flux.just(leaderboardMapper.map(leaderboardRatingJournal));
+    when(fafApiAccessor.getAll(any())).thenReturn(resultFlux);
+    StepVerifier.create(instance.getRatingHistory(player, leaderboard, since)).expectNextCount(1)
+                .expectComplete()
+                .verify();
+    verify(fafApiAccessor).getAll(argThat(
+        ElideMatchers.hasFilter(qBuilder().instant("gamePlayerStats.scoreTime")
+                                          .after(since.toInstant(), false)
+                                          .and()
+                                          .intNum("gamePlayerStats.player.id")
+                                          .eq(player.getId())
+                                          .and()
                                           .intNum("leaderboard.id")
                                           .eq(leaderboard.id()))
     ));


### PR DESCRIPTION
Currently profile page gets all games by default, this causes a lot of lag for players with a lot of games. This changes the default to only fetch games from the last month, significantly reducing loading time.

* **New Features**
  * Rating history now filters based on your selected time period instead of always fetching all data.
  * Default time period changed from "All Time" to "Last Month" for improved performance.

Before:
<img width="1349" height="1088" alt="image" src="https://github.com/user-attachments/assets/9911392d-9e27-46ac-9fac-24b05af28c1e" />

After:
<img width="1337" height="1080" alt="image" src="https://github.com/user-attachments/assets/86c0fd9a-a934-4675-8835-63db3ea52328" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Rating statistics now filter based on the selected time period, allowing users to view data for specific periods (Last Month, Last Year, etc.) instead of all-time history.
  * Default time period selection changed to "Last Month" for a more relevant initial view.

* **Bug Fixes**
  * Time period selection now properly triggers rating display updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->