### PR TITLE
docs: Fix broken installation links for Linux

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -23,7 +23,7 @@ The official client for [Forged Alliance Forever (FAF)](https://www.faforever.co
 A video tutorial is available [here](https://youtu.be/6gsHnt02I_Y). Don't forget to `Enable annotation processing`.
 
 ### Linux
-Please see this [guide](https://wiki.faforever.com/en/Play/Linux-Install) for instructions on how to install FAF on Linux. Alternatively, a youtube [guide](https://www.youtube.com/watch?v=4Wm-yZpV_q8) is available.
+Please see this [guide](https://wiki.faforever.com/en/Play/Linux-Install) for instructions on how to install FAF on Linux, or download the latest package directly from the [Official Releases Page](https://github.com/FAForever/downlords-faf-client/releases). Alternatively, a youtube [guide](https://www.youtube.com/watch?v=4Wm-yZpV_q8) is available.
 
 ## Open Source Licenses
 |                                                                                                                                                |                                                                                                                                                                                               |


### PR DESCRIPTION
Replaced the broken installation guide references with a direct link to the Official Releases page to help Linux users find the latest packages without broken curl commands. Resolves #3133.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an alternative Linux installation option via GitHub releases package downloads alongside existing installation guides.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FAForever/downlords-faf-client/pull/3518)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->