### PR TITLE
Fix integer range filter display

### DIFF
--- a/src/main/java/com/faforever/client/fx/JavaFxUtil.java
+++ b/src/main/java/com/faforever/client/fx/JavaFxUtil.java
@@ -44,6 +44,7 @@ import org.springframework.util.Assert;
 
 import java.awt.image.BufferedImage;
 import java.io.IOException;
+import java.math.RoundingMode;
 import java.nio.file.Path;
 import java.text.DecimalFormat;
 import java.text.ParseException;
@@ -457,6 +458,7 @@ public final class JavaFxUtil {
                                                  RangeSlider rangeSlider) {
     DecimalFormat numberFormat = (DecimalFormat) DecimalFormat.getInstance();
     numberFormat.setMaximumFractionDigits(0);
+    numberFormat.setRoundingMode(RoundingMode.DOWN);
     bindTextFieldAndRangeSlider(lowValueTextField, highValueTextField, rangeSlider, numberFormat);
   }
 

--- a/src/test/java/com/faforever/client/filter/RangeSliderFilterControllerTest.java
+++ b/src/test/java/com/faforever/client/filter/RangeSliderFilterControllerTest.java
@@ -53,6 +53,20 @@ public class RangeSliderFilterControllerTest extends PlatformTest {
   }
 
   @Test
+  public void testFractionalSliderValuesAreTruncatedConsistently() {
+    runOnFxThreadAndWait(() -> {
+      instance.rangeSlider.setLowValue(-2.8);
+      instance.rangeSlider.setHighValue(8.8);
+      instance.root.getText();
+    });
+
+    assertEquals("-2", instance.lowValueTextField.getText());
+    assertEquals("8", instance.highValueTextField.getText());
+    assertEquals(Range.between(-2, 8), instance.valueProperty().getValue());
+    verify(i18n).get("filter.range", "text", -2, 8);
+  }
+
+  @Test
   public void testGetObservableValueWhenNoChange() {
     assertEquals(AbstractRangeSliderFilterController.NO_CHANGE, instance.valueProperty().getValue());
   }


### PR DESCRIPTION
Fixes #3554

## Summary
- Truncate default range-slider text consistently with the integer bounds used by filters.
- Cover fractional slider values with a regression test.

## Before
<img width="523" height="241" alt="Popup shows 3 while the collapsed filter shows 2" src="https://github.com/user-attachments/assets/26755f61-264c-48cb-90b7-5c81090a3730" />

## After
At the same fractional thumb position, both surfaces display `2`.

## Testing
- `./gradlew.bat test --tests com.faforever.client.filter.RangeSliderFilterControllerTest --rerun-tasks --no-daemon`
- Related filter-controller tests (31 passed)
- Manual verification in a client launched from this branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Range slider values with decimals are now consistently truncated instead of rounded in displayed fields, filter ranges, and labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->