### PR TITLE
Search nested mods to match in-game mod manager behavior

### DIFF
--- a/src/main/java/com/faforever/client/mod/ModService.java
+++ b/src/main/java/com/faforever/client/mod/ModService.java
@@ -185,27 +185,33 @@ public class ModService implements InitializingBean, DisposableBean {
       @Override
       protected Void call() {
         updateTitle(i18n.get("modVault.loadingMods"));
-        try (Stream<Path> customModsDirectory = list(forgedAlliancePrefs.getModsDirectory())) {
-          List<Path> modPaths = new ArrayList<>();
-          customModsDirectory.collect(toCollection(() -> modPaths));
+        Path modsDirectory = forgedAlliancePrefs.getModsDirectory();
+
+        try (Stream<Path> walker = Files.walk(modsDirectory, 2)) {
+          List<Path> modPaths = walker
+              .filter(path -> !path.equals(modsDirectory))
+              .filter(Files::isDirectory)
+              .filter(path -> Files.exists(path.resolve("mod_info.lua")))
+              .collect(toCollection(ArrayList::new));
 
           long totalMods = modPaths.size();
           long modsRead = 0;
+
           for (Path modPath : modPaths) {
             updateProgress(++modsRead, totalMods);
             try {
               addInstalledMod(modPath);
             } catch (Exception e) {
               log.warn("Corrupt mod: `{}`", modPath, e);
-
               notificationService.addPersistentWarnNotification(
                   List.of(new Action(i18n.get("corruptedMods.show"), () -> platformService.reveal(modPath))),
                   "corruptedModsError.notification", modPath.getFileName());
             }
           }
         } catch (IOException e) {
-          log.error("Mods could not be read from: `{}`", forgedAlliancePrefs.getModsDirectory(), e);
+          log.error("Mods could not be read from: `{}`", modsDirectory, e);
         }
+
         return null;
       }
     });


### PR DESCRIPTION
## Change

• Load sub-folder installed mods **to match in-game mod manager behavior**.

---

This is done by walking the first sub-directories of all the mods to find a mod_info.lua and

## Why?

It's useful for reducing vault uploads for ***multi-option UI mods*** or ***SIM and UI combo mods***. 

Examples include "Sim Speed Balancer" (SIM - UI combo mod), or even "ReUI" (large multi option UI mod)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Mod discovery now recursively searches configured directories to find and load installed mods more thoroughly
  * Real-time progress updates provided during the mod loading process
  * Improved error reporting includes clearer path details when directory traversal fails
<!-- end of auto-generated comment: release notes by coderabbit.ai -->