### PR TITLE
Correcting sorting after initializing games

### DIFF
--- a/src/main/java/com/faforever/client/game/GamesTableController.java
+++ b/src/main/java/com/faforever/client/game/GamesTableController.java
@@ -113,6 +113,7 @@ public class GamesTableController extends NodeController<Node> {
     gamesTable.setItems(sortedList);
 
     applyLastSorting(gamesTable);
+    fxApplicationThreadExecutor.runLater(gamesTable::sort);
     gamesTable.setOnSort(this::onColumnSorted);
 
     passwordProtectionColumn.setCellValueFactory(param -> param.getValue().passwordProtectedProperty().when(showing));

--- a/src/main/java/com/faforever/client/game/GamesTableController.java
+++ b/src/main/java/com/faforever/client/game/GamesTableController.java
@@ -113,7 +113,6 @@ public class GamesTableController extends NodeController<Node> {
     gamesTable.setItems(sortedList);
 
     applyLastSorting(gamesTable);
-    fxApplicationThreadExecutor.runLater(gamesTable::sort);
     gamesTable.setOnSort(this::onColumnSorted);
 
     passwordProtectionColumn.setCellValueFactory(param -> param.getValue().passwordProtectedProperty().when(showing));
@@ -198,6 +197,7 @@ public class GamesTableController extends NodeController<Node> {
         sortOrder.add(gameTableColumn);
       }
     });
+    fxApplicationThreadExecutor.runLater(gamesTable::sort);
   }
 
   private void onColumnSorted(@NotNull SortEvent<TableView<GameInfo>> event) {


### PR DESCRIPTION
Problem:
When the "Custom games" tab is opened for the first time, sorting is not applied. 
Check:
1. Open the "Custom games" tab.
2. Select the sort by any column.
3. Open any other tab.
4. Open the "Custom games" tab again
**The list is not sorted in the first seconds**

This fix fixes it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved game list initialization so the saved sorting order is reliably applied when the games table loads.
  * Added a deferred refresh of the table sorting on the UI thread after restoring the last sort settings, ensuring the displayed order matches the remembered state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->