### PR TITLE
Display localized lobby notice text

### DIFF
--- a/src/main/java/com/faforever/client/remote/FafServerAccessor.java
+++ b/src/main/java/com/faforever/client/remote/FafServerAccessor.java
@@ -54,8 +54,10 @@ import reactor.function.TupleUtils;
 import reactor.util.retry.Retry;
 
 import java.io.IOException;
+import java.lang.reflect.Method;
 import java.net.URL;
 import java.time.Duration;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -278,7 +280,8 @@ public class FafServerAccessor implements InitializingBean, DisposableBean, Life
       taskScheduler.scheduleWithFixedDelay(Platform::exit, Duration.ofSeconds(10));
     }
 
-    if (noticeMessage.getText() == null) {
+    String localizedText = getLocalizedNoticeText(noticeMessage, noticeMessage.getText());
+    if (localizedText == null) {
       return;
     }
 
@@ -294,8 +297,31 @@ public class FafServerAccessor implements InitializingBean, DisposableBean, Life
       };
     }
     notificationService.addNotification(
-        new ServerNotification(i18n.get("messageFromServer"), noticeMessage.getText(), severity,
+        new ServerNotification(i18n.get("messageFromServer"), localizedText, severity,
                                Collections.singletonList(new DismissAction(i18n))));
+  }
+
+  String getLocalizedNoticeText(Object noticeMessage, String fallbackText) {
+    Optional<String> i18nKey = getOptionalNoticeValue(noticeMessage, "getI18nKey", String.class);
+    if (i18nKey.isEmpty()) {
+      return fallbackText;
+    }
+
+    Object[] args = getOptionalNoticeValue(noticeMessage, "getI18nArgs", Object.class)
+        .map(value -> value instanceof Collection<?> collection ? collection.toArray() : new Object[] {value})
+        .orElseGet(() -> new Object[] {});
+
+    return i18n.getOrDefault(fallbackText, i18nKey.get(), args);
+  }
+
+  private <T> Optional<T> getOptionalNoticeValue(Object noticeMessage, String methodName, Class<T> type) {
+    try {
+      Method method = noticeMessage.getClass().getMethod(methodName);
+      Object value = method.invoke(noticeMessage);
+      return type.isInstance(value) ? Optional.of(type.cast(value)) : Optional.empty();
+    } catch (ReflectiveOperationException e) {
+      return Optional.empty();
+    }
   }
 
   public void restoreGameSession(int id) {

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -9,6 +9,7 @@ dismiss = Dismiss
 errorTitle = Uh oh\!
 bytesProgress = {0} of {1}
 messageFromServer = Message from server
+login.error.banned = You are banned from FAF until {0}. <br>Reason: <br>{1}<br><br><i>If you would like to appeal this ban, please send an email to: moderation@faforever.com</i>
 more = More
 less=Less
 searchResult = Search result

--- a/src/test/java/com/faforever/client/remote/ServerAccessorTest.java
+++ b/src/test/java/com/faforever/client/remote/ServerAccessorTest.java
@@ -334,12 +334,46 @@ public class ServerAccessorTest extends ServiceTest {
   }
 
   @Test
+  public void testLocalizedNoticeTextUsesI18nMetadataWhenPresent() {
+    LocalizableNoticeInfo noticeMessage = new LocalizableNoticeInfo("login.error.banned", List.of("2026-06-01"));
+
+    when(i18n.getOrDefault("You are banned from FAF until 2026-06-01", "login.error.banned", "2026-06-01"))
+        .thenReturn("Localized ban notice");
+
+    String text = instance.getLocalizedNoticeText(noticeMessage, "You are banned from FAF until 2026-06-01");
+
+    assertThat(text, is("Localized ban notice"));
+  }
+
+  @Test
+  public void testLocalizedNoticeTextSupportsMetadataOnlyNotices() {
+    LocalizableNoticeInfo noticeMessage = new LocalizableNoticeInfo("login.error.banned", List.of("2026-06-01"));
+
+    when(i18n.getOrDefault((String) null, "login.error.banned", "2026-06-01"))
+        .thenReturn("Localized ban notice");
+
+    String text = instance.getLocalizedNoticeText(noticeMessage, null);
+
+    assertThat(text, is("Localized ban notice"));
+  }
+
+  @Test
   public void onKickNoticeStopsApplication() throws Exception {
     NoticeInfo noticeMessage = new NoticeInfo("kick", null);
 
     sendFromServer(noticeMessage);
 
     verify(taskScheduler, timeout(10000)).scheduleWithFixedDelay(any(Runnable.class), any(Duration.class));
+  }
+
+  private record LocalizableNoticeInfo(String i18nKey, List<Object> i18nArgs) {
+    public String getI18nKey() {
+      return i18nKey;
+    }
+
+    public List<Object> getI18nArgs() {
+      return i18nArgs;
+    }
   }
 
   @Test


### PR DESCRIPTION
## Summary

- use optional lobby notice i18n metadata when present, falling back to the server text for older messages
- add the default English `login.error.banned` message used by FAForever/server#1083
- cover the metadata fallback path without requiring the unreleased commons model fields at compile time

## Context

Companion work for FAForever/server#1083 and FAForever/faf-java-commons#277. This keeps the client backward-compatible with the current commons release while allowing newer notice payloads to render through the client translation bundle once the commons/server pieces land.

Issue: FAForever/server#640

## Verification

- `JAVA_HOME=/Users/yoseph/Codexperiment/.jdks/jdk-25.0.3+9/Contents/Home ./gradlew test` — 1518 tests passed, 33 skipped
- `JAVA_HOME=/Users/yoseph/Codexperiment/.jdks/jdk-25.0.3+9/Contents/Home ./gradlew test --tests com.faforever.client.remote.ServerAccessorTest.testLocalizedNoticeTextUsesI18nMetadataWhenPresent --tests com.faforever.client.remote.ServerAccessorTest.testLocalizedNoticeTextSupportsMetadataOnlyNotices` — 2 focused tests passed
- `git diff --check`
