### PR TITLE
MaskPatternLayout: skip masking tokens shorter than 3 characters

### DIFF
--- a/src/main/java/com/faforever/client/util/MaskPatternLayout.java
+++ b/src/main/java/com/faforever/client/util/MaskPatternLayout.java
@@ -8,6 +8,12 @@ import java.net.UnknownHostException;
 import java.util.regex.Pattern;
 
 public class MaskPatternLayout extends PatternLayout {
+  // Tokens shorter than this are too generic to mask safely - e.g. a single-letter
+  // hostname like "A" would match every 'a' in every log line under the (?i) regex
+  // and shred readability. The masks exist to redact identifying information from
+  // shared logs; a 1-2 character token is not identifying anyway.
+  private static final int MIN_MASK_LENGTH = 3;
+
   private final String userProfile;
   private final String machineName;
   private final String user;
@@ -30,10 +36,21 @@ public class MaskPatternLayout extends PatternLayout {
   }
 
   public String maskMessage(String message) {
-    String masked = message.replaceAll("(?i)" + Pattern.quote(userProfile), "%USER_PROFILE%")
-                           .replaceAll("(?i)" + Pattern.quote(machineName), "%CPU_NAME%")
-                           .replaceAll("(?i)" + Pattern.quote(user), "%USER%");
+    String masked = message;
+    if (isMaskable(userProfile)) {
+      masked = masked.replaceAll("(?i)" + Pattern.quote(userProfile), "%USER_PROFILE%");
+    }
+    if (isMaskable(machineName)) {
+      masked = masked.replaceAll("(?i)" + Pattern.quote(machineName), "%CPU_NAME%");
+    }
+    if (isMaskable(user)) {
+      masked = masked.replaceAll("(?i)" + Pattern.quote(user), "%USER%");
+    }
 
     return LogMaskingRegistry.maskMessage(masked);
+  }
+
+  private static boolean isMaskable(String token) {
+    return token != null && token.length() >= MIN_MASK_LENGTH;
   }
 }


### PR DESCRIPTION
## Problem

`MaskPatternLayout` replaces every (case-insensitive) occurrence of the
user's home directory, hostname, and username with `%USER_PROFILE%`,
`%CPU_NAME%`, and `%USER%` respectively, to redact identifying info from
shared logs.

When any of those tokens is 1-2 characters long, the
`(?i)` + `Pattern.quote(...)` regex matches inside otherwise-unrelated
words and shreds log output.

**Concrete repro**: a machine with hostname `A` (single letter) sees
every `a` in every log line replaced with `%CPU_NAME%`. The Spring Boot
startup line

```
Starting Application using Java 25.0.3
```

becomes

```
St%CPU_NAME%rting %CPU_NAME%pplic%CPU_NAME%tion using J%CPU_NAME%v%CPU_NAME% 25.0.3
```

The same applies to a 1-2 character username.

## Fix

Add a minimum-length guard (`MIN_MASK_LENGTH = 3`) and an `isMaskable()`
predicate that gates each `replaceAll` call. Tokens shorter than 3
characters are not uniquely identifying anyway, so nothing of redaction
value is lost by skipping the mask for them.

## Test

Encountered on a Windows machine with hostname `A`; with the patch
applied the log output renders correctly. Existing
`TestMaskPatternLayout` tests should continue to pass since they use
realistic-length tokens.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data masking logic in logs to apply redaction more selectively, avoiding masking of overly generic tokens and ensuring more accurate privacy protection.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FAForever/downlords-faf-client/pull/3513)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->