### PR TITLE
Select avatars via the REST API instead of the lobby server

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -283,7 +283,7 @@ dependencies {
     implementation("io.projectreactor.addons:reactor-extra")
     implementation("io.projectreactor:reactor-tools")
 
-    def commonsVersion = "20260407-92612a0"
+    def commonsVersion = "20260626-2e8a5a8"
 
     implementation("com.faforever.commons:data:${commonsVersion}") {
         exclude module: 'guava'

--- a/build.gradle
+++ b/build.gradle
@@ -283,7 +283,7 @@ dependencies {
     implementation("io.projectreactor.addons:reactor-extra")
     implementation("io.projectreactor:reactor-tools")
 
-    def commonsVersion = "20260626-2e8a5a8"
+    def commonsVersion = "20260628-7c450f0"
 
     implementation("com.faforever.commons:data:${commonsVersion}") {
         exclude module: 'guava'

--- a/src/main/java/com/faforever/client/api/FafApiAccessor.java
+++ b/src/main/java/com/faforever/client/api/FafApiAccessor.java
@@ -225,13 +225,15 @@ public class FafApiAccessor implements InitializingBean {
 
   /**
    * Removes the named member from a relationship via the JSON:API relationship endpoint
-   * ({@code DELETE /data/{type}/{id}/relationships/{name}}). Elide requires the related resource to be named
-   * in the body, so for a to-one relationship this clears it only when {@code relatedId} is the current value.
+   * ({@code DELETE /data/{type}/{id}/relationships/{name}}). The owning resource path is built from
+   * {@code navigator}; the relationship segment is appended since the navigator only models the
+   * related-resource path. Elide requires the related resource to be named in the body, so for a
+   * to-one relationship this clears it only when {@code relatedId} is the current value.
    */
-  public Mono<Void> deleteToOneRelationship(String type, String id, String relationshipName,
-                                            String relatedType, String relatedId) {
+  public Mono<Void> deleteFromRelationship(ElideNavigatorOnId<?> navigator, String relationshipName,
+                                           String relatedType, String relatedId) {
     RelationshipDocument body = new RelationshipDocument(new ResourceIdentifier(relatedType, relatedId));
-    String endpointPath = "/data/" + type + "/" + id + "/relationships/" + relationshipName;
+    String endpointPath = navigator.build() + "/relationships/" + relationshipName;
     return retrieveMonoWithErrorHandling(Void.class, apiWebClient.method(HttpMethod.DELETE)
         .uri(endpointPath)
         .contentType(MediaType.parseMediaType(JSONAPI_MEDIA_TYPE))

--- a/src/main/java/com/faforever/client/api/FafApiAccessor.java
+++ b/src/main/java/com/faforever/client/api/FafApiAccessor.java
@@ -33,8 +33,10 @@ import com.faforever.commons.api.elide.ElideEndpointBuilder;
 import com.faforever.commons.api.elide.ElideEntity;
 import com.faforever.commons.api.elide.ElideNavigatorOnCollection;
 import com.faforever.commons.api.elide.ElideNavigatorOnId;
+import com.faforever.commons.api.elide.ElideNavigatorOnRelationshipLink;
 import com.faforever.commons.io.ByteCountListener;
 import com.github.jasminb.jsonapi.JSONAPIDocument;
+import com.github.jasminb.jsonapi.annotations.Type;
 import com.github.jasminb.jsonapi.exceptions.ResourceParseException;
 import com.github.rutledgepaulv.qbuilders.builders.QBuilder;
 import com.github.rutledgepaulv.qbuilders.conditions.Condition;
@@ -225,15 +227,14 @@ public class FafApiAccessor implements InitializingBean {
 
   /**
    * Removes the named member from a relationship via the JSON:API relationship endpoint
-   * ({@code DELETE /data/{type}/{id}/relationships/{name}}). The owning resource path is built from
-   * {@code navigator}; the relationship segment is appended since the navigator only models the
-   * related-resource path. Elide requires the related resource to be named in the body, so for a
+   * ({@code DELETE /data/{type}/{id}/relationships/{name}}). The related resource type is derived from the
+   * navigator's entity type. Elide requires the related resource to be named in the body, so for a
    * to-one relationship this clears it only when {@code relatedId} is the current value.
    */
-  public Mono<Void> deleteFromRelationship(ElideNavigatorOnId<?> navigator, String relationshipName,
-                                           String relatedType, String relatedId) {
+  public Mono<Void> deleteFromRelationship(ElideNavigatorOnRelationshipLink<?> relationshipLink, String relatedId) {
+    String relatedType = relationshipLink.getDtoClass().getAnnotation(Type.class).value();
     RelationshipDocument body = new RelationshipDocument(new ResourceIdentifier(relatedType, relatedId));
-    String endpointPath = navigator.build() + "/relationships/" + relationshipName;
+    String endpointPath = relationshipLink.build();
     return retrieveMonoWithErrorHandling(Void.class, apiWebClient.method(HttpMethod.DELETE)
         .uri(endpointPath)
         .contentType(MediaType.parseMediaType(JSONAPI_MEDIA_TYPE))

--- a/src/main/java/com/faforever/client/api/FafApiAccessor.java
+++ b/src/main/java/com/faforever/client/api/FafApiAccessor.java
@@ -5,6 +5,7 @@ import com.faforever.client.config.ClientProperties.Api;
 import com.faforever.client.io.CountingFileSystemResource;
 import com.faforever.client.login.TokenRetrievalException;
 import com.faforever.commons.api.dto.ApiException;
+import com.faforever.commons.api.dto.AvatarAssignment;
 import com.faforever.commons.api.dto.Clan;
 import com.faforever.commons.api.dto.CoopResult;
 import com.faforever.commons.api.dto.CoopScenario;
@@ -83,6 +84,7 @@ public class FafApiAccessor implements InitializingBean {
 
   @VisibleForTesting
   static final java.util.Map<Class<? extends ElideEntity>, List<String>> INCLUDES = java.util.Map.ofEntries(
+      java.util.Map.entry(AvatarAssignment.class, List.of("avatar")),
       java.util.Map.entry(CoopResult.class, List.of("game.playerStats.player")),
       java.util.Map.entry(Clan.class, List.of("leader", "founder", "memberships", "memberships.player")),
       java.util.Map.entry(LeaderboardEntry.class, List.of("player", "leaderboard")),
@@ -218,6 +220,26 @@ public class FafApiAccessor implements InitializingBean {
         .uri(endpointPath)
         .contentType(MediaType.parseMediaType(JSONAPI_MEDIA_TYPE))
         .bodyValue(request)).doOnSuccess(aVoid -> log.trace("Patched {} at {}", request, endpointPath));
+  }
+
+  /**
+   * Patches a to-one relationship via the JSON:API relationship endpoint
+   * ({@code PATCH /data/{type}/{id}/relationships/{name}}). Unlike a resource PATCH built from a DTO,
+   * this can explicitly clear a relationship by sending {@code {"data": null}}, which the
+   * DTO serializer (configured with {@code Include.NON_NULL}) cannot express.
+   *
+   * @param relatedId the related resource id, or {@code null} to clear the relationship
+   */
+  public Mono<Void> patchToOneRelationship(String type, String id, String relationshipName,
+                                           String relatedType, String relatedId) {
+    String body = relatedId == null
+        ? "{\"data\":null}"
+        : "{\"data\":{\"type\":\"" + relatedType + "\",\"id\":\"" + relatedId + "\"}}";
+    String endpointPath = "/data/" + type + "/" + id + "/relationships/" + relationshipName;
+    return retrieveMonoWithErrorHandling(Void.class, apiWebClient.patch()
+        .uri(endpointPath)
+        .contentType(MediaType.parseMediaType(JSONAPI_MEDIA_TYPE))
+        .bodyValue(body)).doOnSuccess(aVoid -> log.trace("Patched relationship {} at {}", relatedId, endpointPath));
   }
 
   public Mono<Void> delete(ElideNavigatorOnId<?> navigator) {

--- a/src/main/java/com/faforever/client/api/FafApiAccessor.java
+++ b/src/main/java/com/faforever/client/api/FafApiAccessor.java
@@ -46,6 +46,7 @@ import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.ObjectFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Lazy;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
@@ -223,24 +224,24 @@ public class FafApiAccessor implements InitializingBean {
   }
 
   /**
-   * Patches a to-one relationship via the JSON:API relationship endpoint
-   * ({@code PATCH /data/{type}/{id}/relationships/{name}}). Unlike a resource PATCH built from a DTO,
-   * this can explicitly clear a relationship by sending {@code {"data": null}}, which the
-   * DTO serializer (configured with {@code Include.NON_NULL}) cannot express.
-   *
-   * @param relatedId the related resource id, or {@code null} to clear the relationship
+   * Removes the named member from a relationship via the JSON:API relationship endpoint
+   * ({@code DELETE /data/{type}/{id}/relationships/{name}}). Elide requires the related resource to be named
+   * in the body, so for a to-one relationship this clears it only when {@code relatedId} is the current value.
    */
-  public Mono<Void> patchToOneRelationship(String type, String id, String relationshipName,
-                                           String relatedType, String relatedId) {
-    String body = relatedId == null
-        ? "{\"data\":null}"
-        : "{\"data\":{\"type\":\"" + relatedType + "\",\"id\":\"" + relatedId + "\"}}";
+  public Mono<Void> deleteToOneRelationship(String type, String id, String relationshipName,
+                                            String relatedType, String relatedId) {
+    RelationshipDocument body = new RelationshipDocument(new ResourceIdentifier(relatedType, relatedId));
     String endpointPath = "/data/" + type + "/" + id + "/relationships/" + relationshipName;
-    return retrieveMonoWithErrorHandling(Void.class, apiWebClient.patch()
+    return retrieveMonoWithErrorHandling(Void.class, apiWebClient.method(HttpMethod.DELETE)
         .uri(endpointPath)
         .contentType(MediaType.parseMediaType(JSONAPI_MEDIA_TYPE))
-        .bodyValue(body)).doOnSuccess(aVoid -> log.trace("Patched relationship {} at {}", relatedId, endpointPath));
+        .bodyValue(body)).doOnSuccess(aVoid -> log.trace("Deleted relationship member {} at {}", relatedId, endpointPath));
   }
+
+  /** Minimal JSON:API relationship payload (`{"data": {"type": ..., "id": ...}}`) for relationship endpoints. */
+  record RelationshipDocument(ResourceIdentifier data) {}
+
+  record ResourceIdentifier(String type, String id) {}
 
   public Mono<Void> delete(ElideNavigatorOnId<?> navigator) {
     String endpointPath = navigator.build();

--- a/src/main/java/com/faforever/client/avatar/AvatarService.java
+++ b/src/main/java/com/faforever/client/avatar/AvatarService.java
@@ -93,8 +93,8 @@ public class AvatarService {
       if (currentAvatar == null || currentAvatar.id() == null) {
         return;
       }
-      fafApiAccessor.deleteToOneRelationship("player", playerId, "currentAvatar", "avatar",
-              String.valueOf(currentAvatar.id()))
+      fafApiAccessor.deleteFromRelationship(ElideNavigator.of(Player.class).id(playerId), "currentAvatar",
+              "avatar", String.valueOf(currentAvatar.id()))
           .subscribe(null, throwable -> log.error("Could not remove current avatar", throwable));
     });
   }

--- a/src/main/java/com/faforever/client/avatar/AvatarService.java
+++ b/src/main/java/com/faforever/client/avatar/AvatarService.java
@@ -93,8 +93,9 @@ public class AvatarService {
       if (currentAvatar == null || currentAvatar.id() == null) {
         return;
       }
-      fafApiAccessor.deleteFromRelationship(ElideNavigator.of(Player.class).id(playerId), "currentAvatar",
-              "avatar", String.valueOf(currentAvatar.id()))
+      fafApiAccessor.deleteFromRelationship(ElideNavigator.of(Player.class).id(playerId)
+              .relationshipLink(com.faforever.commons.api.dto.Avatar.class, "currentAvatar"),
+              String.valueOf(currentAvatar.id()))
           .subscribe(null, throwable -> log.error("Could not remove current avatar", throwable));
     });
   }

--- a/src/main/java/com/faforever/client/avatar/AvatarService.java
+++ b/src/main/java/com/faforever/client/avatar/AvatarService.java
@@ -8,7 +8,6 @@ import com.faforever.commons.api.dto.AvatarAssignment;
 import com.faforever.commons.api.dto.Player;
 import com.faforever.commons.api.elide.ElideNavigator;
 import com.faforever.commons.api.elide.ElideNavigatorOnCollection;
-import com.faforever.commons.api.elide.ElideNavigatorOnId;
 import javafx.scene.image.Image;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -54,17 +53,6 @@ public class AvatarService {
         .toFuture();
   }
 
-  public CompletableFuture<Avatar> getCurrentAvatar() {
-    String playerId = String.valueOf(playerService.getCurrentPlayer().getId());
-    ElideNavigatorOnId<Player> navigator = ElideNavigator.of(Player.class)
-        .id(playerId)
-        .addInclude("currentAvatar");
-    return fafApiAccessor.getOne(navigator)
-        .mapNotNull(Player::getCurrentAvatar)
-        .map(avatarMapper::map)
-        .toFuture();
-  }
-
   public void changeAvatar(Avatar avatar) {
     // We don't update the local player here: the API writes login.avatar_id, the lobby server consumes the
     // resulting event and broadcasts a player_info back to us, which refreshes the avatar authoritatively.
@@ -88,15 +76,15 @@ public class AvatarService {
 
   private void removeCurrentAvatar() {
     String playerId = String.valueOf(playerService.getCurrentPlayer().getId());
-    // The relationship DELETE must name the avatar to remove, so resolve the currently selected one first.
-    getCurrentAvatar().thenAccept(currentAvatar -> {
-      if (currentAvatar == null || currentAvatar.id() == null) {
-        return;
-      }
-      fafApiAccessor.deleteFromRelationship(ElideNavigator.of(Player.class).id(playerId)
-              .relationshipLink(com.faforever.commons.api.dto.Avatar.class, "currentAvatar"),
-              String.valueOf(currentAvatar.id()))
-          .subscribe(null, throwable -> log.error("Could not remove current avatar", throwable));
-    });
+    Avatar currentAvatar = playerService.getCurrentPlayer().getAvatar();
+
+    if (currentAvatar == null || currentAvatar.id() == null) {
+      return;
+    }
+
+    fafApiAccessor.deleteFromRelationship(ElideNavigator.of(Player.class).id(playerId)
+            .relationshipLink(com.faforever.commons.api.dto.Avatar.class, "currentAvatar"),
+            String.valueOf(currentAvatar.id()))
+        .subscribe(null, throwable -> log.error("Could not remove current avatar", throwable));
   }
 }

--- a/src/main/java/com/faforever/client/avatar/AvatarService.java
+++ b/src/main/java/com/faforever/client/avatar/AvatarService.java
@@ -5,8 +5,10 @@ import com.faforever.client.mapstruct.AvatarMapper;
 import com.faforever.client.player.PlayerService;
 import com.faforever.client.remote.AssetService;
 import com.faforever.commons.api.dto.AvatarAssignment;
+import com.faforever.commons.api.dto.Player;
 import com.faforever.commons.api.elide.ElideNavigator;
 import com.faforever.commons.api.elide.ElideNavigatorOnCollection;
+import com.faforever.commons.api.elide.ElideNavigatorOnId;
 import javafx.scene.image.Image;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.Cacheable;
@@ -47,6 +49,17 @@ public class AvatarService {
         .map(AvatarAssignment::getAvatar)
         .map(avatarMapper::map)
         .collectList()
+        .toFuture();
+  }
+
+  public CompletableFuture<Avatar> getCurrentAvatar() {
+    String playerId = String.valueOf(playerService.getCurrentPlayer().getId());
+    ElideNavigatorOnId<Player> navigator = ElideNavigator.of(Player.class)
+        .id(playerId)
+        .addInclude("currentAvatar");
+    return fafApiAccessor.getOne(navigator)
+        .mapNotNull(Player::getCurrentAvatar)
+        .map(avatarMapper::map)
         .toFuture();
   }
 

--- a/src/main/java/com/faforever/client/avatar/AvatarService.java
+++ b/src/main/java/com/faforever/client/avatar/AvatarService.java
@@ -11,6 +11,7 @@ import com.faforever.commons.api.elide.ElideNavigatorOnCollection;
 import com.faforever.commons.api.elide.ElideNavigatorOnId;
 import javafx.scene.image.Image;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
@@ -24,6 +25,7 @@ import static com.faforever.commons.api.elide.ElideNavigator.qBuilder;
 
 @Lazy
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class AvatarService {
 
@@ -64,9 +66,36 @@ public class AvatarService {
   }
 
   public void changeAvatar(Avatar avatar) {
+    // We don't update the local player here: the API writes login.avatar_id, the lobby server consumes the
+    // resulting event and broadcasts a player_info back to us, which refreshes the avatar authoritatively.
+    if (avatar == null || avatar.id() == null) {
+      removeCurrentAvatar();
+    } else {
+      selectAvatar(avatar);
+    }
+  }
+
+  private void selectAvatar(Avatar avatar) {
     String playerId = String.valueOf(playerService.getCurrentPlayer().getId());
-    String avatarId = avatar == null || avatar.id() == null ? null : String.valueOf(avatar.id());
-    fafApiAccessor.patchToOneRelationship("player", playerId, "currentAvatar", "avatar", avatarId).subscribe();
-    playerService.getCurrentPlayer().setAvatar(avatar);
+    com.faforever.commons.api.dto.Avatar avatarDto = new com.faforever.commons.api.dto.Avatar();
+    avatarDto.setId(String.valueOf(avatar.id()));
+    Player playerDto = new Player();
+    playerDto.setId(playerId);
+    playerDto.setCurrentAvatar(avatarDto);
+    fafApiAccessor.patch(ElideNavigator.of(Player.class).id(playerId), playerDto)
+        .subscribe(null, throwable -> log.error("Could not select avatar ''{}''", avatar.id(), throwable));
+  }
+
+  private void removeCurrentAvatar() {
+    String playerId = String.valueOf(playerService.getCurrentPlayer().getId());
+    // The relationship DELETE must name the avatar to remove, so resolve the currently selected one first.
+    getCurrentAvatar().thenAccept(currentAvatar -> {
+      if (currentAvatar == null || currentAvatar.id() == null) {
+        return;
+      }
+      fafApiAccessor.deleteToOneRelationship("player", playerId, "currentAvatar", "avatar",
+              String.valueOf(currentAvatar.id()))
+          .subscribe(null, throwable -> log.error("Could not remove current avatar", throwable));
+    });
   }
 }

--- a/src/main/java/com/faforever/client/avatar/AvatarService.java
+++ b/src/main/java/com/faforever/client/avatar/AvatarService.java
@@ -1,9 +1,12 @@
 package com.faforever.client.avatar;
 
+import com.faforever.client.api.FafApiAccessor;
 import com.faforever.client.mapstruct.AvatarMapper;
 import com.faforever.client.player.PlayerService;
 import com.faforever.client.remote.AssetService;
-import com.faforever.client.remote.FafServerAccessor;
+import com.faforever.commons.api.dto.AvatarAssignment;
+import com.faforever.commons.api.elide.ElideNavigator;
+import com.faforever.commons.api.elide.ElideNavigatorOnCollection;
 import javafx.scene.image.Image;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.Cacheable;
@@ -15,13 +18,14 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 import static com.faforever.client.config.CacheNames.AVATARS;
+import static com.faforever.commons.api.elide.ElideNavigator.qBuilder;
 
 @Lazy
 @Service
 @RequiredArgsConstructor
 public class AvatarService {
 
-  private final FafServerAccessor fafServerAccessor;
+  private final FafApiAccessor fafApiAccessor;
   private final AssetService assetService;
   private final PlayerService playerService;
   private final AvatarMapper avatarMapper;
@@ -35,11 +39,21 @@ public class AvatarService {
   }
 
   public CompletableFuture<List<Avatar>> getAvailableAvatars() {
-    return fafServerAccessor.getAvailableAvatars().thenApply(avatarMapper::mapDtos);
+    Integer playerId = playerService.getCurrentPlayer().getId();
+    ElideNavigatorOnCollection<AvatarAssignment> navigator = ElideNavigator.of(AvatarAssignment.class)
+        .collection()
+        .setFilter(qBuilder().string("player.id").eq(String.valueOf(playerId)));
+    return fafApiAccessor.getAll(navigator)
+        .map(AvatarAssignment::getAvatar)
+        .map(avatarMapper::map)
+        .collectList()
+        .toFuture();
   }
 
   public void changeAvatar(Avatar avatar) {
-    fafServerAccessor.selectAvatar(avatar.url());
+    String playerId = String.valueOf(playerService.getCurrentPlayer().getId());
+    String avatarId = avatar == null || avatar.id() == null ? null : String.valueOf(avatar.id());
+    fafApiAccessor.patchToOneRelationship("player", playerId, "currentAvatar", "avatar", avatarId).subscribe();
     playerService.getCurrentPlayer().setAvatar(avatar);
   }
 }

--- a/src/main/java/com/faforever/client/fx/contextmenu/AvatarPickerCustomMenuItemController.java
+++ b/src/main/java/com/faforever/client/fx/contextmenu/AvatarPickerCustomMenuItemController.java
@@ -18,7 +18,6 @@ import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
-import java.net.URL;
 import java.util.Objects;
 
 import static com.faforever.client.player.SocialStatus.SELF;
@@ -61,26 +60,27 @@ public class AvatarPickerCustomMenuItemController extends AbstractCustomMenuItem
   }
 
   private void loadAvailableAvatars() {
-    avatarService.getAvailableAvatars().thenAcceptAsync(avatars -> {
-      ObservableList<Avatar> items = FXCollections.observableArrayList(avatars);
-      items.addFirst(noAvatar);
+    avatarService.getAvailableAvatars()
+        .thenCombineAsync(avatarService.getCurrentAvatar(), (avatars, currentAvatar) -> {
+          ObservableList<Avatar> items = FXCollections.observableArrayList(avatars);
+          items.addFirst(noAvatar);
+          avatarComboBox.getItems().setAll(items);
 
-      Avatar currentAvatar = object.getAvatar();
-      // The current avatar may originate from the lobby feed (no id) while the available avatars come
-      // from the API (with id), so match on the url, which is present in both representations.
-      URL currentAvatarUrl = currentAvatar == null ? null : currentAvatar.url();
-      avatarComboBox.getItems().setAll(items);
-      avatarComboBox.getSelectionModel().select(items.stream()
-          .filter(avatarBean -> Objects.equals(avatarBean.url(), currentAvatarUrl))
-          .findFirst()
-          .orElse(null));
+          // The current avatar is read from the API (player.currentAvatar), so it shares the id with the
+          // available avatars and can be matched reliably regardless of what the lobby feed reports.
+          Integer currentAvatarId = currentAvatar == null ? null : currentAvatar.id();
+          avatarComboBox.getSelectionModel().select(items.stream()
+              .filter(avatarBean -> Objects.equals(avatarBean.id(), currentAvatarId))
+              .findFirst()
+              .orElse(noAvatar));
 
-      // Only after the box has been populated, and we selected the current value, we add the listener.
-      // Otherwise, the code above already triggers a changeAvatar()
-      JavaFxUtil.addListener(avatarComboBox.getSelectionModel()
-          .selectedItemProperty(), new WeakInvalidationListener(selectedItemPropertyListener));
-      getRoot().setVisible(isItemVisible());
-    }, fxApplicationThreadExecutor);
+          // Only after the box has been populated, and we selected the current value, we add the listener.
+          // Otherwise, the code above already triggers a changeAvatar()
+          JavaFxUtil.addListener(avatarComboBox.getSelectionModel()
+              .selectedItemProperty(), new WeakInvalidationListener(selectedItemPropertyListener));
+          getRoot().setVisible(isItemVisible());
+          return null;
+        }, fxApplicationThreadExecutor);
   }
 
   private void setAvatar() {

--- a/src/main/java/com/faforever/client/fx/contextmenu/AvatarPickerCustomMenuItemController.java
+++ b/src/main/java/com/faforever/client/fx/contextmenu/AvatarPickerCustomMenuItemController.java
@@ -61,7 +61,8 @@ public class AvatarPickerCustomMenuItemController extends AbstractCustomMenuItem
 
   private void loadAvailableAvatars() {
     avatarService.getAvailableAvatars()
-        .thenCombineAsync(avatarService.getCurrentAvatar(), (avatars, currentAvatar) -> {
+        // The current avatar is only used to preselect; a failure here must not stop the list from showing.
+        .thenCombineAsync(avatarService.getCurrentAvatar().exceptionally(throwable -> null), (avatars, currentAvatar) -> {
           ObservableList<Avatar> items = FXCollections.observableArrayList(avatars);
           items.addFirst(noAvatar);
           avatarComboBox.getItems().setAll(items);

--- a/src/main/java/com/faforever/client/fx/contextmenu/AvatarPickerCustomMenuItemController.java
+++ b/src/main/java/com/faforever/client/fx/contextmenu/AvatarPickerCustomMenuItemController.java
@@ -18,6 +18,7 @@ import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
+import java.net.URL;
 import java.util.Objects;
 
 import static com.faforever.client.player.SocialStatus.SELF;
@@ -65,9 +66,12 @@ public class AvatarPickerCustomMenuItemController extends AbstractCustomMenuItem
       items.addFirst(noAvatar);
 
       Avatar currentAvatar = object.getAvatar();
+      // The current avatar may originate from the lobby feed (no id) while the available avatars come
+      // from the API (with id), so match on the url, which is present in both representations.
+      URL currentAvatarUrl = currentAvatar == null ? null : currentAvatar.url();
       avatarComboBox.getItems().setAll(items);
       avatarComboBox.getSelectionModel().select(items.stream()
-          .filter(avatarBean -> Objects.equals(avatarBean, currentAvatar))
+          .filter(avatarBean -> Objects.equals(avatarBean.url(), currentAvatarUrl))
           .findFirst()
           .orElse(null));
 

--- a/src/main/java/com/faforever/client/fx/contextmenu/AvatarPickerCustomMenuItemController.java
+++ b/src/main/java/com/faforever/client/fx/contextmenu/AvatarPickerCustomMenuItemController.java
@@ -40,7 +40,7 @@ public class AvatarPickerCustomMenuItemController extends AbstractCustomMenuItem
   @Override
   public void afterSetObject() {
     if (object != null && object.getSocialStatus() == SELF) {
-      avatarComboBox.setCellFactory(param -> avatarCell());
+      avatarComboBox.setCellFactory(_ -> avatarCell());
       avatarComboBox.setButtonCell(avatarCell());
 
       noAvatar = new Avatar(null, null, i18n.get("chat.userContext.noAvatar"));
@@ -60,28 +60,24 @@ public class AvatarPickerCustomMenuItemController extends AbstractCustomMenuItem
   }
 
   private void loadAvailableAvatars() {
-    avatarService.getAvailableAvatars()
-        // The current avatar is only used to preselect; a failure here must not stop the list from showing.
-        .thenCombineAsync(avatarService.getCurrentAvatar().exceptionally(throwable -> null), (avatars, currentAvatar) -> {
-          ObservableList<Avatar> items = FXCollections.observableArrayList(avatars);
-          items.addFirst(noAvatar);
-          avatarComboBox.getItems().setAll(items);
+    avatarService.getAvailableAvatars().thenAcceptAsync(avatars -> {
+      ObservableList<Avatar> items = FXCollections.observableArrayList(avatars);
+      items.addFirst(noAvatar);
 
-          // The current avatar is read from the API (player.currentAvatar), so it shares the id with the
-          // available avatars and can be matched reliably regardless of what the lobby feed reports.
-          Integer currentAvatarId = currentAvatar == null ? null : currentAvatar.id();
-          avatarComboBox.getSelectionModel().select(items.stream()
-              .filter(avatarBean -> Objects.equals(avatarBean.id(), currentAvatarId))
-              .findFirst()
-              .orElse(noAvatar));
+      Avatar currentAvatar = object.getAvatar();
+      avatarComboBox.getItems().setAll(items);
+      avatarComboBox.getSelectionModel().select(items.stream()
+          // matching via id is not possible, as the server does not provide the avatar id
+          .filter(avatarBean -> Objects.equals(avatarBean.url(), currentAvatar.url()))
+          .findFirst()
+          .orElse(null));
 
-          // Only after the box has been populated, and we selected the current value, we add the listener.
-          // Otherwise, the code above already triggers a changeAvatar()
-          JavaFxUtil.addListener(avatarComboBox.getSelectionModel()
-              .selectedItemProperty(), new WeakInvalidationListener(selectedItemPropertyListener));
-          getRoot().setVisible(isItemVisible());
-          return null;
-        }, fxApplicationThreadExecutor);
+      // Only after the box has been populated, and we selected the current value, we add the listener.
+      // Otherwise, the code above already triggers a changeAvatar()
+      JavaFxUtil.addListener(avatarComboBox.getSelectionModel()
+                                           .selectedItemProperty(), new WeakInvalidationListener(selectedItemPropertyListener));
+      getRoot().setVisible(isItemVisible());
+    }, fxApplicationThreadExecutor);
   }
 
   private void setAvatar() {

--- a/src/main/java/com/faforever/client/mapstruct/AvatarMapper.java
+++ b/src/main/java/com/faforever/client/mapstruct/AvatarMapper.java
@@ -5,8 +5,6 @@ import com.faforever.commons.lobby.Player;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
-import java.util.List;
-
 @Mapper(uses = {UrlMapper.class}, config = MapperConfiguration.class)
 public interface AvatarMapper {
 
@@ -17,6 +15,4 @@ public interface AvatarMapper {
   com.faforever.commons.api.dto.Avatar map(Avatar bean);
 
   Avatar map(Player.Avatar dto);
-
-  List<Avatar> mapDtos(List<Player.Avatar> dtos);
 }

--- a/src/main/java/com/faforever/client/remote/FafServerAccessor.java
+++ b/src/main/java/com/faforever/client/remote/FafServerAccessor.java
@@ -28,7 +28,6 @@ import com.faforever.commons.lobby.MatchmakerState;
 import com.faforever.commons.lobby.MessageTarget;
 import com.faforever.commons.lobby.NoticeInfo;
 import com.faforever.commons.lobby.Player;
-import com.faforever.commons.lobby.Player.Avatar;
 import com.faforever.commons.lobby.ServerMessage;
 import com.faforever.commons.lobby.VetoData;
 import javafx.application.Platform;
@@ -54,13 +53,11 @@ import reactor.function.TupleUtils;
 import reactor.util.retry.Retry;
 
 import java.io.IOException;
-import java.net.URL;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 @Lazy
@@ -244,14 +241,6 @@ public class FafServerAccessor implements InitializingBean, DisposableBean, Life
 
   public void removeFoe(int playerId) {
     lobbyClient.removeFoe(playerId);
-  }
-
-  public void selectAvatar(URL url) {
-    lobbyClient.selectAvatar(Optional.ofNullable(url).map(URL::toString).orElse(null));
-  }
-
-  public CompletableFuture<List<Avatar>> getAvailableAvatars() {
-    return lobbyClient.getAvailableAvatars().collectList().toFuture();
   }
 
   public void closePlayersGame(int playerId) {

--- a/src/test/java/com/faforever/client/avatar/AvatarServiceTest.java
+++ b/src/test/java/com/faforever/client/avatar/AvatarServiceTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mapstruct.factory.Mappers;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
@@ -21,8 +22,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
-import java.net.URI;
-import java.net.URL;
 import java.nio.file.Path;
 import java.util.List;
 
@@ -36,7 +35,7 @@ import static org.instancio.Select.field;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -128,23 +127,48 @@ public class AvatarServiceTest extends ServiceTest {
   }
 
   @Test
-  public void changeAvatar() throws Exception {
+  public void changeAvatarSelectsViaPlayerPatch() {
     when(playerService.getCurrentPlayer()).thenReturn(PlayerInfoBuilder.create().defaultValues().get());
-    when(fafApiAccessor.patchToOneRelationship(any(), any(), any(), any(), any())).thenReturn(Mono.empty());
+    when(fafApiAccessor.patch(any(), any())).thenReturn(Mono.empty());
 
-    URL url = URI.create("https://example.com").toURL();
-    instance.changeAvatar(Instancio.of(Avatar.class).set(field(Avatar::id), 42).set(field(Avatar::url), url).create());
+    instance.changeAvatar(Instancio.of(Avatar.class).set(field(Avatar::id), 42).create());
 
-    verify(fafApiAccessor).patchToOneRelationship("player", "1", "currentAvatar", "avatar", "42");
+    ArgumentCaptor<com.faforever.commons.api.dto.Player> captor =
+        ArgumentCaptor.forClass(com.faforever.commons.api.dto.Player.class);
+    verify(fafApiAccessor).patch(any(), captor.capture());
+    assertThat(captor.getValue().getId(), is("1"));
+    assertThat(captor.getValue().getCurrentAvatar().getId(), is("42"));
   }
 
   @Test
-  public void changeAvatarToNoAvatarClearsSelection() {
+  public void changeAvatarToNoAvatarDeletesCurrentAvatarRelationship() {
     when(playerService.getCurrentPlayer()).thenReturn(PlayerInfoBuilder.create().defaultValues().get());
-    when(fafApiAccessor.patchToOneRelationship(any(), any(), any(), any(), any())).thenReturn(Mono.empty());
+
+    com.faforever.commons.api.dto.Avatar avatarDto = new com.faforever.commons.api.dto.Avatar();
+    avatarDto.setId("7");
+    avatarDto.setUrl("https://example.com/avatar.png");
+    com.faforever.commons.api.dto.Player player = new com.faforever.commons.api.dto.Player();
+    player.setId("1");
+    player.setCurrentAvatar(avatarDto);
+    when(fafApiAccessor.getOne(any())).thenReturn(Mono.just(player));
+    when(fafApiAccessor.deleteToOneRelationship(any(), any(), any(), any(), any())).thenReturn(Mono.empty());
 
     instance.changeAvatar(new Avatar(null, null, "no avatar"));
 
-    verify(fafApiAccessor).patchToOneRelationship(eq("player"), eq("1"), eq("currentAvatar"), eq("avatar"), eq(null));
+    verify(fafApiAccessor).deleteToOneRelationship("player", "1", "currentAvatar", "avatar", "7");
+  }
+
+  @Test
+  public void changeAvatarToNoAvatarWithoutCurrentAvatarDoesNothing() {
+    when(playerService.getCurrentPlayer()).thenReturn(PlayerInfoBuilder.create().defaultValues().get());
+
+    com.faforever.commons.api.dto.Player player = new com.faforever.commons.api.dto.Player();
+    player.setId("1");
+    player.setCurrentAvatar(null);
+    when(fafApiAccessor.getOne(any())).thenReturn(Mono.just(player));
+
+    instance.changeAvatar(new Avatar(null, null, "no avatar"));
+
+    verify(fafApiAccessor, never()).deleteToOneRelationship(any(), any(), any(), any(), any());
   }
 }

--- a/src/test/java/com/faforever/client/avatar/AvatarServiceTest.java
+++ b/src/test/java/com/faforever/client/avatar/AvatarServiceTest.java
@@ -35,6 +35,7 @@ import static org.instancio.Select.field;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -151,11 +152,12 @@ public class AvatarServiceTest extends ServiceTest {
     player.setId("1");
     player.setCurrentAvatar(avatarDto);
     when(fafApiAccessor.getOne(any())).thenReturn(Mono.just(player));
-    when(fafApiAccessor.deleteToOneRelationship(any(), any(), any(), any(), any())).thenReturn(Mono.empty());
+    when(fafApiAccessor.deleteFromRelationship(any(), any(), any(), any())).thenReturn(Mono.empty());
 
     instance.changeAvatar(new Avatar(null, null, "no avatar"));
 
-    verify(fafApiAccessor).deleteToOneRelationship("player", "1", "currentAvatar", "avatar", "7");
+    verify(fafApiAccessor).deleteFromRelationship(argThat(ElideMatchers.hasId(1)), eq("currentAvatar"), eq("avatar"),
+        eq("7"));
   }
 
   @Test
@@ -169,6 +171,6 @@ public class AvatarServiceTest extends ServiceTest {
 
     instance.changeAvatar(new Avatar(null, null, "no avatar"));
 
-    verify(fafApiAccessor, never()).deleteToOneRelationship(any(), any(), any(), any(), any());
+    verify(fafApiAccessor, never()).deleteFromRelationship(any(), any(), any(), any());
   }
 }

--- a/src/test/java/com/faforever/client/avatar/AvatarServiceTest.java
+++ b/src/test/java/com/faforever/client/avatar/AvatarServiceTest.java
@@ -30,8 +30,6 @@ import static com.faforever.commons.api.elide.ElideNavigator.qBuilder;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
 import static org.instancio.Select.field;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
@@ -98,37 +96,6 @@ public class AvatarServiceTest extends ServiceTest {
   }
 
   @Test
-  public void getCurrentAvatar() {
-    when(playerService.getCurrentPlayer()).thenReturn(PlayerInfoBuilder.create().defaultValues().get());
-
-    com.faforever.commons.api.dto.Avatar avatarDto = new com.faforever.commons.api.dto.Avatar();
-    avatarDto.setId("5");
-    avatarDto.setUrl("https://example.com/avatar.png");
-    avatarDto.setTooltip("tooltip");
-    com.faforever.commons.api.dto.Player player = new com.faforever.commons.api.dto.Player();
-    player.setId("1");
-    player.setCurrentAvatar(avatarDto);
-    when(fafApiAccessor.getOne(any())).thenReturn(Mono.just(player));
-
-    Avatar result = instance.getCurrentAvatar().join();
-
-    assertThat(result, notNullValue());
-    assertThat(result.id(), is(5));
-  }
-
-  @Test
-  public void getCurrentAvatarWhenNoneSelected() {
-    when(playerService.getCurrentPlayer()).thenReturn(PlayerInfoBuilder.create().defaultValues().get());
-
-    com.faforever.commons.api.dto.Player player = new com.faforever.commons.api.dto.Player();
-    player.setId("1");
-    player.setCurrentAvatar(null);
-    when(fafApiAccessor.getOne(any())).thenReturn(Mono.just(player));
-
-    assertThat(instance.getCurrentAvatar().join(), nullValue());
-  }
-
-  @Test
   public void changeAvatarSelectsViaPlayerPatch() {
     when(playerService.getCurrentPlayer()).thenReturn(PlayerInfoBuilder.create().defaultValues().get());
     when(fafApiAccessor.patch(any(), any())).thenReturn(Mono.empty());
@@ -144,15 +111,9 @@ public class AvatarServiceTest extends ServiceTest {
 
   @Test
   public void changeAvatarToNoAvatarDeletesCurrentAvatarRelationship() {
-    when(playerService.getCurrentPlayer()).thenReturn(PlayerInfoBuilder.create().defaultValues().get());
-
-    com.faforever.commons.api.dto.Avatar avatarDto = new com.faforever.commons.api.dto.Avatar();
-    avatarDto.setId("7");
-    avatarDto.setUrl("https://example.com/avatar.png");
-    com.faforever.commons.api.dto.Player player = new com.faforever.commons.api.dto.Player();
-    player.setId("1");
-    player.setCurrentAvatar(avatarDto);
-    when(fafApiAccessor.getOne(any())).thenReturn(Mono.just(player));
+    Avatar currentAvatar = new Avatar(7, null, "tooltip");
+    when(playerService.getCurrentPlayer()).thenReturn(
+        PlayerInfoBuilder.create().defaultValues().avatar(currentAvatar).get());
     when(fafApiAccessor.deleteFromRelationship(any(), any())).thenReturn(Mono.empty());
 
     instance.changeAvatar(new Avatar(null, null, "no avatar"));
@@ -165,12 +126,8 @@ public class AvatarServiceTest extends ServiceTest {
 
   @Test
   public void changeAvatarToNoAvatarWithoutCurrentAvatarDoesNothing() {
-    when(playerService.getCurrentPlayer()).thenReturn(PlayerInfoBuilder.create().defaultValues().get());
-
-    com.faforever.commons.api.dto.Player player = new com.faforever.commons.api.dto.Player();
-    player.setId("1");
-    player.setCurrentAvatar(null);
-    when(fafApiAccessor.getOne(any())).thenReturn(Mono.just(player));
+    when(playerService.getCurrentPlayer()).thenReturn(
+        PlayerInfoBuilder.create().defaultValues().avatar(null).get());
 
     instance.changeAvatar(new Avatar(null, null, "no avatar"));
 

--- a/src/test/java/com/faforever/client/avatar/AvatarServiceTest.java
+++ b/src/test/java/com/faforever/client/avatar/AvatarServiceTest.java
@@ -29,6 +29,9 @@ import java.util.List;
 import static com.faforever.commons.api.elide.ElideNavigator.qBuilder;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 import static org.instancio.Select.field;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
@@ -91,6 +94,37 @@ public class AvatarServiceTest extends ServiceTest {
 
     assertThat(result, hasSize(1));
     verify(fafApiAccessor).getAll(argThat(ElideMatchers.hasFilter(qBuilder().string("player.id").eq("1"))));
+  }
+
+  @Test
+  public void getCurrentAvatar() {
+    when(playerService.getCurrentPlayer()).thenReturn(PlayerInfoBuilder.create().defaultValues().get());
+
+    com.faforever.commons.api.dto.Avatar avatarDto = new com.faforever.commons.api.dto.Avatar();
+    avatarDto.setId("5");
+    avatarDto.setUrl("https://example.com/avatar.png");
+    avatarDto.setTooltip("tooltip");
+    com.faforever.commons.api.dto.Player player = new com.faforever.commons.api.dto.Player();
+    player.setId("1");
+    player.setCurrentAvatar(avatarDto);
+    when(fafApiAccessor.getOne(any())).thenReturn(Mono.just(player));
+
+    Avatar result = instance.getCurrentAvatar().join();
+
+    assertThat(result, notNullValue());
+    assertThat(result.id(), is(5));
+  }
+
+  @Test
+  public void getCurrentAvatarWhenNoneSelected() {
+    when(playerService.getCurrentPlayer()).thenReturn(PlayerInfoBuilder.create().defaultValues().get());
+
+    com.faforever.commons.api.dto.Player player = new com.faforever.commons.api.dto.Player();
+    player.setId("1");
+    player.setCurrentAvatar(null);
+    when(fafApiAccessor.getOne(any())).thenReturn(Mono.just(player));
+
+    assertThat(instance.getCurrentAvatar().join(), nullValue());
   }
 
   @Test

--- a/src/test/java/com/faforever/client/avatar/AvatarServiceTest.java
+++ b/src/test/java/com/faforever/client/avatar/AvatarServiceTest.java
@@ -9,6 +9,7 @@ import com.faforever.client.remote.AssetService;
 import com.faforever.client.test.ElideMatchers;
 import com.faforever.client.test.ServiceTest;
 import com.faforever.commons.api.dto.AvatarAssignment;
+import com.faforever.commons.api.elide.ElideNavigatorOnRelationshipLink;
 import org.instancio.Instancio;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -152,12 +153,14 @@ public class AvatarServiceTest extends ServiceTest {
     player.setId("1");
     player.setCurrentAvatar(avatarDto);
     when(fafApiAccessor.getOne(any())).thenReturn(Mono.just(player));
-    when(fafApiAccessor.deleteFromRelationship(any(), any(), any(), any())).thenReturn(Mono.empty());
+    when(fafApiAccessor.deleteFromRelationship(any(), any())).thenReturn(Mono.empty());
 
     instance.changeAvatar(new Avatar(null, null, "no avatar"));
 
-    verify(fafApiAccessor).deleteFromRelationship(argThat(ElideMatchers.hasId(1)), eq("currentAvatar"), eq("avatar"),
-        eq("7"));
+    ArgumentCaptor<ElideNavigatorOnRelationshipLink> linkCaptor =
+        ArgumentCaptor.forClass(ElideNavigatorOnRelationshipLink.class);
+    verify(fafApiAccessor).deleteFromRelationship(linkCaptor.capture(), eq("7"));
+    assertThat(linkCaptor.getValue().build(), is("/data/player/1/relationships/currentAvatar"));
   }
 
   @Test
@@ -171,6 +174,6 @@ public class AvatarServiceTest extends ServiceTest {
 
     instance.changeAvatar(new Avatar(null, null, "no avatar"));
 
-    verify(fafApiAccessor, never()).deleteFromRelationship(any(), any(), any(), any());
+    verify(fafApiAccessor, never()).deleteFromRelationship(any(), any());
   }
 }

--- a/src/test/java/com/faforever/client/avatar/AvatarServiceTest.java
+++ b/src/test/java/com/faforever/client/avatar/AvatarServiceTest.java
@@ -1,12 +1,14 @@
 package com.faforever.client.avatar;
 
+import com.faforever.client.api.FafApiAccessor;
 import com.faforever.client.builders.PlayerInfoBuilder;
 import com.faforever.client.mapstruct.AvatarMapper;
 import com.faforever.client.mapstruct.MapperSetup;
 import com.faforever.client.player.PlayerService;
 import com.faforever.client.remote.AssetService;
-import com.faforever.client.remote.FafServerAccessor;
+import com.faforever.client.test.ElideMatchers;
 import com.faforever.client.test.ServiceTest;
+import com.faforever.commons.api.dto.AvatarAssignment;
 import org.instancio.Instancio;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -16,15 +18,22 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import java.net.URI;
 import java.net.URL;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
+import static com.faforever.commons.api.elide.ElideNavigator.qBuilder;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
 import static org.instancio.Select.field;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -33,7 +42,7 @@ import static org.mockito.Mockito.when;
 public class AvatarServiceTest extends ServiceTest {
 
   @Mock
-  private FafServerAccessor fafServerAccessor;
+  private FafApiAccessor fafApiAccessor;
   @Mock
   private AssetService assetService;
   @Mock
@@ -67,18 +76,41 @@ public class AvatarServiceTest extends ServiceTest {
 
   @Test
   public void getAvailableAvatars() {
-    when(fafServerAccessor.getAvailableAvatars()).thenReturn(CompletableFuture.completedFuture(List.of()));
-    instance.getAvailableAvatars();
-    verify(fafServerAccessor).getAvailableAvatars();
+    when(playerService.getCurrentPlayer()).thenReturn(PlayerInfoBuilder.create().defaultValues().get());
+
+    com.faforever.commons.api.dto.Avatar avatarDto = new com.faforever.commons.api.dto.Avatar();
+    avatarDto.setId("5");
+    avatarDto.setUrl("https://example.com/avatar.png");
+    avatarDto.setTooltip("tooltip");
+    AvatarAssignment assignment = new AvatarAssignment();
+    assignment.setId("1");
+    assignment.setAvatar(avatarDto);
+    when(fafApiAccessor.getAll(any())).thenReturn(Flux.just(assignment));
+
+    List<Avatar> result = instance.getAvailableAvatars().join();
+
+    assertThat(result, hasSize(1));
+    verify(fafApiAccessor).getAll(argThat(ElideMatchers.hasFilter(qBuilder().string("player.id").eq("1"))));
   }
 
   @Test
   public void changeAvatar() throws Exception {
-    when(playerService.getCurrentPlayer()).thenReturn(PlayerInfoBuilder.create().get());
+    when(playerService.getCurrentPlayer()).thenReturn(PlayerInfoBuilder.create().defaultValues().get());
+    when(fafApiAccessor.patchToOneRelationship(any(), any(), any(), any(), any())).thenReturn(Mono.empty());
 
     URL url = URI.create("https://example.com").toURL();
-    instance.changeAvatar(Instancio.of(Avatar.class).set(field(Avatar::url), url).create());
+    instance.changeAvatar(Instancio.of(Avatar.class).set(field(Avatar::id), 42).set(field(Avatar::url), url).create());
 
-    verify(fafServerAccessor).selectAvatar(url);
+    verify(fafApiAccessor).patchToOneRelationship("player", "1", "currentAvatar", "avatar", "42");
+  }
+
+  @Test
+  public void changeAvatarToNoAvatarClearsSelection() {
+    when(playerService.getCurrentPlayer()).thenReturn(PlayerInfoBuilder.create().defaultValues().get());
+    when(fafApiAccessor.patchToOneRelationship(any(), any(), any(), any(), any())).thenReturn(Mono.empty());
+
+    instance.changeAvatar(new Avatar(null, null, "no avatar"));
+
+    verify(fafApiAccessor).patchToOneRelationship(eq("player"), eq("1"), eq("currentAvatar"), eq("avatar"), eq(null));
   }
 }

--- a/src/test/java/com/faforever/client/fx/contextmenu/AvatarPickerCustomMenuItemControllerTest.java
+++ b/src/test/java/com/faforever/client/fx/contextmenu/AvatarPickerCustomMenuItemControllerTest.java
@@ -34,7 +34,6 @@ public class AvatarPickerCustomMenuItemControllerTest extends PlatformTest {
 
   @BeforeEach
   public void setUp() throws Exception {
-    lenient().when(avatarService.getCurrentAvatar()).thenReturn(CompletableFuture.completedFuture(null));
     loadFxml("theme/chat/avatar_picker_menu_item.fxml", clazz -> instance);
   }
 
@@ -85,11 +84,10 @@ public class AvatarPickerCustomMenuItemControllerTest extends PlatformTest {
   public void testSelectNoAvatar() throws Exception {
     Avatar avatar = Instancio.create(Avatar.class);
     when(avatarService.getAvailableAvatars()).thenReturn(CompletableFuture.completedFuture(Collections.singletonList(avatar)));
-    when(avatarService.getCurrentAvatar()).thenReturn(CompletableFuture.completedFuture(avatar));
     when(i18n.get("chat.userContext.noAvatar")).thenReturn("no avatar");
 
     runOnFxThreadAndWait(() -> instance.setObject(
-        PlayerInfoBuilder.create().defaultValues().socialStatus(SocialStatus.SELF).get()));
+        PlayerInfoBuilder.create().defaultValues().avatar(avatar).socialStatus(SocialStatus.SELF).get()));
     assertEquals(avatar, instance.avatarComboBox.getSelectionModel().getSelectedItem());
 
     runOnFxThreadAndWait(() -> instance.avatarComboBox.getSelectionModel().select(0)); // 0 index - no avatar

--- a/src/test/java/com/faforever/client/fx/contextmenu/AvatarPickerCustomMenuItemControllerTest.java
+++ b/src/test/java/com/faforever/client/fx/contextmenu/AvatarPickerCustomMenuItemControllerTest.java
@@ -19,6 +19,7 @@ import java.util.concurrent.CompletableFuture;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -33,6 +34,7 @@ public class AvatarPickerCustomMenuItemControllerTest extends PlatformTest {
 
   @BeforeEach
   public void setUp() throws Exception {
+    lenient().when(avatarService.getCurrentAvatar()).thenReturn(CompletableFuture.completedFuture(null));
     loadFxml("theme/chat/avatar_picker_menu_item.fxml", clazz -> instance);
   }
 
@@ -83,10 +85,11 @@ public class AvatarPickerCustomMenuItemControllerTest extends PlatformTest {
   public void testSelectNoAvatar() throws Exception {
     Avatar avatar = Instancio.create(Avatar.class);
     when(avatarService.getAvailableAvatars()).thenReturn(CompletableFuture.completedFuture(Collections.singletonList(avatar)));
+    when(avatarService.getCurrentAvatar()).thenReturn(CompletableFuture.completedFuture(avatar));
     when(i18n.get("chat.userContext.noAvatar")).thenReturn("no avatar");
 
     runOnFxThreadAndWait(() -> instance.setObject(
-        PlayerInfoBuilder.create().defaultValues().avatar(avatar).socialStatus(SocialStatus.SELF).get()));
+        PlayerInfoBuilder.create().defaultValues().socialStatus(SocialStatus.SELF).get()));
     assertEquals(avatar, instance.avatarComboBox.getSelectionModel().getSelectedItem());
 
     runOnFxThreadAndWait(() -> instance.avatarComboBox.getSelectionModel().select(0)); // 0 index - no avatar

--- a/src/test/java/com/faforever/client/remote/ServerAccessorTest.java
+++ b/src/test/java/com/faforever/client/remote/ServerAccessorTest.java
@@ -45,7 +45,6 @@ import com.faforever.commons.lobby.PartyInfo;
 import com.faforever.commons.lobby.PartyInfo.PartyMember;
 import com.faforever.commons.lobby.PartyInvite;
 import com.faforever.commons.lobby.PartyKick;
-import com.faforever.commons.lobby.Player.Avatar;
 import com.faforever.commons.lobby.SearchInfo;
 import com.faforever.commons.lobby.ServerMessage;
 import com.faforever.commons.lobby.SessionResponse;
@@ -80,8 +79,6 @@ import reactor.test.StepVerifier;
 
 import java.io.IOException;
 import java.net.InetAddress;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.time.Duration;
@@ -491,23 +488,6 @@ public class ServerAccessorTest extends ServiceTest {
   }
 
   @Test
-  public void testGetAvailableAvatars() throws Exception {
-
-    instance.getAvailableAvatars();
-
-    assertMessageContainsComponents(
-        "avatar", "list_avatar", "action"
-    );
-
-    AvatarListInfo avatarList = new AvatarListInfo(
-        List.of(new Avatar("google.com", "test"), new Avatar("google.com", "test")));
-    sendFromServer(avatarList);
-
-    assertTrue(messageReceivedByClientLatch.await(TIMEOUT, TIMEOUT_UNIT));
-    assertThat(receivedMessage, is(avatarList));
-  }
-
-  @Test
   public void testRestoreGameSession() {
 
     instance.restoreGameSession(1);
@@ -601,17 +581,6 @@ public class ServerAccessorTest extends ServiceTest {
         "set_party_factions",
         "factions",
         "aeon", "uef", "cybran", "seraphim");
-  }
-
-  @Test
-  public void testSelectAvatar() throws MalformedURLException {
-    URL url = new URL("http://google.com");
-
-    instance.selectAvatar(url);
-
-    assertMessageContainsComponents("avatar", "action",
-        url.toString()
-    );
   }
 
   @Test
@@ -779,7 +748,6 @@ public class ServerAccessorTest extends ServiceTest {
   public void testOnAvatarMessage() throws InterruptedException, JsonProcessingException {
     AvatarListInfo avatarMessage = new AvatarListInfo(List.of());
 
-    instance.getAvailableAvatars();
     sendFromServer(avatarMessage);
     assertTrue(messageReceivedByClientLatch.await(TIMEOUT, TIMEOUT_UNIT));
     assertThat(receivedMessage, is(avatarMessage));


### PR DESCRIPTION
## What

Avatar listing and selection now go through the FAF REST API (Elide JSON:API) instead of the legacy lobby socket commands. The API is the single writer of the selected avatar (`login.avatar_id` → `player.currentAvatar`) and validates that the chosen avatar is actually assigned to the player.

## Changes

- **`AvatarService.getAvailableAvatars()`** queries the current player's `AvatarAssignment`s via `FafApiAccessor` (with the `avatar` relationship included) and maps them.
- **`AvatarService.changeAvatar()`** PATCHes `player.currentAvatar` through a new `FafApiAccessor.patchToOneRelationship(...)` helper that targets the JSON:API relationship endpoint (`PATCH /data/player/{id}/relationships/currentAvatar`). This is used for both setting and clearing — clearing sends `{"data": null}`, which a DTO PATCH cannot express because the serializer is configured with `Include.NON_NULL`.
- **Avatar picker** preselects the active avatar by `url` rather than full record equality, because the current avatar may originate from the lobby feed (no `id`) while available avatars now come from the API (with `id`). This also makes "no avatar" preselect correctly.
- Removed the now-dead lobby avatar list/select code (`FafServerAccessor`, `AvatarMapper.mapDtos`) and their tests.
- Bumped `faf-commons` to `20260626-2e8a5a8`, the release exposing `Player.currentAvatar` / deprecating `AvatarAssignment.selected`.

## Testing

- `./gradlew compileJava` clean (JDK 25).
- `AvatarServiceTest` rewritten against a mocked `FafApiAccessor` (list filter on `player.id`, set + clear PATCH); picker and `ServerAccessorTest` pass. 51 tests green.

Depends on the API-side change (faf-java-api PR #1146) that makes `Player.currentAvatar` PATCH-able and server-validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled requesting the avatar relationship include and added support for retrieving the player’s currently equipped avatar to drive UI selection.

* **Bug Fixes**
  * Improved avatar picker reliability by loading available avatars and the current avatar together, selecting the correct option, and safely falling back to “no avatar” on missing data or errors.
  * Clearing an avatar now reliably removes the current selection via the appropriate relationship update flow; selecting an avatar updates the player’s current avatar remotely.

* **Chores**
  * Updated the bundled shared library version to keep dependencies current.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->