### PR TITLE
[3496] Takes 1st value, logged occurence, though doesnt make sense.

### DIFF
--- a/src/main/java/com/faforever/client/leaderboard/LeaderboardService.java
+++ b/src/main/java/com/faforever/client/leaderboard/LeaderboardService.java
@@ -20,6 +20,7 @@ import com.faforever.commons.api.elide.ElideNavigatorOnCollection;
 import com.github.rutledgepaulv.qbuilders.conditions.Condition;
 import javafx.scene.image.Image;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
@@ -42,6 +43,7 @@ import static com.faforever.commons.api.elide.ElideNavigator.qBuilder;
 @Lazy
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class LeaderboardService {
 
   private final AssetService assetService;
@@ -202,6 +204,8 @@ public class LeaderboardService {
                                                                             .addSortingRule(
                                                                                 "leagueSeasonDivisionSubdivision.subdivisionIndex",
                                                                                 false).addSortingRule("score", false)
+                                                                            // Unique tiebreaker for stable pagination order (#3496)
+                                                                            .addSortingRule("loginId", true)
                                                                             .pageSize(fafApiAccessor.getMaxPageSize());
 
     return fafApiAccessor.getAll(navigator).index().collectList().flatMapMany(this::mapLeagueEntryDtoToBean).cache();
@@ -212,7 +216,21 @@ public class LeaderboardService {
                                                                                        .collect(Collectors.toMap(
                                                                                            tuple -> tuple.getT2()
                                                                                                          .getLoginId(),
-                                                                                           Function.identity()));
+                                                                                           Function.identity(),
+                                                                                           (first, duplicate) -> {
+                                                                                             log.warn(
+                                                                                                 "Duplicate league entry for loginId {} at rank {} (entity id {}), "
+                                                                                                     + "already had rank {} (entity id {}) for the same player - keeping the first one",
+                                                                                                 duplicate.getT2()
+                                                                                                          .getLoginId(),
+                                                                                                 duplicate.getT1(),
+                                                                                                 duplicate.getT2()
+                                                                                                          .getId(),
+                                                                                                 first.getT1(),
+                                                                                                 first.getT2()
+                                                                                                      .getId());
+                                                                                             return first;
+                                                                                           }));
     return playerService.getPlayersByIds(scoresByPlayer.keySet()).map(player -> {
       Tuple2<Long, LeagueSeasonScore> seasonScoreWithRank = scoresByPlayer.get(player.getId());
       return leaderboardMapper.map(seasonScoreWithRank.getT2(), player, seasonScoreWithRank.getT1());

--- a/src/test/java/com/faforever/client/leaderboard/LeaderboardServiceTest.java
+++ b/src/test/java/com/faforever/client/leaderboard/LeaderboardServiceTest.java
@@ -18,6 +18,7 @@ import com.faforever.client.remote.AssetService;
 import com.faforever.client.test.ElideMatchers;
 import com.faforever.client.test.ServiceTest;
 import com.faforever.commons.api.elide.ElideEntity;
+import com.faforever.commons.api.elide.ElideNavigatorOnCollection;
 import org.instancio.Instancio;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -222,6 +223,28 @@ public class LeaderboardServiceTest extends ServiceTest {
         Flux.just(PlayerInfoBuilder.create().id(1).username("junit").get()));
 
     StepVerifier.create(instance.getActiveEntries(leagueSeason)).expectNext(leagueEntry).verifyComplete();
+
+    verify(fafApiAccessor).getAll(
+        argThat((ElideNavigatorOnCollection<?> navigator) -> navigator != null && navigator.build()
+                                                                                            .contains(",loginId")));
+  }
+
+  @Test
+  public void testGetLeagueEntriesDuplicateLoginIdKeepsFirstInsteadOfThrowing() {
+    LeagueSeason leagueSeason = Instancio.create(LeagueSeason.class);
+    LeagueEntry leagueEntry1 = Instancio.of(LeagueEntry.class)
+                                        .set(field(LeagueEntry::rank), 0L)
+                                        .set(field(LeagueEntry::player), player)
+                                        .create();
+    LeagueEntry leagueEntry2 = Instancio.of(LeagueEntry.class)
+                                        .set(field(LeagueEntry::player), player)
+                                        .create();
+    Flux<ElideEntity> resultFlux = Flux.just(leaderboardMapper.map(leagueEntry1), leaderboardMapper.map(leagueEntry2));
+    when(fafApiAccessor.getAll(any())).thenReturn(resultFlux);
+    when(playerService.getPlayersByIds(anyCollection())).thenReturn(
+        Flux.just(PlayerInfoBuilder.create().id(1).username("junit").get()));
+
+    StepVerifier.create(instance.getActiveEntries(leagueSeason)).expectNext(leagueEntry1).verifyComplete();
   }
 
   @Test


### PR DESCRIPTION
https://github.com/FAForever/downlords-faf-client/issues/3496 - hopeful fix?

dunno if it counts as fix, if i hit the correct position ... doesnt make sense, how there can be duplicate issue.
If there is sounds like DB mess.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved leaderboard data processing to handle duplicate player entries gracefully, ensuring more reliable and consistent ranking information.
  * Improved leaderboard pagination stability by applying a consistent tie-breaker when entries share the same ranking criteria.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->