### PR TITLE
Proposal: crash-containment fix for xactengine2_9.dll access violations (draft, seeking feedback)

### DIFF
--- a/contrib/xact-crash-fix/BUILD.md
+++ b/contrib/xact-crash-fix/BUILD.md
@@ -31,7 +31,7 @@ export PATH="/c/msys64/mingw32/bin:$PATH"   # adjust to your MSYS2 install locat
 cd src
 gcc -shared -m32 -O2 -Wall \
   -o bugsplat_proxy.dll \
-  dllmain.c proxylog.c xact_guards.c flags.c \
+  dllmain.c proxylog.c logger.c debug_string_sink.c file_sink.c xact_guards.c flags.c \
   minhook/src/buffer.c minhook/src/hook.c minhook/src/trampoline.c \
   minhook/src/hde/hde32.c minhook/src/hde/hde64.c \
   bugsplat_proxy.def \
@@ -52,7 +52,7 @@ the game process) wants to inject it directly instead of via the BugSplat trick:
 ```bash
 gcc -shared -m32 -O2 -Wall \
   -o xact_guards.dll \
-  guards_dllmain.c proxylog.c xact_guards.c flags.c \
+  guards_dllmain.c proxylog.c logger.c debug_string_sink.c file_sink.c xact_guards.c flags.c \
   minhook/src/buffer.c minhook/src/hook.c minhook/src/trampoline.c \
   minhook/src/hde/hde32.c minhook/src/hde/hde64.c \
   -Iminhook/include -Iminhook/src \

--- a/contrib/xact-crash-fix/BUILD.md
+++ b/contrib/xact-crash-fix/BUILD.md
@@ -1,0 +1,82 @@
+# Building
+
+Requires a 32-bit MinGW toolchain (the game and its DLLs are 32-bit, `i686-w64-mingw32-gcc`
+specifically - a 64-bit-only MinGW will fail to link). Easiest path on Windows: install
+[MSYS2](https://www.msys2.org/), then:
+
+```
+pacman -S mingw-w64-i686-gcc mingw-w64-i686-binutils mingw-w64-i686-headers mingw-w64-i686-crt
+```
+
+## 1. Fetch MinHook
+
+This repo doesn't vendor [MinHook](https://github.com/TsudaKageyu/minhook) (BSD-2-Clause) -
+fetch it into `src/minhook/`:
+
+```bash
+cd src
+BASE="https://raw.githubusercontent.com/TsudaKageyu/minhook/master"
+for f in src/buffer.c src/hde/hde32.c src/hde/hde64.c src/hook.c src/trampoline.c \
+         include/MinHook.h src/buffer.h src/trampoline.h src/hde/hde32.h src/hde/hde64.h \
+         src/hde/table32.h src/hde/table64.h src/hde/pstdint.h LICENSE.txt; do
+  mkdir -p "minhook/$(dirname "$f")"
+  curl -sfL "$BASE/$f" -o "minhook/$f"
+done
+```
+
+## 2. Build
+
+```bash
+export PATH="/c/msys64/mingw32/bin:$PATH"   # adjust to your MSYS2 install location
+cd src
+gcc -shared -m32 -O2 -Wall \
+  -o bugsplat_proxy.dll \
+  dllmain.c proxylog.c xact_guards.c flags.c \
+  minhook/src/buffer.c minhook/src/hook.c minhook/src/trampoline.c \
+  minhook/src/hde/hde32.c minhook/src/hde/hde64.c \
+  bugsplat_proxy.def \
+  -Iminhook/include -Iminhook/src \
+  -lpsapi -mthreads
+```
+
+This produces `bugsplat_proxy.dll`, whose 19 exports all forward transparently to
+whatever the real `BugSplat.dll` provides (see `bugsplat_proxy.def`) - see the main
+README for the export-list-must-match-your-BugSplat.dll caveat.
+
+### Optional: the standalone guards DLL
+
+The same protection logic can also be built as a standalone DLL with no BugSplat
+dependency at all - useful if something else (e.g. a debugger that already controls
+the game process) wants to inject it directly instead of via the BugSplat trick:
+
+```bash
+gcc -shared -m32 -O2 -Wall \
+  -o xact_guards.dll \
+  guards_dllmain.c proxylog.c xact_guards.c flags.c \
+  minhook/src/buffer.c minhook/src/hook.c minhook/src/trampoline.c \
+  minhook/src/hde/hde32.c minhook/src/hde/hde64.c \
+  -Iminhook/include -Iminhook/src \
+  -lpsapi -mthreads
+```
+
+No `.def` file needed - it doesn't forward any exports, it just installs the guards
+via its own `DllMain` the moment it's loaded, by whatever loaded it.
+
+## 3. Validate before touching a live install
+
+Build and run `test_harness.c` the same way (`gcc -m32 -O2 -o test_harness.exe test_harness.c`)
+from the same directory as a copy of the built `bugsplat_proxy.dll` and a copy of the real
+`BugSplat.dll` renamed to `BugSplat_real.dll` - it loads both and confirms all hooks install
+successfully against a real, directly-loaded `xactengine2_9.dll` without touching your actual
+FAF installation. See the main README for what "pass" looks like.
+
+## 4. Install (manual, until this ships through the FAF client itself)
+
+In `C:\ProgramData\FAForever\bin\`:
+
+1. **Back up the real `BugSplat.dll` first** - copy it aside before touching anything.
+2. Copy the backed-up original to `BugSplat_real.dll` (the proxy's forwarder target).
+3. Copy the built `bugsplat_proxy.dll` in as `BugSplat.dll`.
+
+To undo: delete your `BugSplat.dll`, restore the backup you made in step 1 back to
+`BugSplat.dll`, delete `BugSplat_real.dll`. Nothing else is touched.

--- a/contrib/xact-crash-fix/GUIDELINES-REVIEW.md
+++ b/contrib/xact-crash-fix/GUIDELINES-REVIEW.md
@@ -1,0 +1,80 @@
+# Compliance review against FAForever/java-guidelines wiki
+
+Source: `github.com/FAForever/java-guidelines/wiki` — 3 pages total: **Home** (just points at
+the other two), **Coding Standards**, **Contribution Guidelines**. Full relevant content below,
+evaluated against our actual `contrib/xact-crash-fix/src/*.c` files and the PR/commit already made.
+
+## What the guidelines actually say
+
+### Coding Standards (thin — mostly Java-specific, noted where N/A)
+- Never throw generic `Error`/`RuntimeException`/`Throwable`/`Exception`. **N/A** — no Java exceptions in C.
+- "Exception handlers should preserve the original exception." **Loosely applies**: we don't swallow
+  failures silently — every `MH_CreateHook`/`MH_EnableHook`/`AddVectoredExceptionHandler` failure gets
+  logged with its actual status code, not discarded.
+- SLF4J logging, placeholder-quoting style (`'{}'` not bare `{}`). **N/A**, Java-specific API — but the
+  underlying principle (don't use raw stdout, make logged values visually distinct) is honored: we use
+  `OutputDebugStringA` (the correct native equivalent of a debug channel, not `printf`/console output
+  in the shipped DLL — `printf` only appears in `test_harness.c`, a standalone dev tool, not the DLL
+  itself), and log lines already read like `"...target=%p, strategy=%s) -> %d"` with clear separation.
+
+### Contribution Guidelines (the real substance)
+
+> "Quality has highest priority" · "'Quick and dirty' implementations are discouraged... there is only
+> clean and solid" · "Prefer longer, unambiguous names over short but ambiguous ones" · "Prefer slower
+> but easily readable code over short/fast but hard to read code" · "Even small things matter"
+
+> Comments/JavaDoc: "comments are bad practice"... but "know when to ignore this rule."
+
+> TODO/FIXME: `FIXME` = wrong/missing code, `TODO` = works but needs improvement. Always mark
+> temporary/unfinished work with one of these plus an explanation.
+
+> Process: issue on GitHub first → branch `feature/#00-some-keywords` (`00` = issue ID) → commit
+> messages include the issue ID, e.g. `#23 implemented update task`.
+
+> Definition of Done: "approach 100% test coverage (line & branch)" · reviewed by another contributor ·
+> ready to merge into `develop`.
+
+**No section anywhere addresses non-Java, native, or "contrib"-style contributions.** No guidance
+either way — this repo's Java-centric process wasn't written with a case like ours in mind.
+
+## Compliance checklist
+
+| Guideline | Status | Notes |
+|---|---|---|
+| Unambiguous naming | ⚠️ **Partial** | See below — the offset-encoded names (`Detour_0041d751` etc.) are the clearest violation. Flagged for the sibling renaming pass. |
+| Comments: "avoid, but know when to ignore" | ✅ **Compliant, deliberately** | Every comment in this codebase explains *why* (reverse-engineered behavior, an unusual C-can't-do-`__try__except` workaround), never *what* — exactly the case the guideline's own escape hatch describes. Worth stating this explicitly if a reviewer questions the comment density; it's not an oversight. |
+| TODO/FIXME usage | ✅ **Compliant** | None used, and correctly so — nothing here is unfinished/broken code. What's unverified (e.g. "doesn't exercise the actual recovery path", DLL-version portability) is disclosed in prose in the README/INTEGRATION docs as a *scope limitation*, not left as an in-code TODO masking a real gap. |
+| No raw stdout in shipped code | ✅ **Compliant** | `OutputDebugStringA` in the DLL; `printf` only in the standalone `test_harness.c` dev tool, which is appropriate there. |
+| Preserve/log failures, don't swallow | ✅ **Compliant** | Every hook-install and VEH-registration failure path logs the real status/error code. |
+| Issue created before work | ❌ **Not done** | No GitHub issue exists for this. |
+| Branch name `feature/#<id>-keywords` | ❌ **Not compliant** | Actual: `bugfix/fix-sound-issue-xactengine2_9-catch-wave-bank-invalid-memory-access` — wrong prefix, no issue ID, and it's a URL-unfriendly, very long slug. |
+| Commit message includes issue ID | ❌ **Not done** | No issue ID exists to include. |
+| ~100% test coverage | ⚠️ **Honest partial, already disclosed** | `test_harness.c` validates the injection/hook-install mechanics against the real DLL; it explicitly does NOT exercise the setjmp/longjmp recovery path (needs a live game session with real XACT vtables) — this is already stated plainly in the harness's own header comment and in the PR description, not hidden. |
+| Reviewed by another contributor | N/A yet | Correctly still in draft. |
+
+## Recommendations, prioritized
+
+1. **Naming pass** (see sibling agent's work) — rename `Detour_0041d751`/`Detour_0041d212`/
+   `Detour_0041de46` and their `fpOrig_*`/`Fn_*` typedefs to something that says what each site *does*
+   (teardown/UAF, null-hop cue-lookup, list-walk) instead of the raw hex offset. This is the single
+   most visible naming gap and the easiest to fix without losing any information — the exact offset is
+   still documented in the header comment right above each one.
+
+2. **The issue-first gap is real and worth addressing directly, not worked around.** My recommendation:
+   don't rename the branch or rewrite the existing commit to retroactively fake compliance — that
+   loses honest history for no real benefit. Instead: **open a GitHub issue now** describing the bug
+   (can reuse most of the PR description), then **edit the PR description** to link it (`Fixes #<id>`
+   or just `Relates to #<id>`, since this is explicitly a draft/discussion-starter, not a claimed fix
+   in the "ready to merge" sense their process implies). That satisfies the spirit (a durable, linkable
+   issue exists) without pretending the branch was planned that way from the start — which it wasn't;
+   this began as live crash investigation, not a scheduled feature. Worth saying so plainly in a PR
+   comment: the process here was necessarily retroactive because the work started as diagnosis, not
+   planned development.
+
+3. **Explicitly acknowledge the "avoid comments" tension in the PR description**, briefly — a
+   maintainer skimming this code will immediately notice it's far more heavily commented than typical
+   FAF Java code. One sentence pointing at the guideline's own "know when to ignore this rule" clause
+   heads off that friction before it becomes a review comment.
+
+4. Nothing here blocks the PR staying open as a draft — none of these are "must fix before anyone
+   looks at it," they're what to clean up before asking for it to come out of draft.

--- a/contrib/xact-crash-fix/INTEGRATION.md
+++ b/contrib/xact-crash-fix/INTEGRATION.md
@@ -1,0 +1,46 @@
+# Integration point in this repo
+
+`GameBinariesUpdateTaskImpl.java` (`src/main/java/com/faforever/client/patch/`) is what
+actually places `BugSplat.dll` (and its siblings) into `C:\ProgramData\FAForever\bin\` -
+it copies them verbatim from the vanilla Steam SupCom install's own `bin` folder:
+
+```java
+static final Collection<String> BINARIES_TO_COPY = Arrays.asList(
+    "BsSndRpt.exe", "BugSplat.dll", "BugSplatRc.dll", "DbgHelp.dll", ...
+);
+...
+if (!Files.exists(destination)) {
+    copy(source, destination, REPLACE_EXISTING);
+}
+```
+
+Two things worth knowing about this:
+
+1. **The client doesn't ship its own `BugSplat.dll`** - it's the real one, straight from
+   Steam. That's the file this proxy is designed to shadow.
+2. **The copy only happens if the destination doesn't already exist.** This is actually
+   convenient for testing this fix manually (dropping the proxy in as `BugSplat.dll`
+   won't get silently overwritten by a future client update), but it also means there's
+   no existing "always place the latest version of this file" hook to attach to as-is.
+
+## Where a real integration would go (not done here - this needs maintainer input)
+
+The natural point would be a small addition to `copyGameFilesToFafBinDirectory()` (or a
+new sibling method), executed *after* the existing binaries copy, that would:
+
+1. Detect if the fix should be active (a preference toggle, most likely - this
+   shouldn't be silently forced on everyone without opt-in given it's patching behavior
+   around a Microsoft-owned DLL, not something in this codebase).
+2. If so: rename/copy the just-placed real `BugSplat.dll` to `BugSplat_real.dll` (only
+   if that file doesn't already exist, to avoid clobbering a real one with a stale proxy
+   pass-through target on a repeat run), then place the built proxy DLL (bundled as a
+   resource, the way `BsSndRpt.exe` etc. already ship) as `BugSplat.dll`.
+3. Ideally, a version check against the on-disk `xactengine2_9.dll` (see the main
+   README's portability section) before installing, so a mismatched Windows/DLL version
+   fails safe (do nothing) instead of hooking the wrong byte offsets.
+
+None of that is implemented here - deliberately. Wiring this into the actual
+install/update path is a decision for the maintainers (does this belong in the client
+at all vs. staying an optional community tool? what's the right opt-in mechanism?
+who's responsible if a future `xactengine2_9.dll` update shifts the offsets?) - this
+folder is meant to make that conversation concrete, not to presume the answer.

--- a/contrib/xact-crash-fix/LICENSE
+++ b/contrib/xact-crash-fix/LICENSE
@@ -1,0 +1,27 @@
+MIT License
+
+Copyright (c) 2026 Alex Baumann
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+
+This project vendors/depends on MinHook (https://github.com/TsudaKageyu/minhook),
+licensed separately under the BSD-2-Clause license - see BUILD.md for how it's
+fetched at build time.

--- a/contrib/xact-crash-fix/README.md
+++ b/contrib/xact-crash-fix/README.md
@@ -1,0 +1,81 @@
+# Supreme Commander: FA — Crash Containment Fix
+
+A community-buildable fix for a long-standing crash in Forged Alliance / FAF: the game randomly hard-crashes to desktop during play, most often several minutes into a match, sometimes on exit. This document explains the bug, the fix, what's confirmed vs. still open, and what would need to change before this could be shared or upstreamed.
+
+**Architecture note (current, `src/` reflects this):** the fix is split into two pieces — `xact_guards.c`/`flags.c` contain all the actual protection logic (shared, reusable), and each of `dllmain.c` (builds `bugsplat_proxy.dll`, the injection vector used today) / `guards_dllmain.c` (builds a standalone `xact_guards.dll`, usable by any OTHER loader — e.g. a debugger like [FADeepProbe](https://github.com/faforever/fadeepprobe) injecting it directly, without needing the BugSplat trick at all) is just a thin entry point calling into the shared code. Diagnostic output goes through `OutputDebugStringA` by default (visible to any attached debugger); pass `/logxactguards` on the game's own command line to also get a persistent log file next to wherever the DLL loaded from. See `INTEGRATION.md` for the concrete integration point found in this repo (`GameBinariesUpdateTaskImpl.java`).
+
+## The bug, in plain terms
+
+The game's audio system occasionally crashes the whole process. This isn't a driver problem, a hardware problem, or anything specific to one machine — it's a bug in a small piece of code Microsoft shipped in 2007 as part of the DirectX runtime, which this ~2007-era game engine depends on and which Microsoft never updated. Two different game threads can end up touching the same piece of audio memory at the same moment — one thread is in the middle of freeing/reloading it, another thread tries to read it — and whichever one loses that race crashes the entire game.
+
+## The bug, technically
+
+**Component:** `xactengine2_9.dll`, version `9.20.1057.0000 (WGGT_AUG07.Release)` — Microsoft's XACT Engine API, part of the DirectX End-User Runtime (August 2007 release), `Microsoft Corporation`. This is a redistributable component installed once by any DirectX-9-era game that needs it (not a Windows OS file that varies by Windows version) and lives at `C:\Windows\SysWOW64\xactengine2_9.dll` on a 64-bit Windows install.
+
+**Three known fault sites**, all in the same subsystem (wave-bank reload/free, driven by one function `FUN_0041d60e`):
+
+| Offset | Function | Bug shape |
+|---|---|---|
+| `+0x1D751` | `FUN_0041d751` (teardown) | Use-after-free: a pointer (`this+0x5c`) is null-checked but the *pointee* was already freed by another thread. Reads Windows' freed-heap fill pattern `0xFEEEFEEE`, then crashes calling through it. |
+| `+0x1D212` | `FUN_0041d212` (cue lookup) | Null-pointer dereference: a 4-hop pointer chain off the same field has no null check between hops; if a reload is mid-flight, an intermediate hop is null and the next dereference faults. |
+| `+0x1DE46` | (unnamed, linked-list walk) | Iterator invalidation: walks a linked list of wave-bank nodes, calling the same reload function on each node — but that call can free/mutate nodes later in the list, which the walk never accounts for. |
+
+**Root cause** (confirmed via Ghidra static analysis, whole-binary cross-reference scan for every write to the shared field): the reload function `FUN_0041d60e` correctly frees and nulls the shared pointer, and correctly guards *itself* against re-entering concurrently via `InterlockedCompareExchange` on two flag fields. But **none of the three reader sites above check or acquire that same lock** — they just read the raw pointer. This is a classic partial/asymmetric locking bug: the writer locks against itself, never against readers, and the readers were never written to participate in the lock at all. The null-deref and use-after-free crashes are two symptoms of the exact same missing synchronization, not two separate defects; the third (list-walk) site is a related but mechanically distinct bug in the same subsystem.
+
+This matches a years-old, well-known community report (independent of this investigation) of the identical crash — same DLL, same version (`9.20.1057.0`), same exception code — which is itself useful portability evidence: this isn't a one-machine problem.
+
+## How the fix works
+
+**We don't patch `xactengine2_9.dll` itself.** It's a Microsoft DLL, and while it's plain unsigned userland code (not kernel, no anti-tamper observed), directly binary-patching a shared system file is invasive and hard to distribute/undo cleanly. Instead:
+
+1. **Injection vector:** `ForgedAlliance.exe` genuinely imports `BugSplat.dll` (FAF's own bundled crash-reporter) from its own install directory by name — normal Windows DLL search order checks the application's own directory first, so a same-named DLL placed there loads *instead of* the real one. We built a **proxy `BugSplat.dll`** that transparently forwards all 19 of the real DLL's exports (verified byte-for-byte against the original — nothing about BugSplat's own behavior changes) and additionally runs our own code at load time. `xactengine2_9.dll` itself can't be shadowed this same way — it's COM-activated (resolved via the registry, not search order) — so BugSplat is purely a "way to get our own code running early inside the game's process," unrelated to what BugSplat itself does.
+2. **Hooking:** once loaded, a background thread polls for `xactengine2_9.dll` to appear (it loads a moment later, when the game initializes audio), then uses **MinHook** (github.com/TsudaKageyu/minhook, BSD-2-Clause) to install inline hooks at the three known fault-site addresses, computed as `(loaded module base) + (fixed offset)` — so it's independent of ASLR/where Windows happens to load the DLL each run.
+3. **Containment:** each hook wraps the real function call using `setjmp`/`longjmp` triggered from inside a Windows Vectored Exception Handler (GCC/MinGW has no `__try`/`__except` — that's an MSVC-only extension — so this is the portable equivalent). If the wrapped call faults, the VEH recognizes it's inside a guarded call on that thread (thread-local state, so it's race-safe with itself) and jumps back to right after the `setjmp`, turning "the whole game crashes" into "that one risky operation was skipped, logged, and play continues." A process-wide VEH also catches (and logs, but does **not** attempt to recover from) any *other* access violation inside the DLL that isn't one of the three known sites — deliberately conservative: we don't guess at recovery for faults we haven't characterized, since a wrong guess could corrupt state worse than crashing.
+4. **Feature flags:** each of the three hooks can be set to `disabled` / `passthrough` (installed but no recovery, still logged) / `contain` (full recovery) via a plain-text config file, re-read once per game launch — no rebuild needed to try different combinations.
+
+## Confirmed vs. still open
+
+**Confirmed, with real evidence (not just theory):**
+- All three hooks install successfully against the real DLL (standalone test harness, `MH_OK` for every `CreateHook`/`EnableHook` call).
+- The wrapper is live and has caught real crashes during actual play: the `+0x1DE46` site fired and was contained **4 times in about 5 minutes** in one session, with the game continuing to run each time (confirmed via the runtime log and the live process still running afterward). Before this fix, that exact fault would have killed the game every time.
+
+**Still open / not yet done:**
+- The root-cause fix (adding the missing lock acquisition at the three reader sites, rather than catching the resulting crash) has not been attempted — containment was judged sufficient and much lower-risk for now.
+- Haven't confirmed via a live debugger (WinDbg) which specific caller reaches the reader sites from a background thread — inferred from static evidence (the asymmetric-locking pattern plus prior worker-thread crash stack frames), not directly observed together in one trace.
+- Dr. Memory (installed, ready) hasn't been run against a real play session yet — would give the first fully dynamic confirmation (real free-call-stack + real bad-reuse-call-stack) of the static analysis above.
+- Whether there are *more* unguarded fault sites in the same subsystem beyond these three is unknown — they were found reactively (one from initial static analysis, two more from live crashes as they occurred), not from an exhaustive audit.
+
+## Portability: will this work on someone else's machine?
+
+**Short answer: probably yes for the core mechanism, but not as currently packaged — three concrete things need fixing first.**
+
+1. **Hardcoded paths (must fix before sharing with anyone).** The log file and the feature-flag config file are currently hardcoded to this machine's specific path: `C:\Users\admin\Desktop\supreme commander crash debug\...` (see `proxylog.c` line 12, `flags.c` line 7). This will not work on any other machine as-is — needs to become relative to the DLL's own install directory (e.g. write next to `BugSplat.dll` itself) or a standard location like `%LOCALAPPDATA%\FAForever\`.
+
+2. **`xactengine2_9.dll` version dependency — reasonably strong evidence it's fine, not proven.** The three hook addresses are fixed byte offsets into this specific DLL. This machine's copy is version `9.20.1057.0000 (WGGT_AUG07.Release)`. Reasons to be fairly confident this is the same file on most other Windows installs that have this game working at all:
+   - It's a DirectX End-User Runtime redistributable component, not a Windows OS file — it doesn't change with Windows updates, and Microsoft never released a newer version of it after 2007.
+   - The independent community crash report referenced above (a different user, found in earlier research, not affiliated with this session) hit the identical DLL version and the identical exception signature — real cross-machine evidence, not just theory.
+   - That said, this has not been verified against a second real machine in this session. **Before wide distribution, the safe move is to have the proxy DLL check the loaded `xactengine2_9.dll`'s version at runtime and refuse to install the hooks (falling back to pure pass-through / logging only) if the version doesn't match exactly** — cheap insurance against a version mismatch silently hooking the wrong bytes and crashing somewhere new instead of fixing anything.
+
+3. **`BugSplat.dll` export list dependency.** The 19-export forwarder table is pinned to whatever `BugSplat.dll` FAF's client currently bundles. If FAF ever updates to a different BugSplat SDK version with a different export set, the forwarder `.def` file would need regenerating (a mismatched/missing forward is a hard DLL-load failure, so this fails loudly, not silently — not dangerous, just needs a rebuild when it happens).
+
+4. **Platform scope:** Windows-only by nature (Win32 DLL injection, PE format, MinHook). No reason to expect issues across different Windows 10/11 builds specifically, since nothing here depends on Windows-version-specific behavior — only on the DirectX component above. Works on 32-bit or 64-bit Windows host the same way (the game itself is always 32-bit, running under WOW64 on a 64-bit host, which is what this was built/tested on).
+
+## Checklist before this could be shared or upstreamed
+
+- [ ] Replace hardcoded log/config paths with something portable (relative to the DLL's own directory, or a standard per-user app-data location).
+- [ ] Add a runtime version check against the real `xactengine2_9.dll` before installing hooks; fail safe (pass-through only) on a mismatch rather than assuming the offsets are still correct.
+- [ ] Determine FAF's actual license (not yet checked — don't assume GPL or anything else) before writing any license header into code intended for submission.
+- [ ] Decide on distribution mechanism (see below) and, if pursuing upstream, open a conversation with FAF maintainers before assuming a PR would be accepted — this patches behavior around a Microsoft-owned DLL, not FAF's own code, so it's a judgment call for them, not something a PR can force through.
+- [ ] Consider running under Dr. Memory for one real play session to get dynamic confirmation of the root-cause analysis, strengthening confidence before wider release.
+- [ ] Decide whether to also fix the root cause (add the missing lock at the reader sites) rather than only containing the crash — lower risk to ship containment first, but worth revisiting once more confidence is built up.
+
+## Where this could be hosted / shared
+
+A few realistic options, in rough order of fit:
+
+- **FAF's own client repo (`FAForever/downlords-faf-client`), as a bundled binary asset.** This is the most "real" path if the goal is it becoming a standard part of FAF: the client already bundles binary assets (`BugSplat.dll`, `dbghelp.dll`) alongside `ForgedAlliance.exe` at install/update time, so there's precedent for shipping a native DLL this way even though the client itself is Java. Requires maintainer buy-in, not just a PR — see checklist above.
+- **FAF community channels (Discord, forums) as a standalone optional download.** Lowest-friction way to get it in front of the people who'd actually use it and get feedback, without needing anyone's approval first. A GitHub repo of your own (or a Gist) as the actual file host, linked from there, is the standard pattern for this kind of community tool.
+- **A dedicated small GitHub repo of your own.** Gives it a real home with version history, issues, and a README — reasonable middle ground between "just a forum post" and "merged into the official client." Also the natural staging point if an eventual PR to the client repo is the long-term goal (point the client at a tagged release).
+- **ModDB (moddb.com).** Not a great fit — ModDB is built around game *content* mods (maps, factions, total conversions, textures), not binary patches/crash fixes for the underlying engine. Nothing stops someone from posting it there, but it's not really the audience or format ModDB is designed for, and it would likely get more attention and better context in an FAF-specific venue instead.
+
+No public action was taken as part of preparing this document — no repo, branch, or PR was created, nothing was uploaded anywhere. This is purely groundwork for your own review before deciding how (or whether) to share this further.

--- a/contrib/xact-crash-fix/src/bugsplat_proxy.def
+++ b/contrib/xact-crash-fix/src/bugsplat_proxy.def
@@ -1,0 +1,21 @@
+LIBRARY bugsplat_proxy
+EXPORTS
+??0MiniDmpSender@@QAE@ABV0@@Z = BugSplat_real.??0MiniDmpSender@@QAE@ABV0@@Z
+??0MiniDmpSender@@QAE@PBD000K@Z = BugSplat_real.??0MiniDmpSender@@QAE@PBD000K@Z
+??0MiniDmpSender@@QAE@PBG000K@Z = BugSplat_real.??0MiniDmpSender@@QAE@PBG000K@Z
+??1MiniDmpSender@@UAE@XZ = BugSplat_real.??1MiniDmpSender@@UAE@XZ
+??4MiniDmpSender@@QAEAAV0@ABV0@@Z = BugSplat_real.??4MiniDmpSender@@QAEAAV0@ABV0@@Z
+??_7MiniDmpSender@@6B@ = BugSplat_real.??_7MiniDmpSender@@6B@
+?SetDbghelpFlags@MiniDmpSender@@QAEXW4dbghelpFlags@1@@Z = BugSplat_real.?SetDbghelpFlags@MiniDmpSender@@QAEXW4dbghelpFlags@1@@Z
+?createReport@MiniDmpSender@@QAEXPAU_EXCEPTION_POINTERS@@@Z = BugSplat_real.?createReport@MiniDmpSender@@QAEXPAU_EXCEPTION_POINTERS@@@Z
+?createReport@MiniDmpSender@@QAEXXZ = BugSplat_real.?createReport@MiniDmpSender@@QAEXXZ
+?enableExceptionFilter@MiniDmpSender@@QAE_N_N@Z = BugSplat_real.?enableExceptionFilter@MiniDmpSender@@QAE_N_N@Z
+?getFlags@MiniDmpSender@@QBEKXZ = BugSplat_real.?getFlags@MiniDmpSender@@QBEKXZ
+?hookExceptionFilter@MiniDmpSender@@QAE_NXZ = BugSplat_real.?hookExceptionFilter@MiniDmpSender@@QAE_NXZ
+?isExceptionFilterEnabled@MiniDmpSender@@QBE_NXZ = BugSplat_real.?isExceptionFilterEnabled@MiniDmpSender@@QBE_NXZ
+?resetAppIdentifierA@MiniDmpSender@@QAEXPBD@Z = BugSplat_real.?resetAppIdentifierA@MiniDmpSender@@QAEXPBD@Z
+?resetAppIdentifierW@MiniDmpSender@@QAEXPBG@Z = BugSplat_real.?resetAppIdentifierW@MiniDmpSender@@QAEXPBG@Z
+?resetVersionStringA@MiniDmpSender@@QAEXPBD@Z = BugSplat_real.?resetVersionStringA@MiniDmpSender@@QAEXPBD@Z
+?resetVersionStringW@MiniDmpSender@@QAEXPBG@Z = BugSplat_real.?resetVersionStringW@MiniDmpSender@@QAEXPBG@Z
+?setCallback@MiniDmpSender@@QAEXP6A_NIPAX0@Z@Z = BugSplat_real.?setCallback@MiniDmpSender@@QAEXP6A_NIPAX0@Z@Z
+?setFlags@MiniDmpSender@@QAE_NK@Z = BugSplat_real.?setFlags@MiniDmpSender@@QAE_NK@Z

--- a/contrib/xact-crash-fix/src/debug_string_sink.c
+++ b/contrib/xact-crash-fix/src/debug_string_sink.c
@@ -1,0 +1,24 @@
+#include <windows.h>
+#include <stdlib.h>
+#include "debug_string_sink.h"
+
+static void DebugStringSink_Write(ILogSink *self, LogLevel level, const char *formattedMessage)
+{
+    (void)self;
+    (void)level;
+    OutputDebugStringA(formattedMessage);
+}
+
+static void DebugStringSink_Destroy(ILogSink *self)
+{
+    free(self);
+}
+
+ILogSink *CreateDebugStringSink(void)
+{
+    ILogSink *sink = (ILogSink *)malloc(sizeof(ILogSink));
+    if (!sink) return NULL;
+    sink->Write = DebugStringSink_Write;
+    sink->Destroy = DebugStringSink_Destroy;
+    return sink;
+}

--- a/contrib/xact-crash-fix/src/debug_string_sink.h
+++ b/contrib/xact-crash-fix/src/debug_string_sink.h
@@ -1,0 +1,12 @@
+#ifndef DEBUG_STRING_SINK_H
+#define DEBUG_STRING_SINK_H
+
+#include "ilog_sink.h"
+
+/* A sink that writes to OutputDebugStringA - picked up natively by any
+ * attached debugger (FADeepProbe, WinDbg, DebugView). Stateless, but
+ * still heap-allocated so LoggerDestroy can uniformly call Destroy on
+ * every sink regardless of type. */
+ILogSink *CreateDebugStringSink(void);
+
+#endif

--- a/contrib/xact-crash-fix/src/dllmain.c
+++ b/contrib/xact-crash-fix/src/dllmain.c
@@ -1,0 +1,32 @@
+/*
+ * dllmain.c - BugSplat-proxy entry point (builds bugsplat_proxy.dll). This
+ * gets loaded AS BugSplat.dll (real BugSplat.dll's 19 exports are forwarded
+ * to a copy saved as BugSplat_real.dll via bugsplat_proxy.def). We
+ * piggyback on the fact that ForgedAlliance.exe genuinely imports
+ * BugSplat.dll from its own directory (confirmed via its import table),
+ * which is what gets us loaded early, before the game's XACT audio engine
+ * initializes.
+ *
+ * This file is now ONLY the injection vector - the actual guard-install
+ * logic lives in xact_guards.c's StartXactGuardsWatcher(), shared with
+ * guards_dllmain.c (which builds a standalone xact_guards.dll usable by
+ * any OTHER loader, e.g. a debugger like FADeepProbe injecting it
+ * directly instead of going through the BugSplat trick at all).
+ */
+#include <windows.h>
+#include "xact_guards.h"
+
+BOOL WINAPI DllMain(HINSTANCE hinst, DWORD reason, LPVOID reserved)
+{
+    (void)reserved;
+
+    if (reason == DLL_PROCESS_ATTACH) {
+        DisableThreadLibraryCalls(hinst);
+        /* Don't do real work here - DllMain runs under the loader lock.
+         * StartXactGuardsWatcher spawns a thread and does everything else
+         * there (standard Win32 DLL-injection hygiene). */
+        StartXactGuardsWatcher(hinst);
+    }
+
+    return TRUE;
+}

--- a/contrib/xact-crash-fix/src/file_sink.c
+++ b/contrib/xact-crash-fix/src/file_sink.c
@@ -1,0 +1,46 @@
+#include <windows.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "file_sink.h"
+
+typedef struct {
+    ILogSink base; /* must be first member - callers only ever see &self->base */
+    char path[MAX_PATH];
+} FileSink;
+
+static void FileSink_Write(ILogSink *self, LogLevel level, const char *formattedMessage)
+{
+    (void)level;
+    FileSink *fileSink = (FileSink *)self;
+
+    FILE *f = fopen(fileSink->path, "a");
+    if (!f) return; /* unwritable path - silently drop, don't crash the guarded process over a log write */
+
+    SYSTEMTIME st;
+    GetLocalTime(&st);
+    fprintf(f, "[%04d-%02d-%02d %02d:%02d:%02d.%03d] %s",
+            st.wYear, st.wMonth, st.wDay, st.wHour, st.wMinute, st.wSecond, st.wMilliseconds,
+            formattedMessage);
+    fclose(f);
+}
+
+static void FileSink_Destroy(ILogSink *self)
+{
+    free(self);
+}
+
+ILogSink *CreateFileSink(const char *fullPath)
+{
+    if (!fullPath || fullPath[0] == '\0') return NULL;
+    if (strlen(fullPath) >= MAX_PATH) return NULL;
+
+    FileSink *fileSink = (FileSink *)malloc(sizeof(FileSink));
+    if (!fileSink) return NULL;
+
+    fileSink->base.Write = FileSink_Write;
+    fileSink->base.Destroy = FileSink_Destroy;
+    strcpy(fileSink->path, fullPath);
+
+    return &fileSink->base;
+}

--- a/contrib/xact-crash-fix/src/file_sink.h
+++ b/contrib/xact-crash-fix/src/file_sink.h
@@ -1,0 +1,24 @@
+#ifndef FILE_SINK_H
+#define FILE_SINK_H
+
+#include "ilog_sink.h"
+
+/* A sink that appends timestamped lines to a file. Opens/writes/closes
+ * per call rather than holding a handle open - these guards fire rarely
+ * (only on the fault paths being contained, or sparse INFO-level setup
+ * messages), so log-write performance isn't a concern, and this avoids
+ * any shared-handle/locking complexity or a leaked-open-handle-on-crash
+ * problem.
+ *
+ * fullPath must already be a complete, resolved path (this sink doesn't
+ * know about "relative to the DLL's directory" - that's Logger/proxylog.c's
+ * job, keeping this sink a dumb, reusable building block).
+ *
+ * Returns NULL if fullPath is NULL/empty - caller should treat that as
+ * "don't add a file sink" rather than a hard error. A path that's merely
+ * unwritable at construction time still returns a sink (each Write just
+ * silently no-ops if fopen fails - matches the previous implementation's
+ * behavior of not crashing on a bad path). */
+ILogSink *CreateFileSink(const char *fullPath);
+
+#endif

--- a/contrib/xact-crash-fix/src/flags.c
+++ b/contrib/xact-crash-fix/src/flags.c
@@ -5,8 +5,11 @@
 #include "proxylog.h"
 
 /* Defaults: every guard fully active - editing/deleting the config file
- * never reduces protection below "everything on". */
-XactFlags g_flags = { STRAT_CONTAIN, STRAT_CONTAIN, STRAT_CONTAIN };
+ * never reduces protection below "everything on". Logging defaults to
+ * INFO + debug-string on + file off (ProxyLogConfigure gets called with
+ * these below even when no config file exists, so this struct literal
+ * is only the in-memory fallback until that call runs). */
+XactFlags g_flags = { STRAT_CONTAIN, STRAT_CONTAIN, STRAT_CONTAIN, LOG_INFO, TRUE, "" };
 
 /* Builds "<dir this DLL loaded from>\xact_proxy_flags.ini" - portable,
  * no hardcoded path (see proxylog.c's ProxyGetDir for why). */
@@ -41,6 +44,13 @@ static const char *StrategyName(GuardStrategy s)
     }
 }
 
+static BOOL ParseBool(const char *v, BOOL defaultValue)
+{
+    if (_stricmp(v, "true") == 0 || _stricmp(v, "1") == 0 || _stricmp(v, "yes") == 0)  return TRUE;
+    if (_stricmp(v, "false") == 0 || _stricmp(v, "0") == 0 || _stricmp(v, "no") == 0)  return FALSE;
+    return defaultValue; /* unrecognized -> keep current default rather than guess */
+}
+
 static void WriteTemplateFile(const char *path)
 {
     FILE *f = fopen(path, "w");
@@ -49,7 +59,7 @@ static void WriteTemplateFile(const char *path)
         "# xact_proxy feature flags - edit this file and relaunch the game to try\n"
         "# different things. Re-read once at DLL load, no rebuild needed.\n"
         "#\n"
-        "# Values: disabled | passthrough | contain\n"
+        "# Guard strategy values: disabled | passthrough | contain\n"
         "#   disabled    - hook not installed at all (same as no wrapper for this site)\n"
         "#   passthrough - hook installed, but just calls the original function with no\n"
         "#                 recovery - a crash here still crashes, but the VEH still logs it\n"
@@ -59,6 +69,19 @@ static void WriteTemplateFile(const char *path)
         "HOOK_1D751=contain\n"
         "HOOK_1D212=contain\n"
         "HOOK_1DE46=contain\n"
+        "#\n"
+        "# Logging - matches FAF's own TRACE/DEBUG/INFO/WARN/ERROR convention.\n"
+        "# LOG_LEVEL: minimum level that gets emitted (messages below this are dropped).\n"
+        "# LOG_DEBUGSTRING: true/false - send output to OutputDebugStringA (any attached\n"
+        "#   debugger - FADeepProbe, WinDbg, DebugView - picks this up natively).\n"
+        "# LOG_FILE: bare filename (e.g. xact_proxy_runtime.log), resolved next to this\n"
+        "#   DLL - leave empty to disable the file sink. Passing /logxactguards on the\n"
+        "#   game's own command line forces the file sink on for that one launch\n"
+        "#   regardless of this setting, as a quick override.\n"
+        "#\n"
+        "LOG_LEVEL=info\n"
+        "LOG_DEBUGSTRING=true\n"
+        "LOG_FILE=\n"
     );
     fclose(f);
 }
@@ -70,9 +93,10 @@ void LoadXactFlags(void)
 
     FILE *f = fopen(flagsPath, "r");
     if (!f) {
-        ProxyLog("LoadXactFlags: no config file at \"%s\" - using defaults (all contain), "
-                 "writing a template for next time", flagsPath);
+        ProxyLog("LoadXactFlags: no config file at \"%s\" - using defaults (all contain, "
+                 "log level info), writing a template for next time", flagsPath);
         WriteTemplateFile(flagsPath);
+        ProxyLogConfigure(g_flags.logLevel, g_flags.logDebugStringEnabled, g_flags.logFileName);
         return;
     }
 
@@ -91,10 +115,21 @@ void LoadXactFlags(void)
         if (_stricmp(key, "HOOK_1D751") == 0)      g_flags.hook1D751 = ParseStrategy(val);
         else if (_stricmp(key, "HOOK_1D212") == 0) g_flags.hook1D212 = ParseStrategy(val);
         else if (_stricmp(key, "HOOK_1DE46") == 0) g_flags.hook1DE46 = ParseStrategy(val);
+        else if (_stricmp(key, "LOG_LEVEL") == 0)  g_flags.logLevel = ProxyLogLevelFromString(val);
+        else if (_stricmp(key, "LOG_DEBUGSTRING") == 0)
+            g_flags.logDebugStringEnabled = ParseBool(val, g_flags.logDebugStringEnabled);
+        else if (_stricmp(key, "LOG_FILE") == 0)
+            strncpy(g_flags.logFileName, val, sizeof(g_flags.logFileName) - 1);
     }
     fclose(f);
 
-    ProxyLog("LoadXactFlags: loaded from \"%s\" -> hook1D751=%s hook1D212=%s hook1DE46=%s",
+    /* Apply the logging settings before the summary line below, so that
+     * line itself already reflects the newly-configured level/sinks. */
+    ProxyLogConfigure(g_flags.logLevel, g_flags.logDebugStringEnabled, g_flags.logFileName);
+
+    ProxyLog("LoadXactFlags: loaded from \"%s\" -> hook1D751=%s hook1D212=%s hook1DE46=%s "
+             "logDebugString=%s logFile=\"%s\"",
              flagsPath, StrategyName(g_flags.hook1D751), StrategyName(g_flags.hook1D212),
-             StrategyName(g_flags.hook1DE46));
+             StrategyName(g_flags.hook1DE46),
+             g_flags.logDebugStringEnabled ? "true" : "false", g_flags.logFileName);
 }

--- a/contrib/xact-crash-fix/src/flags.c
+++ b/contrib/xact-crash-fix/src/flags.c
@@ -1,0 +1,100 @@
+#include <windows.h>
+#include <stdio.h>
+#include <string.h>
+#include "flags.h"
+#include "proxylog.h"
+
+/* Defaults: every guard fully active - editing/deleting the config file
+ * never reduces protection below "everything on". */
+XactFlags g_flags = { STRAT_CONTAIN, STRAT_CONTAIN, STRAT_CONTAIN };
+
+/* Builds "<dir this DLL loaded from>\xact_proxy_flags.ini" - portable,
+ * no hardcoded path (see proxylog.c's ProxyGetDir for why). */
+static void GetFlagsPath(char *out, size_t outSize)
+{
+    const char *dir = ProxyGetDir();
+    if (dir[0] == '\0') {
+        /* ProxyLogInit hasn't run / failed - fall back to relative path
+         * (current directory), same spirit as proxylog.c's own fallback */
+        strncpy(out, "xact_proxy_flags.ini", outSize - 1);
+        out[outSize - 1] = '\0';
+        return;
+    }
+    snprintf(out, outSize, "%sxact_proxy_flags.ini", dir);
+}
+
+static GuardStrategy ParseStrategy(const char *v)
+{
+    if (_stricmp(v, "disabled") == 0)    return STRAT_DISABLED;
+    if (_stricmp(v, "passthrough") == 0) return STRAT_PASSTHROUGH;
+    if (_stricmp(v, "contain") == 0)     return STRAT_CONTAIN;
+    return STRAT_CONTAIN; /* unrecognized value -> safest default, not "off" */
+}
+
+static const char *StrategyName(GuardStrategy s)
+{
+    switch (s) {
+        case STRAT_DISABLED:    return "disabled";
+        case STRAT_PASSTHROUGH: return "passthrough";
+        case STRAT_CONTAIN:     return "contain";
+        default:                return "?";
+    }
+}
+
+static void WriteTemplateFile(const char *path)
+{
+    FILE *f = fopen(path, "w");
+    if (!f) return;
+    fprintf(f,
+        "# xact_proxy feature flags - edit this file and relaunch the game to try\n"
+        "# different things. Re-read once at DLL load, no rebuild needed.\n"
+        "#\n"
+        "# Values: disabled | passthrough | contain\n"
+        "#   disabled    - hook not installed at all (same as no wrapper for this site)\n"
+        "#   passthrough - hook installed, but just calls the original function with no\n"
+        "#                 recovery - a crash here still crashes, but the VEH still logs it\n"
+        "#                 (useful to check whether a hook itself changes anything)\n"
+        "#   contain     - full recovery: catch the crash, log it, keep the game running\n"
+        "#\n"
+        "HOOK_1D751=contain\n"
+        "HOOK_1D212=contain\n"
+        "HOOK_1DE46=contain\n"
+    );
+    fclose(f);
+}
+
+void LoadXactFlags(void)
+{
+    char flagsPath[MAX_PATH];
+    GetFlagsPath(flagsPath, sizeof(flagsPath));
+
+    FILE *f = fopen(flagsPath, "r");
+    if (!f) {
+        ProxyLog("LoadXactFlags: no config file at \"%s\" - using defaults (all contain), "
+                 "writing a template for next time", flagsPath);
+        WriteTemplateFile(flagsPath);
+        return;
+    }
+
+    char line[256];
+    while (fgets(line, sizeof(line), f)) {
+        char *nl = strpbrk(line, "\r\n");
+        if (nl) *nl = 0;
+        if (line[0] == '#' || line[0] == '\0') continue;
+
+        char *eq = strchr(line, '=');
+        if (!eq) continue;
+        *eq = '\0';
+        const char *key = line;
+        const char *val = eq + 1;
+
+        if (_stricmp(key, "HOOK_1D751") == 0)      g_flags.hook1D751 = ParseStrategy(val);
+        else if (_stricmp(key, "HOOK_1D212") == 0) g_flags.hook1D212 = ParseStrategy(val);
+        else if (_stricmp(key, "HOOK_1DE46") == 0) g_flags.hook1DE46 = ParseStrategy(val);
+    }
+    fclose(f);
+
+    ProxyLog("LoadXactFlags: loaded from \"%s\" -> hook1D751=%s hook1D212=%s hook1DE46=%s",
+             flagsPath, StrategyName(g_flags.hook1D751), StrategyName(g_flags.hook1D212),
+             StrategyName(g_flags.hook1DE46));
+}

--- a/contrib/xact-crash-fix/src/flags.h
+++ b/contrib/xact-crash-fix/src/flags.h
@@ -1,5 +1,7 @@
 #ifndef XACT_FLAGS_H
 #define XACT_FLAGS_H
+#include <windows.h>
+#include "proxylog.h"
 
 /* Strategy pattern: each guarded site's runtime behavior is one of three
  * interchangeable strategies, selected via an external config file (no
@@ -17,14 +19,23 @@ typedef struct {
     GuardStrategy hook1D751;  /* use-after-free / dangling-pointer teardown site (§2.7) */
     GuardStrategy hook1D212;  /* null pointer-chain-hop site (§2.7) */
     GuardStrategy hook1DE46;  /* linked-list iterator-invalidation site (§2.7c) */
+
+    /* Logging - see proxylog.h's ProxyLogConfigure(), which these get
+     * passed to verbatim after parsing. */
+    LogLevel logLevel;             /* LOG_LEVEL= */
+    BOOL     logDebugStringEnabled; /* LOG_DEBUGSTRING= (true/false) */
+    char     logFileName[MAX_PATH]; /* LOG_FILE= - bare filename, "" = file sink off
+                                      * (unless /logxactguards overrides it, see proxylog.c) */
 } XactFlags;
 
 extern XactFlags g_flags;
 
-/* Reads C:\Users\admin\Desktop\supreme commander crash debug\xact_proxy_flags.ini
- * if present; any missing/unrecognized key keeps its default (STRAT_CONTAIN -
- * i.e. full protection - so a missing or malformed config file never silently
- * turns protection off). Writes out a template file if none exists yet. */
+/* Reads "<dir this module loaded from>\xact_proxy_flags.ini" if present;
+ * any missing/unrecognized key keeps its default (STRAT_CONTAIN for the
+ * hooks - i.e. full protection - so a missing or malformed config file
+ * never silently turns protection off). Writes out a template file if
+ * none exists yet. Also calls ProxyLogConfigure() with the parsed logging
+ * settings before returning. */
 void LoadXactFlags(void);
 
 #endif

--- a/contrib/xact-crash-fix/src/flags.h
+++ b/contrib/xact-crash-fix/src/flags.h
@@ -1,0 +1,30 @@
+#ifndef XACT_FLAGS_H
+#define XACT_FLAGS_H
+
+/* Strategy pattern: each guarded site's runtime behavior is one of three
+ * interchangeable strategies, selected via an external config file (no
+ * rebuild needed to switch) - read once per game launch. */
+typedef enum {
+    STRAT_DISABLED    = 0, /* hook not installed at all - identical to pre-wrapper behavior for this site */
+    STRAT_PASSTHROUGH = 1, /* hook installed, but detour just calls the original with no try/catch -
+                             * useful for isolating "does the hook itself change anything" from
+                             * "does the recovery logic work", since a crash here still crashes
+                             * the process same as if unhooked, but still gets logged by the VEH */
+    STRAT_CONTAIN     = 2  /* full setjmp/longjmp recovery - the original wrapper behavior */
+} GuardStrategy;
+
+typedef struct {
+    GuardStrategy hook1D751;  /* use-after-free / dangling-pointer teardown site (§2.7) */
+    GuardStrategy hook1D212;  /* null pointer-chain-hop site (§2.7) */
+    GuardStrategy hook1DE46;  /* linked-list iterator-invalidation site (§2.7c) */
+} XactFlags;
+
+extern XactFlags g_flags;
+
+/* Reads C:\Users\admin\Desktop\supreme commander crash debug\xact_proxy_flags.ini
+ * if present; any missing/unrecognized key keeps its default (STRAT_CONTAIN -
+ * i.e. full protection - so a missing or malformed config file never silently
+ * turns protection off). Writes out a template file if none exists yet. */
+void LoadXactFlags(void);
+
+#endif

--- a/contrib/xact-crash-fix/src/guards_dllmain.c
+++ b/contrib/xact-crash-fix/src/guards_dllmain.c
@@ -1,0 +1,27 @@
+/*
+ * guards_dllmain.c - entry point for the STANDALONE guards DLL (builds
+ * xact_guards.dll). Unlike bugsplat_proxy.dll, this has no need to
+ * masquerade as anything or forward any exports - it's meant to be
+ * injected directly by whatever already has a foothold in the game's
+ * process, e.g. a debugger like FADeepProbe (which already launches
+ * ForgedAlliance.exe under its own control - it could LoadLibrary this
+ * DLL into the child process right after CreateProcess, as an
+ * alternative to going through the BugSplat.dll proxy trick at all).
+ *
+ * This is intentionally the smallest possible file - all real logic is
+ * shared with dllmain.c via xact_guards.c's StartXactGuardsWatcher().
+ */
+#include <windows.h>
+#include "xact_guards.h"
+
+BOOL WINAPI DllMain(HINSTANCE hinst, DWORD reason, LPVOID reserved)
+{
+    (void)reserved;
+
+    if (reason == DLL_PROCESS_ATTACH) {
+        DisableThreadLibraryCalls(hinst);
+        StartXactGuardsWatcher(hinst);
+    }
+
+    return TRUE;
+}

--- a/contrib/xact-crash-fix/src/ilog_sink.h
+++ b/contrib/xact-crash-fix/src/ilog_sink.h
@@ -1,0 +1,21 @@
+#ifndef ILOG_SINK_H
+#define ILOG_SINK_H
+
+#include "proxylog.h" /* LogLevel */
+
+/* A log sink is anything that can receive a fully-formatted log line - a
+ * debugger (OutputDebugStringA), a file, or a test double. Plain C, no
+ * inheritance: a struct of function pointers is the interface, and each
+ * concrete sink is just a struct that starts with one of these (or embeds
+ * it as first member) plus whatever private state it needs after that -
+ * the classic C "vtable" idiom.
+ *
+ * self->Write's formattedMessage already has the "[xact_guards] [LEVEL]
+ * [tid=...]" prefix and trailing newline applied by Logger - sinks just
+ * write it as-is, they don't reformat. */
+typedef struct ILogSink {
+    void (*Write)(struct ILogSink *self, LogLevel level, const char *formattedMessage);
+    void (*Destroy)(struct ILogSink *self); /* frees self and any owned resources; NULL if nothing to free */
+} ILogSink;
+
+#endif

--- a/contrib/xact-crash-fix/src/logger.c
+++ b/contrib/xact-crash-fix/src/logger.c
@@ -1,0 +1,90 @@
+#include <windows.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "logger.h"
+
+#define MAX_SINKS 8
+
+struct Logger {
+    ILogSink *sinks[MAX_SINKS];
+    int sinkCount;
+    LogLevel minLevel;
+};
+
+Logger *CreateLogger(void)
+{
+    Logger *logger = (Logger *)malloc(sizeof(Logger));
+    if (!logger) return NULL;
+    logger->sinkCount = 0;
+    logger->minLevel = LOG_INFO;
+    return logger;
+}
+
+void LoggerAddSink(Logger *logger, ILogSink *sink)
+{
+    if (!logger || !sink) return;
+    if (logger->sinkCount >= MAX_SINKS) return; /* fixed-size on purpose - we only ever have 2 sink types today */
+    logger->sinks[logger->sinkCount++] = sink;
+}
+
+void LoggerSetMinLevel(Logger *logger, LogLevel level)
+{
+    if (!logger) return;
+    logger->minLevel = level;
+}
+
+static const char *LevelTag(LogLevel level)
+{
+    switch (level) {
+        case LOG_TRACE: return "TRACE";
+        case LOG_DEBUG: return "DEBUG";
+        case LOG_INFO:  return "INFO";
+        case LOG_WARN:  return "WARN";
+        case LOG_ERROR: return "ERROR";
+        default:        return "?";
+    }
+}
+
+void LoggerLogV(Logger *logger, LogLevel level, const char *fmt, va_list args)
+{
+    if (!logger) return;
+    if (level < logger->minLevel) return;
+    if (logger->sinkCount == 0) return;
+
+    char msg[1024];
+    int n = _snprintf(msg, sizeof(msg) - 2, "[xact_guards] [%s] [tid=%lu] ",
+                       LevelTag(level), (unsigned long)GetCurrentThreadId());
+    if (n < 0) n = 0;
+    if ((size_t)n >= sizeof(msg) - 2) n = (int)sizeof(msg) - 2;
+
+    int n2 = _vsnprintf(msg + n, sizeof(msg) - (size_t)n - 2, fmt, args);
+    if (n2 < 0) n2 = 0;
+
+    size_t total = (size_t)n + (size_t)n2;
+    if (total > sizeof(msg) - 2) total = sizeof(msg) - 2;
+    msg[total] = '\n';
+    msg[total + 1] = '\0';
+
+    for (int i = 0; i < logger->sinkCount; i++) {
+        logger->sinks[i]->Write(logger->sinks[i], level, msg);
+    }
+}
+
+void LoggerLog(Logger *logger, LogLevel level, const char *fmt, ...)
+{
+    va_list args;
+    va_start(args, fmt);
+    LoggerLogV(logger, level, fmt, args);
+    va_end(args);
+}
+
+void LoggerDestroy(Logger *logger)
+{
+    if (!logger) return;
+    for (int i = 0; i < logger->sinkCount; i++) {
+        if (logger->sinks[i]->Destroy) {
+            logger->sinks[i]->Destroy(logger->sinks[i]);
+        }
+    }
+    free(logger);
+}

--- a/contrib/xact-crash-fix/src/logger.h
+++ b/contrib/xact-crash-fix/src/logger.h
@@ -1,0 +1,29 @@
+#ifndef LOGGER_H
+#define LOGGER_H
+
+#include <stdarg.h>
+#include "ilog_sink.h"
+
+/* Opaque - the dependency-injection container for log sinks. Formats each
+ * message once, then dispatches to every registered sink (if the message
+ * clears the logger's single minimum level - level-gating happens here,
+ * not per-sink, matching how this behaved before this was split out). */
+typedef struct Logger Logger;
+
+Logger *CreateLogger(void);
+
+/* Logger takes ownership - calls sink->Destroy on it when LoggerDestroy
+ * runs. A NULL sink is silently ignored (lets callers do
+ * LoggerAddSink(logger, CreateFileSink(path)) without a NULL check when
+ * CreateFileSink() might reasonably return NULL for "no file wanted"). */
+void LoggerAddSink(Logger *logger, ILogSink *sink);
+
+void LoggerSetMinLevel(Logger *logger, LogLevel level);
+
+void LoggerLog(Logger *logger, LogLevel level, const char *fmt, ...);
+void LoggerLogV(Logger *logger, LogLevel level, const char *fmt, va_list args);
+
+/* Detaches and destroys every sink, then frees the logger itself. */
+void LoggerDestroy(Logger *logger);
+
+#endif

--- a/contrib/xact-crash-fix/src/proxylog.c
+++ b/contrib/xact-crash-fix/src/proxylog.c
@@ -1,12 +1,27 @@
 /*
- * proxylog.c - leveled diagnostic logging for the xactengine2_9.dll
- * crash-containment guards, with two independently-configurable sinks:
- * OutputDebugStringA (picked up natively by any attached debugger -
- * FADeepProbe, WinDbg, DebugView) and an optional file next to wherever
- * this DLL is actually loaded from. Both the minimum level and which
- * sinks are active are set via ProxyLogConfigure(), driven by
- * xact_proxy_flags.ini (see flags.c) - so logging behavior is entirely
- * config-driven, no rebuild needed to change it.
+ * proxylog.c - path resolution + the composition root for logging.
+ *
+ * The actual logging behavior (which sinks are active, what the minimum
+ * level is) now lives behind a real interface (ILogSink, see ilog_sink.h)
+ * with dependency injection: CreateDebugStringSink()/CreateFileSink()
+ * build sink objects, and ProxyLogConfigure() injects whichever ones are
+ * wanted into a Logger (logger.h) - the sinks and the Logger have no idea
+ * OutputDebugStringA or fopen() exist at the call-site level, they just
+ * implement/consume ILogSink.
+ *
+ * This ISN'T textbook parameter-passing DI, though, and that's deliberate:
+ * several call sites (xact_guards.c's MinHook detour functions) have
+ * signatures fixed by the game binary's own calling convention - a
+ * `Logger *` can't be threaded through them as an explicit parameter
+ * without breaking the ABI MinHook's trampoline relies on. So injection
+ * happens at ONE composition root instead (right here, in
+ * ProxyLogConfigure, called once after config is parsed) - the resulting
+ * Logger* is stored in a module-level static, and the free-function API
+ * below (LogInfo() etc.) looks it up internally. The actual behavior
+ * swap (which sinks, what level) still happens entirely at the
+ * composition root, not hardcoded into the logging calls - that's the
+ * part that matters for testability/swappability, even though the
+ * *lookup* is global rather than passed-in.
  *
  * ProxyGetDir() is also used by flags.c, which needs to find
  * xact_proxy_flags.ini next to wherever this code is actually loaded
@@ -17,18 +32,40 @@
 #include <stdarg.h>
 #include <string.h>
 #include "proxylog.h"
+#include "logger.h"
+#include "debug_string_sink.h"
+#include "file_sink.h"
 
 #define LOG_FLAG L"/logxactguards"
 #define DEFAULT_LOG_FILENAME "xact_proxy_runtime.log"
 
 static char g_moduleDirectory[MAX_PATH] = "";  /* directory this module loaded from, trailing backslash */
-static char g_logFilePath[MAX_PATH] = "";
 static BOOL g_pathsInitialized = FALSE;
 static BOOL g_cmdLineForceFile = FALSE;
 
-static LogLevel g_minLevel = LOG_INFO;
-static BOOL g_debugStringEnabled = TRUE;
-static BOOL g_fileLoggingEnabled = FALSE;
+/* The composition root's output. Never NULL after this file's own static
+ * initialization below - CreateDefaultLogger() runs at first use if
+ * ProxyLogConfigure() hasn't been called yet, so early startup messages
+ * (before config is parsed) still go somewhere sensible instead of
+ * vanishing. */
+static Logger *g_activeLogger = NULL;
+
+static Logger *CreateDefaultLogger(void)
+{
+    Logger *logger = CreateLogger();
+    if (!logger) return NULL;
+    LoggerSetMinLevel(logger, LOG_INFO);
+    LoggerAddSink(logger, CreateDebugStringSink()); /* file sink stays off until config says otherwise */
+    return logger;
+}
+
+static Logger *GetActiveLogger(void)
+{
+    if (!g_activeLogger) {
+        g_activeLogger = CreateDefaultLogger();
+    }
+    return g_activeLogger;
+}
 
 /* Checks THIS PROCESS's own command line (not an arbitrary string - always
  * GetCommandLineW()) for a flag, case-insensitively. Manual search to avoid
@@ -74,21 +111,36 @@ const char *ProxyGetDir(void)
 
 void ProxyLogConfigure(LogLevel minLevel, BOOL debugStringEnabled, const char *fileNameOrNull)
 {
-    g_minLevel = minLevel;
-    g_debugStringEnabled = debugStringEnabled;
+    /* Composition root: replace whatever logger was active (the default
+     * one, if this is the first real configure call) with a freshly wired
+     * one reflecting the requested sinks/level. */
+    Logger *oldLogger = g_activeLogger;
+
+    Logger *logger = CreateLogger();
+    if (!logger) return; /* leave g_activeLogger as it was rather than dropping logging entirely */
+
+    LoggerSetMinLevel(logger, minLevel);
+
+    if (debugStringEnabled) {
+        LoggerAddSink(logger, CreateDebugStringSink());
+    }
 
     const char *effectiveFileName = fileNameOrNull;
     if ((!effectiveFileName || effectiveFileName[0] == '\0') && g_cmdLineForceFile) {
-        effectiveFileName = DEFAULT_LOG_FILENAME; /* one-launch override, config left it off */
+        effectiveFileName = DEFAULT_LOG_FILENAME; /* one-launch override, config left the file sink off */
     }
 
     if (g_pathsInitialized && effectiveFileName && effectiveFileName[0] != '\0' &&
         strlen(g_moduleDirectory) + strlen(effectiveFileName) < MAX_PATH) {
-        strcpy(g_logFilePath, g_moduleDirectory);
-        strcat(g_logFilePath, effectiveFileName);
-        g_fileLoggingEnabled = TRUE;
-    } else {
-        g_fileLoggingEnabled = FALSE;
+        char fullPath[MAX_PATH];
+        strcpy(fullPath, g_moduleDirectory);
+        strcat(fullPath, effectiveFileName);
+        LoggerAddSink(logger, CreateFileSink(fullPath));
+    }
+
+    g_activeLogger = logger;
+    if (oldLogger) {
+        LoggerDestroy(oldLogger);
     }
 }
 
@@ -104,71 +156,24 @@ LogLevel ProxyLogLevelFromString(const char *s)
     return LOG_INFO; /* unrecognized -> sensible default, not silently "off" */
 }
 
-static const char *LevelTag(LogLevel level)
-{
-    switch (level) {
-        case LOG_TRACE: return "TRACE";
-        case LOG_DEBUG: return "DEBUG";
-        case LOG_INFO:  return "INFO";
-        case LOG_WARN:  return "WARN";
-        case LOG_ERROR: return "ERROR";
-        default:        return "?";
-    }
-}
-
-static void ProxyLogAtV(LogLevel level, const char *fmt, va_list ap)
-{
-    if (level < g_minLevel) return;
-    if (!g_debugStringEnabled && !g_fileLoggingEnabled) return;
-
-    char msg[1024];
-    int n = _snprintf(msg, sizeof(msg) - 2, "[xact_guards] [%s] [tid=%lu] ",
-                       LevelTag(level), (unsigned long)GetCurrentThreadId());
-    if (n < 0) n = 0;
-    if ((size_t)n >= sizeof(msg) - 2) n = (int)sizeof(msg) - 2;
-
-    int n2 = _vsnprintf(msg + n, sizeof(msg) - (size_t)n - 2, fmt, ap);
-    if (n2 < 0) n2 = 0;
-
-    size_t total = (size_t)n + (size_t)n2;
-    if (total > sizeof(msg) - 2) total = sizeof(msg) - 2;
-    msg[total] = '\n';
-    msg[total + 1] = '\0';
-
-    if (g_debugStringEnabled) {
-        OutputDebugStringA(msg);
-    }
-
-    if (g_fileLoggingEnabled) {
-        FILE *f = fopen(g_logFilePath, "a");
-        if (f) {
-            SYSTEMTIME st;
-            GetLocalTime(&st);
-            fprintf(f, "[%04d-%02d-%02d %02d:%02d:%02d.%03d] %s",
-                    st.wYear, st.wMonth, st.wDay, st.wHour, st.wMinute, st.wSecond, st.wMilliseconds, msg);
-            fclose(f);
-        }
-    }
-}
-
 void ProxyLogAt(LogLevel level, const char *fmt, ...)
 {
     va_list ap;
     va_start(ap, fmt);
-    ProxyLogAtV(level, fmt, ap);
+    LoggerLogV(GetActiveLogger(), level, fmt, ap);
     va_end(ap);
 }
 
-void LogTrace(const char *fmt, ...) { va_list ap; va_start(ap, fmt); ProxyLogAtV(LOG_TRACE, fmt, ap); va_end(ap); }
-void LogDebug(const char *fmt, ...) { va_list ap; va_start(ap, fmt); ProxyLogAtV(LOG_DEBUG, fmt, ap); va_end(ap); }
-void LogInfo (const char *fmt, ...) { va_list ap; va_start(ap, fmt); ProxyLogAtV(LOG_INFO,  fmt, ap); va_end(ap); }
-void LogWarn (const char *fmt, ...) { va_list ap; va_start(ap, fmt); ProxyLogAtV(LOG_WARN,  fmt, ap); va_end(ap); }
-void LogError(const char *fmt, ...) { va_list ap; va_start(ap, fmt); ProxyLogAtV(LOG_ERROR, fmt, ap); va_end(ap); }
+void LogTrace(const char *fmt, ...) { va_list ap; va_start(ap, fmt); LoggerLogV(GetActiveLogger(), LOG_TRACE, fmt, ap); va_end(ap); }
+void LogDebug(const char *fmt, ...) { va_list ap; va_start(ap, fmt); LoggerLogV(GetActiveLogger(), LOG_DEBUG, fmt, ap); va_end(ap); }
+void LogInfo (const char *fmt, ...) { va_list ap; va_start(ap, fmt); LoggerLogV(GetActiveLogger(), LOG_INFO,  fmt, ap); va_end(ap); }
+void LogWarn (const char *fmt, ...) { va_list ap; va_start(ap, fmt); LoggerLogV(GetActiveLogger(), LOG_WARN,  fmt, ap); va_end(ap); }
+void LogError(const char *fmt, ...) { va_list ap; va_start(ap, fmt); LoggerLogV(GetActiveLogger(), LOG_ERROR, fmt, ap); va_end(ap); }
 
 void ProxyLog(const char *fmt, ...)
 {
     va_list ap;
     va_start(ap, fmt);
-    ProxyLogAtV(LOG_INFO, fmt, ap);
+    LoggerLogV(GetActiveLogger(), LOG_INFO, fmt, ap);
     va_end(ap);
 }

--- a/contrib/xact-crash-fix/src/proxylog.c
+++ b/contrib/xact-crash-fix/src/proxylog.c
@@ -1,0 +1,108 @@
+/*
+ * proxylog.c - diagnostic output for the xactengine2_9.dll crash-containment
+ * guards. Always goes to OutputDebugStringA (any attached debugger - FADeepProbe,
+ * WinDbg, DebugView - picks these up natively as OUTPUT_DEBUG_STRING events).
+ * ADDITIONALLY writes to a log file if "/logxactguards" appears anywhere on
+ * this process's own command line (same convention the game itself uses for
+ * its own flags - /init, /log, /nobugreport, etc.) - lets you opt into a
+ * persistent, after-the-fact-reviewable log per launch without editing any
+ * config file or needing DebugView running.
+ *
+ * ProxyGetDir() is kept for flags.c, which needs to find xact_proxy_flags.ini
+ * next to wherever this code is actually loaded from - portable across
+ * machines, not a hardcoded path.
+ */
+#include <windows.h>
+#include <stdio.h>
+#include <stdarg.h>
+#include <string.h>
+#include "proxylog.h"
+
+#define LOG_FLAG L"/logxactguards"
+
+static char g_dir[MAX_PATH] = "";      /* directory this module loaded from, trailing backslash */
+static char g_logPath[MAX_PATH] = "";
+static BOOL g_ready = FALSE;
+static BOOL g_fileLoggingEnabled = FALSE;
+
+/* Manual case-insensitive wide substring search - avoids pulling in
+ * shlwapi.dll just for StrStrIW. */
+static BOOL ContainsFlagCI(const wchar_t *haystack, const wchar_t *needle)
+{
+    size_t needleLen = wcslen(needle);
+    for (const wchar_t *p = haystack; *p; p++) {
+        if (_wcsnicmp(p, needle, needleLen) == 0) {
+            return TRUE;
+        }
+    }
+    return FALSE;
+}
+
+void ProxyLogInit(HMODULE selfModule)
+{
+    char dllPath[MAX_PATH];
+    if (GetModuleFileNameA(selfModule, dllPath, MAX_PATH) == 0) {
+        return; /* g_ready stays FALSE - ProxyGetDir becomes a no-op rather than guessing a path */
+    }
+
+    char *lastSlash = strrchr(dllPath, '\\');
+    if (!lastSlash) {
+        return;
+    }
+
+    size_t dirLen = (size_t)(lastSlash - dllPath) + 1; /* include the slash */
+    if (dirLen >= MAX_PATH) {
+        return;
+    }
+    memcpy(g_dir, dllPath, dirLen);
+    g_dir[dirLen] = '\0';
+
+    g_ready = TRUE;
+
+    g_fileLoggingEnabled = ContainsFlagCI(GetCommandLineW(), LOG_FLAG);
+    if (g_fileLoggingEnabled) {
+        if (dirLen + strlen("xact_proxy_runtime.log") < MAX_PATH) {
+            strcpy(g_logPath, g_dir);
+            strcat(g_logPath, "xact_proxy_runtime.log");
+        } else {
+            g_fileLoggingEnabled = FALSE; /* path too long, fall back to debug-string only */
+        }
+    }
+}
+
+const char *ProxyGetDir(void)
+{
+    return g_ready ? g_dir : "";
+}
+
+void ProxyLog(const char *fmt, ...)
+{
+    char msg[1024];
+    int n = _snprintf(msg, sizeof(msg) - 2, "[xact_guards] [tid=%lu] ", (unsigned long)GetCurrentThreadId());
+    if (n < 0) n = 0;
+    if ((size_t)n >= sizeof(msg) - 2) n = (int)sizeof(msg) - 2;
+
+    va_list ap;
+    va_start(ap, fmt);
+    int n2 = _vsnprintf(msg + n, sizeof(msg) - (size_t)n - 2, fmt, ap);
+    va_end(ap);
+    if (n2 < 0) n2 = 0;
+
+    size_t total = (size_t)n + (size_t)n2;
+    if (total > sizeof(msg) - 2) total = sizeof(msg) - 2;
+    msg[total] = '\n';
+    msg[total + 1] = '\0';
+
+    OutputDebugStringA(msg);
+
+    if (g_fileLoggingEnabled) {
+        FILE *f = fopen(g_logPath, "a");
+        if (f) {
+            SYSTEMTIME st;
+            GetLocalTime(&st);
+            fprintf(f, "[%04d-%02d-%02d %02d:%02d:%02d.%03d] %s",
+                    st.wYear, st.wMonth, st.wDay, st.wHour, st.wMinute, st.wSecond, st.wMilliseconds, msg);
+            fclose(f);
+        }
+    }
+}

--- a/contrib/xact-crash-fix/src/proxylog.c
+++ b/contrib/xact-crash-fix/src/proxylog.c
@@ -1,16 +1,16 @@
 /*
- * proxylog.c - diagnostic output for the xactengine2_9.dll crash-containment
- * guards. Always goes to OutputDebugStringA (any attached debugger - FADeepProbe,
- * WinDbg, DebugView - picks these up natively as OUTPUT_DEBUG_STRING events).
- * ADDITIONALLY writes to a log file if "/logxactguards" appears anywhere on
- * this process's own command line (same convention the game itself uses for
- * its own flags - /init, /log, /nobugreport, etc.) - lets you opt into a
- * persistent, after-the-fact-reviewable log per launch without editing any
- * config file or needing DebugView running.
+ * proxylog.c - leveled diagnostic logging for the xactengine2_9.dll
+ * crash-containment guards, with two independently-configurable sinks:
+ * OutputDebugStringA (picked up natively by any attached debugger -
+ * FADeepProbe, WinDbg, DebugView) and an optional file next to wherever
+ * this DLL is actually loaded from. Both the minimum level and which
+ * sinks are active are set via ProxyLogConfigure(), driven by
+ * xact_proxy_flags.ini (see flags.c) - so logging behavior is entirely
+ * config-driven, no rebuild needed to change it.
  *
- * ProxyGetDir() is kept for flags.c, which needs to find xact_proxy_flags.ini
- * next to wherever this code is actually loaded from - portable across
- * machines, not a hardcoded path.
+ * ProxyGetDir() is also used by flags.c, which needs to find
+ * xact_proxy_flags.ini next to wherever this code is actually loaded
+ * from - portable across machines, not a hardcoded path.
  */
 #include <windows.h>
 #include <stdio.h>
@@ -19,19 +19,25 @@
 #include "proxylog.h"
 
 #define LOG_FLAG L"/logxactguards"
+#define DEFAULT_LOG_FILENAME "xact_proxy_runtime.log"
 
-static char g_dir[MAX_PATH] = "";      /* directory this module loaded from, trailing backslash */
-static char g_logPath[MAX_PATH] = "";
-static BOOL g_ready = FALSE;
+static char g_moduleDirectory[MAX_PATH] = "";  /* directory this module loaded from, trailing backslash */
+static char g_logFilePath[MAX_PATH] = "";
+static BOOL g_pathsInitialized = FALSE;
+static BOOL g_cmdLineForceFile = FALSE;
+
+static LogLevel g_minLevel = LOG_INFO;
+static BOOL g_debugStringEnabled = TRUE;
 static BOOL g_fileLoggingEnabled = FALSE;
 
-/* Manual case-insensitive wide substring search - avoids pulling in
- * shlwapi.dll just for StrStrIW. */
-static BOOL ContainsFlagCI(const wchar_t *haystack, const wchar_t *needle)
+/* Checks THIS PROCESS's own command line (not an arbitrary string - always
+ * GetCommandLineW()) for a flag, case-insensitively. Manual search to avoid
+ * pulling in shlwapi.dll just for StrStrIW. */
+static BOOL CommandLineHasFlag(const wchar_t *flag)
 {
-    size_t needleLen = wcslen(needle);
-    for (const wchar_t *p = haystack; *p; p++) {
-        if (_wcsnicmp(p, needle, needleLen) == 0) {
+    size_t flagLen = wcslen(flag);
+    for (const wchar_t *p = GetCommandLineW(); *p; p++) {
+        if (_wcsnicmp(p, flag, flagLen) == 0) {
             return TRUE;
         }
     }
@@ -42,7 +48,7 @@ void ProxyLogInit(HMODULE selfModule)
 {
     char dllPath[MAX_PATH];
     if (GetModuleFileNameA(selfModule, dllPath, MAX_PATH) == 0) {
-        return; /* g_ready stays FALSE - ProxyGetDir becomes a no-op rather than guessing a path */
+        return; /* g_pathsInitialized stays FALSE - ProxyGetDir becomes a no-op rather than guessing a path */
     }
 
     char *lastSlash = strrchr(dllPath, '\\');
@@ -54,38 +60,74 @@ void ProxyLogInit(HMODULE selfModule)
     if (dirLen >= MAX_PATH) {
         return;
     }
-    memcpy(g_dir, dllPath, dirLen);
-    g_dir[dirLen] = '\0';
+    memcpy(g_moduleDirectory, dllPath, dirLen);
+    g_moduleDirectory[dirLen] = '\0';
 
-    g_ready = TRUE;
-
-    g_fileLoggingEnabled = ContainsFlagCI(GetCommandLineW(), LOG_FLAG);
-    if (g_fileLoggingEnabled) {
-        if (dirLen + strlen("xact_proxy_runtime.log") < MAX_PATH) {
-            strcpy(g_logPath, g_dir);
-            strcat(g_logPath, "xact_proxy_runtime.log");
-        } else {
-            g_fileLoggingEnabled = FALSE; /* path too long, fall back to debug-string only */
-        }
-    }
+    g_pathsInitialized = TRUE;
+    g_cmdLineForceFile = CommandLineHasFlag(LOG_FLAG);
 }
 
 const char *ProxyGetDir(void)
 {
-    return g_ready ? g_dir : "";
+    return g_pathsInitialized ? g_moduleDirectory : "";
 }
 
-void ProxyLog(const char *fmt, ...)
+void ProxyLogConfigure(LogLevel minLevel, BOOL debugStringEnabled, const char *fileNameOrNull)
 {
+    g_minLevel = minLevel;
+    g_debugStringEnabled = debugStringEnabled;
+
+    const char *effectiveFileName = fileNameOrNull;
+    if ((!effectiveFileName || effectiveFileName[0] == '\0') && g_cmdLineForceFile) {
+        effectiveFileName = DEFAULT_LOG_FILENAME; /* one-launch override, config left it off */
+    }
+
+    if (g_pathsInitialized && effectiveFileName && effectiveFileName[0] != '\0' &&
+        strlen(g_moduleDirectory) + strlen(effectiveFileName) < MAX_PATH) {
+        strcpy(g_logFilePath, g_moduleDirectory);
+        strcat(g_logFilePath, effectiveFileName);
+        g_fileLoggingEnabled = TRUE;
+    } else {
+        g_fileLoggingEnabled = FALSE;
+    }
+}
+
+LogLevel ProxyLogLevelFromString(const char *s)
+{
+    if (!s) return LOG_INFO;
+    if (_stricmp(s, "trace") == 0)                              return LOG_TRACE;
+    if (_stricmp(s, "debug") == 0)                              return LOG_DEBUG;
+    if (_stricmp(s, "info") == 0)                               return LOG_INFO;
+    if (_stricmp(s, "warn") == 0 || _stricmp(s, "warning") == 0) return LOG_WARN;
+    if (_stricmp(s, "error") == 0)                              return LOG_ERROR;
+    if (_stricmp(s, "none") == 0 || _stricmp(s, "off") == 0)    return LOG_NONE;
+    return LOG_INFO; /* unrecognized -> sensible default, not silently "off" */
+}
+
+static const char *LevelTag(LogLevel level)
+{
+    switch (level) {
+        case LOG_TRACE: return "TRACE";
+        case LOG_DEBUG: return "DEBUG";
+        case LOG_INFO:  return "INFO";
+        case LOG_WARN:  return "WARN";
+        case LOG_ERROR: return "ERROR";
+        default:        return "?";
+    }
+}
+
+static void ProxyLogAtV(LogLevel level, const char *fmt, va_list ap)
+{
+    if (level < g_minLevel) return;
+    if (!g_debugStringEnabled && !g_fileLoggingEnabled) return;
+
     char msg[1024];
-    int n = _snprintf(msg, sizeof(msg) - 2, "[xact_guards] [tid=%lu] ", (unsigned long)GetCurrentThreadId());
+    int n = _snprintf(msg, sizeof(msg) - 2, "[xact_guards] [%s] [tid=%lu] ",
+                       LevelTag(level), (unsigned long)GetCurrentThreadId());
     if (n < 0) n = 0;
     if ((size_t)n >= sizeof(msg) - 2) n = (int)sizeof(msg) - 2;
 
-    va_list ap;
-    va_start(ap, fmt);
     int n2 = _vsnprintf(msg + n, sizeof(msg) - (size_t)n - 2, fmt, ap);
-    va_end(ap);
     if (n2 < 0) n2 = 0;
 
     size_t total = (size_t)n + (size_t)n2;
@@ -93,10 +135,12 @@ void ProxyLog(const char *fmt, ...)
     msg[total] = '\n';
     msg[total + 1] = '\0';
 
-    OutputDebugStringA(msg);
+    if (g_debugStringEnabled) {
+        OutputDebugStringA(msg);
+    }
 
     if (g_fileLoggingEnabled) {
-        FILE *f = fopen(g_logPath, "a");
+        FILE *f = fopen(g_logFilePath, "a");
         if (f) {
             SYSTEMTIME st;
             GetLocalTime(&st);
@@ -105,4 +149,26 @@ void ProxyLog(const char *fmt, ...)
             fclose(f);
         }
     }
+}
+
+void ProxyLogAt(LogLevel level, const char *fmt, ...)
+{
+    va_list ap;
+    va_start(ap, fmt);
+    ProxyLogAtV(level, fmt, ap);
+    va_end(ap);
+}
+
+void LogTrace(const char *fmt, ...) { va_list ap; va_start(ap, fmt); ProxyLogAtV(LOG_TRACE, fmt, ap); va_end(ap); }
+void LogDebug(const char *fmt, ...) { va_list ap; va_start(ap, fmt); ProxyLogAtV(LOG_DEBUG, fmt, ap); va_end(ap); }
+void LogInfo (const char *fmt, ...) { va_list ap; va_start(ap, fmt); ProxyLogAtV(LOG_INFO,  fmt, ap); va_end(ap); }
+void LogWarn (const char *fmt, ...) { va_list ap; va_start(ap, fmt); ProxyLogAtV(LOG_WARN,  fmt, ap); va_end(ap); }
+void LogError(const char *fmt, ...) { va_list ap; va_start(ap, fmt); ProxyLogAtV(LOG_ERROR, fmt, ap); va_end(ap); }
+
+void ProxyLog(const char *fmt, ...)
+{
+    va_list ap;
+    va_start(ap, fmt);
+    ProxyLogAtV(LOG_INFO, fmt, ap);
+    va_end(ap);
 }

--- a/contrib/xact-crash-fix/src/proxylog.h
+++ b/contrib/xact-crash-fix/src/proxylog.h
@@ -1,0 +1,19 @@
+#ifndef PROXYLOG_H
+#define PROXYLOG_H
+#include <windows.h>
+
+/* Call once from DllMain, before any other thread might use ProxyLog or
+ * ProxyGetDir - not thread-safe by itself, relies on DllMain's own
+ * loader-lock-serialized guarantee of running exactly once, first. */
+void ProxyLogInit(HMODULE selfModule);
+
+/* Directory this DLL itself was loaded from (trailing backslash included),
+ * e.g. "C:\ProgramData\FAForever\bin\" - portable across machines, unlike
+ * a hardcoded path. Other modules (flags.c) build their own filenames off
+ * this instead of hardcoding a path too. Returns "" if ProxyLogInit
+ * hasn't run yet or failed. */
+const char *ProxyGetDir(void);
+
+void ProxyLog(const char *fmt, ...);
+
+#endif

--- a/contrib/xact-crash-fix/src/proxylog.h
+++ b/contrib/xact-crash-fix/src/proxylog.h
@@ -2,8 +2,20 @@
 #define PROXYLOG_H
 #include <windows.h>
 
-/* Call once from DllMain, before any other thread might use ProxyLog or
- * ProxyGetDir - not thread-safe by itself, relies on DllMain's own
+/* Matches the FAF project's own logging convention (TRACE < DEBUG < INFO <
+ * WARN < ERROR). LOG_NONE is a sentinel for "suppress everything", usable
+ * as a configured minimum level, not as a level to log AT. */
+typedef enum {
+    LOG_TRACE = 0,
+    LOG_DEBUG = 1,
+    LOG_INFO  = 2,
+    LOG_WARN  = 3,
+    LOG_ERROR = 4,
+    LOG_NONE  = 5
+} LogLevel;
+
+/* Call once from DllMain, before any other thread might use any of the
+ * functions below - not thread-safe by itself, relies on DllMain's own
  * loader-lock-serialized guarantee of running exactly once, first. */
 void ProxyLogInit(HMODULE selfModule);
 
@@ -14,6 +26,36 @@ void ProxyLogInit(HMODULE selfModule);
  * hasn't run yet or failed. */
 const char *ProxyGetDir(void);
 
+/* Sets the minimum level that gets emitted, whether OutputDebugStringA is
+ * used, and whether/where a file sink writes - call after parsing config
+ * (flags.c). Before this runs, sensible defaults apply on their own
+ * (INFO, debug-string on, file off), so early log calls (including
+ * LoadXactFlags' own "config loaded from..." message) still behave
+ * reasonably.
+ *
+ * fileNameOrNull is a bare filename (e.g. "xact_proxy_runtime.log"),
+ * resolved relative to ProxyGetDir() internally - never a full path, so
+ * the portability guarantee above holds regardless of what's configured.
+ * NULL or "" disables the file sink - UNLESS "/logxactguards" is present
+ * on this process's own command line, which forces the file sink on with
+ * a default filename regardless of config, as a quick one-launch override
+ * for whoever can't easily edit the config file first. */
+void ProxyLogConfigure(LogLevel minLevel, BOOL debugStringEnabled, const char *fileNameOrNull);
+
+/* Case-insensitive "trace"/"debug"/"info"/"warn"/"warning"/"error"/"none"/"off";
+ * anything else (including NULL) returns LOG_INFO. */
+LogLevel ProxyLogLevelFromString(const char *s);
+
+void ProxyLogAt(LogLevel level, const char *fmt, ...);
+void LogTrace(const char *fmt, ...);
+void LogDebug(const char *fmt, ...);
+void LogInfo(const char *fmt, ...);
+void LogWarn(const char *fmt, ...);
+void LogError(const char *fmt, ...);
+
+/* Back-compat shim (logs at LOG_INFO) for call sites not yet migrated to
+ * the leveled API above (xact_guards.c, dllmain.c, guards_dllmain.c, as
+ * of this writing - migrate them and retire this). */
 void ProxyLog(const char *fmt, ...);
 
 #endif

--- a/contrib/xact-crash-fix/src/test_harness.c
+++ b/contrib/xact-crash-fix/src/test_harness.c
@@ -1,0 +1,105 @@
+/*
+ * test_harness.c - standalone validation, run entirely from build/, never
+ * touches the live FAF directory. Tests EITHER injection vector - pass
+ * "bugsplat" (default) to test bugsplat_proxy.dll (the BugSplat.dll
+ * forwarder trick) or "guards" to test xact_guards.dll directly (the
+ * standalone path, usable by any other loader e.g. a debugger).
+ *
+ * Since diagnostic output now goes through OutputDebugStringA instead of
+ * a log file, this harness implements the standard "DBWIN" debug-string
+ * capture protocol (the same one Sysinternals DebugView uses) so we can
+ * actually see and verify the output without needing DebugView installed.
+ *
+ * "Pass" = both LoadLibrary calls succeed, and the captured debug output
+ * shows MH_OK (0) for both MH_CreateHook/MH_EnableHook at all three
+ * offsets. This does NOT exercise the actual crash-recovery (setjmp/
+ * longjmp) path - that needs the real XACT object's vtables active via a
+ * real game session.
+ */
+#include <windows.h>
+#include <stdio.h>
+#include <string.h>
+#include <process.h>
+
+static HANDLE g_bufferReady, g_dataReady, g_mapping;
+static void *g_view;
+static volatile BOOL g_capturing = TRUE;
+
+static unsigned __stdcall DbgStringCaptureThread(void *param)
+{
+    (void)param;
+    while (g_capturing) {
+        DWORD wait = WaitForSingleObject(g_dataReady, 200);
+        if (wait == WAIT_OBJECT_0) {
+            DWORD pid = *(DWORD *)g_view;
+            const char *text = (const char *)g_view + sizeof(DWORD);
+            printf("[dbgstr pid=%lu] %s", (unsigned long)pid, text);
+            SetEvent(g_bufferReady);
+        }
+    }
+    return 0;
+}
+
+static HANDLE StartDbgStringCapture(void)
+{
+    g_bufferReady = CreateEventA(NULL, FALSE, TRUE, "DBWIN_BUFFER_READY");
+    g_dataReady   = CreateEventA(NULL, FALSE, FALSE, "DBWIN_DATA_READY");
+    g_mapping     = CreateFileMappingA(INVALID_HANDLE_VALUE, NULL, PAGE_READWRITE, 0, 4096, "DBWIN_BUFFER");
+    g_view        = MapViewOfFile(g_mapping, FILE_MAP_READ, 0, 0, 512);
+
+    if (!g_bufferReady || !g_dataReady || !g_mapping || !g_view) {
+        printf("[harness] WARNING: couldn't set up debug-string capture (GetLastError=%lu) - "
+               "hooks may still work, you just won't see their log output here\n",
+               (unsigned long)GetLastError());
+        return NULL;
+    }
+
+    uintptr_t h = _beginthreadex(NULL, 0, DbgStringCaptureThread, NULL, 0, NULL);
+    return (HANDLE)h;
+}
+
+int main(int argc, char **argv)
+{
+    const char *which = (argc > 1) ? argv[1] : "bugsplat";
+    const wchar_t *dllName = (strcmp(which, "guards") == 0) ? L"xact_guards.dll" : L"bugsplat_proxy.dll";
+
+    printf("[harness] testing: %ls\n", dllName);
+    printf("[harness] starting debug-string capture (so we can see OutputDebugStringA output)...\n");
+    HANDLE captureThread = StartDbgStringCapture();
+
+    printf("[harness] loading %ls...\n", dllName);
+    HMODULE proxy = LoadLibraryW(dllName);
+    if (!proxy) {
+        printf("[harness] FAIL: LoadLibraryW(%ls) failed, GetLastError=%lu\n",
+               dllName, (unsigned long)GetLastError());
+        if (wcscmp(dllName, L"bugsplat_proxy.dll") == 0) {
+            printf("[harness] (most likely cause: one of the 19 export forwarders in "
+                   "bugsplat_proxy.def didn't resolve - check BugSplat_real.dll is present "
+                   "in this directory)\n");
+        }
+        return 1;
+    }
+    printf("[harness] OK: %ls loaded, handle=%p\n", dllName, proxy);
+
+    printf("[harness] loading the REAL system xactengine2_9.dll directly (simulates COM activation)...\n");
+    HMODULE xact = LoadLibraryW(L"C:\\Windows\\SysWOW64\\xactengine2_9.dll");
+    if (!xact) {
+        printf("[harness] FAIL: LoadLibraryW(real xactengine2_9.dll) failed, GetLastError=%lu\n",
+               (unsigned long)GetLastError());
+        return 1;
+    }
+    printf("[harness] OK: real xactengine2_9.dll loaded at %p\n", xact);
+
+    printf("[harness] waiting 3s for the watcher thread to detect it and install guards...\n");
+    Sleep(3000);
+
+    printf("[harness] done - check the [dbgstr] lines above for \"MH_EnableHook\" -> 0 (0 = MH_OK) "
+           "at all three offsets (+0x1D751, +0x1D212, +0x1DE46).\n");
+
+    g_capturing = FALSE;
+    if (captureThread) { WaitForSingleObject(captureThread, 1000); CloseHandle(captureThread); }
+
+    FreeLibrary(xact);
+    FreeLibrary(proxy);
+    return 0;
+}

--- a/contrib/xact-crash-fix/src/xact_guards.c
+++ b/contrib/xact-crash-fix/src/xact_guards.c
@@ -1,0 +1,314 @@
+/*
+ * xact_guards.c
+ *
+ * Crash containment for three known access-violation sites inside the real
+ * xactengine2_9.dll (Microsoft's ~2007 XACT audio middleware, statically
+ * analyzed via Ghidra - see the plan doc's §2.7/§2.7a/§2.7b/§2.7c for the
+ * full writeup). All three trace back to the same underlying subsystem
+ * (wave-bank reload/free, `FUN_0041d60e`), reached via the object field
+ * this+0x5c or a related linked-list of the same objects:
+ *
+ *   +0x1D212 (FUN_0041d212): a pointer-chain hop (this->0x5c->0x2c) can be
+ *     NULL and gets dereferenced with no check - "Read from 0x00000010"
+ *     class of crash. Root cause (§2.7b): FUN_0041d60e frees+nulls
+ *     this->0x5c under its own InterlockedCompareExchange lock, but this
+ *     reader never checks/acquires that lock - classic missing-lock race.
+ *
+ *   +0x1D751 (FUN_0041d751): a teardown routine null-checks this->0x5c
+ *     before a vtable call, but the *pointee* can already be freed
+ *     (dangling, not NULL) - reads Windows' freed-heap fill pattern
+ *     0xFEEEFEEE. Same missing-lock race as above, different fault flavor.
+ *
+ *   +0x1DE46 (linked-list walk, §2.7c): walks a sentinel-terminated linked
+ *     list, calling FUN_0041d60e on every node - i.e. a self-modifying
+ *     traversal that never protects itself against FUN_0041d60e freeing
+ *     list entries out from under the walk. Related subsystem, different
+ *     bug shape (iterator invalidation, not the reader/writer race).
+ *
+ * GCC/MinGW does not implement MSVC's __try/__except language extension,
+ * so containment here uses the standard setjmp/longjmp-from-a-Vectored-
+ * Exception-Handler pattern instead: each detour sets a per-thread
+ * recovery point before calling the real (trampolined) function; if that
+ * call faults, the VEH below recognizes we're inside a guarded call on
+ * this thread and longjmp()s back, turning the fault into "that one call
+ * didn't happen" instead of a process crash. A small per-thread stack of
+ * recovery points (not just one) handles the fact that +0x1D751's own
+ * body internally calls +0x1D212 - MinHook's inline hook redirects that
+ * internal call through our detour too, so guarded calls can nest.
+ *
+ * Strategy pattern: each site's runtime behavior (disabled / passthrough /
+ * contain, see flags.h) is read from an external config file once at
+ * install time, so different combinations can be tried across launches
+ * without rebuilding - see flags.c.
+ *
+ * This is a genuinely unusual pattern - deliberately over-commented so a
+ * future reader (including future us) doesn't need to reverse-engineer
+ * the reasoning again.
+ */
+#include <windows.h>
+#include <psapi.h>
+#include <process.h>
+#include <setjmp.h>
+#include "MinHook.h"
+#include "proxylog.h"
+#include "flags.h"
+#include "xact_guards.h"
+
+#define MAX_GUARD_DEPTH 8
+
+static __thread jmp_buf   g_recoveryStack[MAX_GUARD_DEPTH];
+static __thread const char *g_guardSiteStack[MAX_GUARD_DEPTH];
+static __thread int       g_guardDepth = 0;
+
+static void  *g_xactBase = NULL;
+static SIZE_T g_xactSize = 0;
+static PVOID  g_vehHandle = NULL;
+
+/* Shared "enter a guarded call" helper - every detour follows the exact
+ * same shape, this just centralizes the depth/stack bookkeeping so the
+ * three detours below only differ in the actual call + its argument list
+ * (which C's lack of generics/variadic-safe function pointers means can't
+ * be fully collapsed into one function). Returns 1 if the caller should
+ * take the "call original directly, no protection" path (either because
+ * of PASSTHROUGH strategy or the depth safety valve), 0 if it already
+ * handled everything (CONTAIN path, including logging on recovery). */
+
+/* ---- +0x1D751 hook (use-after-free / dangling-pointer teardown site) ---- */
+
+typedef void (__thiscall *Fn_0041d751)(void *this_);
+static Fn_0041d751 fpOrig_0041d751 = NULL;
+
+static void __thiscall Detour_0041d751(void *this_)
+{
+    if (g_flags.hook1D751 == STRAT_PASSTHROUGH) {
+        fpOrig_0041d751(this_);
+        return;
+    }
+
+    if (g_guardDepth >= MAX_GUARD_DEPTH) {
+        ProxyLog("hook-1d751: guard stack full (depth=%d), calling through UNGUARDED, this=%p",
+                 g_guardDepth, this_);
+        fpOrig_0041d751(this_);
+        return;
+    }
+
+    int depth = g_guardDepth++;
+    g_guardSiteStack[depth] = "1d751(UAF-teardown)";
+
+    if (setjmp(g_recoveryStack[depth]) == 0) {
+        fpOrig_0041d751(this_);
+    } else {
+        ProxyLog("hook-1d751: CONTAINED an access violation inside the teardown/UAF site "
+                 "(this=%p, depth=%d) - one wave-bank cleanup call was skipped, game should continue",
+                 this_, depth);
+    }
+
+    g_guardDepth--;
+}
+
+/* ---- +0x1D212 hook (null pointer-chain hop, dominant repeat crash) ---- */
+
+typedef void (__thiscall *Fn_0041d212)(void *this_, unsigned char param1);
+static Fn_0041d212 fpOrig_0041d212 = NULL;
+
+static void __thiscall Detour_0041d212(void *this_, unsigned char param1)
+{
+    if (g_flags.hook1D212 == STRAT_PASSTHROUGH) {
+        fpOrig_0041d212(this_, param1);
+        return;
+    }
+
+    if (g_guardDepth >= MAX_GUARD_DEPTH) {
+        ProxyLog("hook-1d212: guard stack full (depth=%d), calling through UNGUARDED, this=%p param1=%u",
+                 g_guardDepth, this_, (unsigned)param1);
+        fpOrig_0041d212(this_, param1);
+        return;
+    }
+
+    int depth = g_guardDepth++;
+    g_guardSiteStack[depth] = "1d212(null-hop)";
+
+    if (setjmp(g_recoveryStack[depth]) == 0) {
+        fpOrig_0041d212(this_, param1);
+    } else {
+        ProxyLog("hook-1d212: CONTAINED an access violation on the null-pointer-chain site "
+                 "(this=%p, param1=%u, depth=%d) - that sound/cue lookup was skipped, game should continue",
+                 this_, (unsigned)param1, depth);
+    }
+
+    g_guardDepth--;
+}
+
+/* ---- +0x1DE46 hook (linked-list iterator invalidation, §2.7c) ---- */
+
+typedef void (__thiscall *Fn_0041de46)(void *this_);
+static Fn_0041de46 fpOrig_0041de46 = NULL;
+
+static void __thiscall Detour_0041de46(void *this_)
+{
+    if (g_flags.hook1DE46 == STRAT_PASSTHROUGH) {
+        fpOrig_0041de46(this_);
+        return;
+    }
+
+    if (g_guardDepth >= MAX_GUARD_DEPTH) {
+        ProxyLog("hook-1de46: guard stack full (depth=%d), calling through UNGUARDED, this=%p",
+                 g_guardDepth, this_);
+        fpOrig_0041de46(this_);
+        return;
+    }
+
+    int depth = g_guardDepth++;
+    g_guardSiteStack[depth] = "1de46(list-walk)";
+
+    if (setjmp(g_recoveryStack[depth]) == 0) {
+        fpOrig_0041de46(this_);
+    } else {
+        /* A fault mid-walk means we abandon the rest of the list for this
+         * call - the nodes already processed before the fault keep
+         * whatever FUN_0041d60e already did to them; the ones not yet
+         * reached just don't get reloaded this pass. Same "skip the risky
+         * bit, keep playing" tradeoff as the other two sites. */
+        ProxyLog("hook-1de46: CONTAINED an access violation mid-list-walk "
+                 "(this=%p, depth=%d) - remainder of that wave-bank reload pass was skipped, game should continue",
+                 this_, depth);
+    }
+
+    g_guardDepth--;
+}
+
+/* ---- process-wide safety net ---- */
+
+static LONG WINAPI XactVeh(EXCEPTION_POINTERS *ep)
+{
+    if (ep->ExceptionRecord->ExceptionCode != EXCEPTION_ACCESS_VIOLATION) {
+        return EXCEPTION_CONTINUE_SEARCH;
+    }
+
+    void *faultAddr = (void *)(UINT_PTR)ep->ContextRecord->Eip;
+    BOOL inXactModule = g_xactBase &&
+        (BYTE *)faultAddr >= (BYTE *)g_xactBase &&
+        (BYTE *)faultAddr <  (BYTE *)g_xactBase + g_xactSize;
+
+    if (g_guardDepth > 0) {
+        /* We're inside one of our own guarded calls on THIS thread (TLS -
+         * naturally scoped per-thread, so a fault on a different thread
+         * can never mistakenly recover here even if that thread also has
+         * a guard active). Recover at the innermost active guard. */
+        int depth = g_guardDepth - 1;
+        ProxyLog("VEH: access violation at %p during guarded call [%s] (depth=%d) - recovering via longjmp",
+                 faultAddr, g_guardSiteStack[depth], depth);
+        longjmp(g_recoveryStack[depth], 1); /* does not return */
+    }
+
+    if (inXactModule) {
+        /* A fault inside xactengine2_9.dll that ISN'T inside one of our
+         * guarded calls (either a genuinely new/unknown site, or a
+         * PASSTHROUGH-strategy site deliberately not catching). We
+         * deliberately do NOT attempt recovery here - we don't understand
+         * every possible fault well enough to know what a safe
+         * continuation looks like, and a wrong guess could corrupt state
+         * worse than just crashing. Log full context so this becomes a
+         * new candidate for a targeted hook, then let it crash normally
+         * (so WER/the game's own crash handler still produces a report). */
+        ProxyLog("VEH: UNGUARDED access violation inside xactengine2_9.dll at %p "
+                 "(module base=%p size=%lu) - Eax=%08lx Ecx=%08lx Edx=%08lx Ebx=%08lx "
+                 "Esp=%08lx Ebp=%08lx Esi=%08lx Edi=%08lx - NOT contained, letting it crash "
+                 "so this becomes a new hook candidate",
+                 faultAddr, g_xactBase, (unsigned long)g_xactSize,
+                 ep->ContextRecord->Eax, ep->ContextRecord->Ecx, ep->ContextRecord->Edx, ep->ContextRecord->Ebx,
+                 ep->ContextRecord->Esp, ep->ContextRecord->Ebp, ep->ContextRecord->Esi, ep->ContextRecord->Edi);
+    }
+
+    return EXCEPTION_CONTINUE_SEARCH;
+}
+
+static void InstallOneHook(const char *name, void *target, void *detour, void **origOut, GuardStrategy strategy)
+{
+    if (strategy == STRAT_DISABLED) {
+        ProxyLog("InstallXactGuards: %s DISABLED by config, not installing hook (target=%p)", name, target);
+        return;
+    }
+
+    MH_STATUS st = MH_CreateHook(target, detour, origOut);
+    ProxyLog("InstallXactGuards: MH_CreateHook %s (target=%p, strategy=%s) -> %d",
+             name, target, strategy == STRAT_PASSTHROUGH ? "passthrough" : "contain", (int)st);
+    if (st == MH_OK) {
+        st = MH_EnableHook(target);
+        ProxyLog("InstallXactGuards: MH_EnableHook %s -> %d", name, (int)st);
+    }
+}
+
+void InstallXactGuards(HMODULE xactBase)
+{
+    LoadXactFlags();
+
+    MODULEINFO mi;
+    if (GetModuleInformation(GetCurrentProcess(), xactBase, &mi, sizeof(mi))) {
+        g_xactBase = mi.lpBaseOfDll;
+        g_xactSize = mi.SizeOfImage;
+    } else {
+        /* Fallback: base is what we were handed, size unknown -> treat as
+         * a single point rather than a range for the "inXactModule" check. */
+        g_xactBase = xactBase;
+        g_xactSize = 1;
+    }
+
+    ProxyLog("InstallXactGuards: xactengine2_9.dll base=%p size=%lu",
+             g_xactBase, (unsigned long)g_xactSize);
+
+    g_vehHandle = AddVectoredExceptionHandler(1 /* call first */, XactVeh);
+    if (!g_vehHandle) {
+        ProxyLog("InstallXactGuards: AddVectoredExceptionHandler FAILED (GetLastError=%lu)",
+                 (unsigned long)GetLastError());
+    }
+
+    MH_STATUS st = MH_Initialize();
+    if (st != MH_OK && st != MH_ERROR_ALREADY_INITIALIZED) {
+        ProxyLog("InstallXactGuards: MH_Initialize failed: %d", (int)st);
+        return;
+    }
+
+    InstallOneHook("+0x1D751", (BYTE *)g_xactBase + 0x1D751, (void *)Detour_0041d751,
+                   (void **)&fpOrig_0041d751, g_flags.hook1D751);
+    InstallOneHook("+0x1D212", (BYTE *)g_xactBase + 0x1D212, (void *)Detour_0041d212,
+                   (void **)&fpOrig_0041d212, g_flags.hook1D212);
+    InstallOneHook("+0x1DE46", (BYTE *)g_xactBase + 0x1DE46, (void *)Detour_0041de46,
+                   (void **)&fpOrig_0041de46, g_flags.hook1DE46);
+
+    ProxyLog("InstallXactGuards: setup complete");
+}
+
+/* ---- shared watcher-thread entry point, usable by any loader ---- */
+
+static unsigned __stdcall WatcherThread(void *param)
+{
+    (void)param;
+
+    ProxyLog("WatcherThread: started, polling for xactengine2_9.dll");
+
+    HMODULE xactBase = NULL;
+    for (int i = 0; i < 300; i++) { /* ~300 * 200ms = 60s max wait */
+        xactBase = GetModuleHandleW(L"xactengine2_9.dll");
+        if (xactBase) break;
+        Sleep(200);
+    }
+
+    if (xactBase) {
+        ProxyLog("WatcherThread: xactengine2_9.dll found at %p after polling, installing guards", xactBase);
+        InstallXactGuards(xactBase);
+    } else {
+        ProxyLog("WatcherThread: xactengine2_9.dll never appeared after 60s - guards NOT installed "
+                 "(game may not use XACT this session, or loaded it unusually slowly)");
+    }
+
+    return 0;
+}
+
+void StartXactGuardsWatcher(HMODULE selfModule)
+{
+    ProxyLogInit(selfModule); /* must run before any ProxyLog/ProxyGetDir call, anywhere */
+    ProxyLog("StartXactGuardsWatcher: spawning watcher thread");
+    uintptr_t h = _beginthreadex(NULL, 0, WatcherThread, NULL, 0, NULL);
+    if (h) CloseHandle((HANDLE)h);
+}

--- a/contrib/xact-crash-fix/src/xact_guards.c
+++ b/contrib/xact-crash-fix/src/xact_guards.c
@@ -56,113 +56,112 @@
 
 #define MAX_GUARD_DEPTH 8
 
-static __thread jmp_buf   g_recoveryStack[MAX_GUARD_DEPTH];
-static __thread const char *g_guardSiteStack[MAX_GUARD_DEPTH];
-static __thread int       g_guardDepth = 0;
+/* One entry per currently-active guarded call on this thread. Grouping the
+ * recovery point with its site name (instead of two parallel arrays) makes
+ * "these belong to the same stack frame" the type itself, not a convention
+ * you have to remember to keep in sync. */
+typedef struct {
+    jmp_buf recoveryPoint;
+    const char *siteName;
+} GuardFrame;
+
+static __thread GuardFrame g_guardFrames[MAX_GUARD_DEPTH];
+static __thread int        g_activeGuardCount = 0;
 
 static void  *g_xactBase = NULL;
 static SIZE_T g_xactSize = 0;
 static PVOID  g_vehHandle = NULL;
 
-/* Shared "enter a guarded call" helper - every detour follows the exact
- * same shape, this just centralizes the depth/stack bookkeeping so the
- * three detours below only differ in the actual call + its argument list
- * (which C's lack of generics/variadic-safe function pointers means can't
- * be fully collapsed into one function). Returns 1 if the caller should
- * take the "call original directly, no protection" path (either because
- * of PASSTHROUGH strategy or the depth safety valve), 0 if it already
- * handled everything (CONTAIN path, including logging on recovery). */
+/* ---- +0x1D751: use-after-free / dangling-pointer teardown site ---- */
 
-/* ---- +0x1D751 hook (use-after-free / dangling-pointer teardown site) ---- */
+typedef void (__thiscall *TeardownFn)(void *this_);
+static TeardownFn s_realTeardownFn = NULL;
 
-typedef void (__thiscall *Fn_0041d751)(void *this_);
-static Fn_0041d751 fpOrig_0041d751 = NULL;
-
-static void __thiscall Detour_0041d751(void *this_)
+static void __thiscall TeardownDetour_0x1D751(void *this_)
 {
     if (g_flags.hook1D751 == STRAT_PASSTHROUGH) {
-        fpOrig_0041d751(this_);
+        s_realTeardownFn(this_);
         return;
     }
 
-    if (g_guardDepth >= MAX_GUARD_DEPTH) {
+    if (g_activeGuardCount >= MAX_GUARD_DEPTH) {
         ProxyLog("hook-1d751: guard stack full (depth=%d), calling through UNGUARDED, this=%p",
-                 g_guardDepth, this_);
-        fpOrig_0041d751(this_);
+                 g_activeGuardCount, this_);
+        s_realTeardownFn(this_);
         return;
     }
 
-    int depth = g_guardDepth++;
-    g_guardSiteStack[depth] = "1d751(UAF-teardown)";
+    int depth = g_activeGuardCount++;
+    g_guardFrames[depth].siteName = "1d751(UAF-teardown)";
 
-    if (setjmp(g_recoveryStack[depth]) == 0) {
-        fpOrig_0041d751(this_);
+    if (setjmp(g_guardFrames[depth].recoveryPoint) == 0) {
+        s_realTeardownFn(this_);
     } else {
         ProxyLog("hook-1d751: CONTAINED an access violation inside the teardown/UAF site "
                  "(this=%p, depth=%d) - one wave-bank cleanup call was skipped, game should continue",
                  this_, depth);
     }
 
-    g_guardDepth--;
+    g_activeGuardCount--;
 }
 
-/* ---- +0x1D212 hook (null pointer-chain hop, dominant repeat crash) ---- */
+/* ---- +0x1D212: null pointer-chain hop, dominant repeat crash ---- */
 
-typedef void (__thiscall *Fn_0041d212)(void *this_, unsigned char param1);
-static Fn_0041d212 fpOrig_0041d212 = NULL;
+typedef void (__thiscall *NullHopFn)(void *this_, unsigned char param1);
+static NullHopFn s_realNullHopFn = NULL;
 
-static void __thiscall Detour_0041d212(void *this_, unsigned char param1)
+static void __thiscall NullHopDetour_0x1D212(void *this_, unsigned char param1)
 {
     if (g_flags.hook1D212 == STRAT_PASSTHROUGH) {
-        fpOrig_0041d212(this_, param1);
+        s_realNullHopFn(this_, param1);
         return;
     }
 
-    if (g_guardDepth >= MAX_GUARD_DEPTH) {
+    if (g_activeGuardCount >= MAX_GUARD_DEPTH) {
         ProxyLog("hook-1d212: guard stack full (depth=%d), calling through UNGUARDED, this=%p param1=%u",
-                 g_guardDepth, this_, (unsigned)param1);
-        fpOrig_0041d212(this_, param1);
+                 g_activeGuardCount, this_, (unsigned)param1);
+        s_realNullHopFn(this_, param1);
         return;
     }
 
-    int depth = g_guardDepth++;
-    g_guardSiteStack[depth] = "1d212(null-hop)";
+    int depth = g_activeGuardCount++;
+    g_guardFrames[depth].siteName = "1d212(null-hop)";
 
-    if (setjmp(g_recoveryStack[depth]) == 0) {
-        fpOrig_0041d212(this_, param1);
+    if (setjmp(g_guardFrames[depth].recoveryPoint) == 0) {
+        s_realNullHopFn(this_, param1);
     } else {
         ProxyLog("hook-1d212: CONTAINED an access violation on the null-pointer-chain site "
                  "(this=%p, param1=%u, depth=%d) - that sound/cue lookup was skipped, game should continue",
                  this_, (unsigned)param1, depth);
     }
 
-    g_guardDepth--;
+    g_activeGuardCount--;
 }
 
-/* ---- +0x1DE46 hook (linked-list iterator invalidation, §2.7c) ---- */
+/* ---- +0x1DE46: linked-list iterator invalidation, §2.7c ---- */
 
-typedef void (__thiscall *Fn_0041de46)(void *this_);
-static Fn_0041de46 fpOrig_0041de46 = NULL;
+typedef void (__thiscall *ListWalkFn)(void *this_);
+static ListWalkFn s_realListWalkFn = NULL;
 
-static void __thiscall Detour_0041de46(void *this_)
+static void __thiscall ListWalkDetour_0x1DE46(void *this_)
 {
     if (g_flags.hook1DE46 == STRAT_PASSTHROUGH) {
-        fpOrig_0041de46(this_);
+        s_realListWalkFn(this_);
         return;
     }
 
-    if (g_guardDepth >= MAX_GUARD_DEPTH) {
+    if (g_activeGuardCount >= MAX_GUARD_DEPTH) {
         ProxyLog("hook-1de46: guard stack full (depth=%d), calling through UNGUARDED, this=%p",
-                 g_guardDepth, this_);
-        fpOrig_0041de46(this_);
+                 g_activeGuardCount, this_);
+        s_realListWalkFn(this_);
         return;
     }
 
-    int depth = g_guardDepth++;
-    g_guardSiteStack[depth] = "1de46(list-walk)";
+    int depth = g_activeGuardCount++;
+    g_guardFrames[depth].siteName = "1de46(list-walk)";
 
-    if (setjmp(g_recoveryStack[depth]) == 0) {
-        fpOrig_0041de46(this_);
+    if (setjmp(g_guardFrames[depth].recoveryPoint) == 0) {
+        s_realListWalkFn(this_);
     } else {
         /* A fault mid-walk means we abandon the rest of the list for this
          * call - the nodes already processed before the fault keep
@@ -174,31 +173,31 @@ static void __thiscall Detour_0041de46(void *this_)
                  this_, depth);
     }
 
-    g_guardDepth--;
+    g_activeGuardCount--;
 }
 
 /* ---- process-wide safety net ---- */
 
-static LONG WINAPI XactVeh(EXCEPTION_POINTERS *ep)
+static LONG WINAPI HandleXactAccessViolation(EXCEPTION_POINTERS *exceptionInfo)
 {
-    if (ep->ExceptionRecord->ExceptionCode != EXCEPTION_ACCESS_VIOLATION) {
+    if (exceptionInfo->ExceptionRecord->ExceptionCode != EXCEPTION_ACCESS_VIOLATION) {
         return EXCEPTION_CONTINUE_SEARCH;
     }
 
-    void *faultAddr = (void *)(UINT_PTR)ep->ContextRecord->Eip;
+    void *faultAddr = (void *)(UINT_PTR)exceptionInfo->ContextRecord->Eip;
     BOOL inXactModule = g_xactBase &&
         (BYTE *)faultAddr >= (BYTE *)g_xactBase &&
         (BYTE *)faultAddr <  (BYTE *)g_xactBase + g_xactSize;
 
-    if (g_guardDepth > 0) {
+    if (g_activeGuardCount > 0) {
         /* We're inside one of our own guarded calls on THIS thread (TLS -
          * naturally scoped per-thread, so a fault on a different thread
          * can never mistakenly recover here even if that thread also has
          * a guard active). Recover at the innermost active guard. */
-        int depth = g_guardDepth - 1;
+        int depth = g_activeGuardCount - 1;
         ProxyLog("VEH: access violation at %p during guarded call [%s] (depth=%d) - recovering via longjmp",
-                 faultAddr, g_guardSiteStack[depth], depth);
-        longjmp(g_recoveryStack[depth], 1); /* does not return */
+                 faultAddr, g_guardFrames[depth].siteName, depth);
+        longjmp(g_guardFrames[depth].recoveryPoint, 1); /* does not return */
     }
 
     if (inXactModule) {
@@ -216,26 +215,28 @@ static LONG WINAPI XactVeh(EXCEPTION_POINTERS *ep)
                  "Esp=%08lx Ebp=%08lx Esi=%08lx Edi=%08lx - NOT contained, letting it crash "
                  "so this becomes a new hook candidate",
                  faultAddr, g_xactBase, (unsigned long)g_xactSize,
-                 ep->ContextRecord->Eax, ep->ContextRecord->Ecx, ep->ContextRecord->Edx, ep->ContextRecord->Ebx,
-                 ep->ContextRecord->Esp, ep->ContextRecord->Ebp, ep->ContextRecord->Esi, ep->ContextRecord->Edi);
+                 exceptionInfo->ContextRecord->Eax, exceptionInfo->ContextRecord->Ecx,
+                 exceptionInfo->ContextRecord->Edx, exceptionInfo->ContextRecord->Ebx,
+                 exceptionInfo->ContextRecord->Esp, exceptionInfo->ContextRecord->Ebp,
+                 exceptionInfo->ContextRecord->Esi, exceptionInfo->ContextRecord->Edi);
     }
 
     return EXCEPTION_CONTINUE_SEARCH;
 }
 
-static void InstallOneHook(const char *name, void *target, void *detour, void **origOut, GuardStrategy strategy)
+static void InstallOneHook(const char *siteLabel, void *target, void *detour, void **originalFnOut, GuardStrategy strategy)
 {
     if (strategy == STRAT_DISABLED) {
-        ProxyLog("InstallXactGuards: %s DISABLED by config, not installing hook (target=%p)", name, target);
+        ProxyLog("InstallXactGuards: %s DISABLED by config, not installing hook (target=%p)", siteLabel, target);
         return;
     }
 
-    MH_STATUS st = MH_CreateHook(target, detour, origOut);
+    MH_STATUS hookStatus = MH_CreateHook(target, detour, originalFnOut);
     ProxyLog("InstallXactGuards: MH_CreateHook %s (target=%p, strategy=%s) -> %d",
-             name, target, strategy == STRAT_PASSTHROUGH ? "passthrough" : "contain", (int)st);
-    if (st == MH_OK) {
-        st = MH_EnableHook(target);
-        ProxyLog("InstallXactGuards: MH_EnableHook %s -> %d", name, (int)st);
+             siteLabel, target, strategy == STRAT_PASSTHROUGH ? "passthrough" : "contain", (int)hookStatus);
+    if (hookStatus == MH_OK) {
+        hookStatus = MH_EnableHook(target);
+        ProxyLog("InstallXactGuards: MH_EnableHook %s -> %d", siteLabel, (int)hookStatus);
     }
 }
 
@@ -243,10 +244,10 @@ void InstallXactGuards(HMODULE xactBase)
 {
     LoadXactFlags();
 
-    MODULEINFO mi;
-    if (GetModuleInformation(GetCurrentProcess(), xactBase, &mi, sizeof(mi))) {
-        g_xactBase = mi.lpBaseOfDll;
-        g_xactSize = mi.SizeOfImage;
+    MODULEINFO moduleInfo;
+    if (GetModuleInformation(GetCurrentProcess(), xactBase, &moduleInfo, sizeof(moduleInfo))) {
+        g_xactBase = moduleInfo.lpBaseOfDll;
+        g_xactSize = moduleInfo.SizeOfImage;
     } else {
         /* Fallback: base is what we were handed, size unknown -> treat as
          * a single point rather than a range for the "inXactModule" check. */
@@ -257,24 +258,24 @@ void InstallXactGuards(HMODULE xactBase)
     ProxyLog("InstallXactGuards: xactengine2_9.dll base=%p size=%lu",
              g_xactBase, (unsigned long)g_xactSize);
 
-    g_vehHandle = AddVectoredExceptionHandler(1 /* call first */, XactVeh);
+    g_vehHandle = AddVectoredExceptionHandler(1 /* call first */, HandleXactAccessViolation);
     if (!g_vehHandle) {
         ProxyLog("InstallXactGuards: AddVectoredExceptionHandler FAILED (GetLastError=%lu)",
                  (unsigned long)GetLastError());
     }
 
-    MH_STATUS st = MH_Initialize();
-    if (st != MH_OK && st != MH_ERROR_ALREADY_INITIALIZED) {
-        ProxyLog("InstallXactGuards: MH_Initialize failed: %d", (int)st);
+    MH_STATUS initStatus = MH_Initialize();
+    if (initStatus != MH_OK && initStatus != MH_ERROR_ALREADY_INITIALIZED) {
+        ProxyLog("InstallXactGuards: MH_Initialize failed: %d", (int)initStatus);
         return;
     }
 
-    InstallOneHook("+0x1D751", (BYTE *)g_xactBase + 0x1D751, (void *)Detour_0041d751,
-                   (void **)&fpOrig_0041d751, g_flags.hook1D751);
-    InstallOneHook("+0x1D212", (BYTE *)g_xactBase + 0x1D212, (void *)Detour_0041d212,
-                   (void **)&fpOrig_0041d212, g_flags.hook1D212);
-    InstallOneHook("+0x1DE46", (BYTE *)g_xactBase + 0x1DE46, (void *)Detour_0041de46,
-                   (void **)&fpOrig_0041de46, g_flags.hook1DE46);
+    InstallOneHook("+0x1D751", (BYTE *)g_xactBase + 0x1D751, (void *)TeardownDetour_0x1D751,
+                   (void **)&s_realTeardownFn, g_flags.hook1D751);
+    InstallOneHook("+0x1D212", (BYTE *)g_xactBase + 0x1D212, (void *)NullHopDetour_0x1D212,
+                   (void **)&s_realNullHopFn, g_flags.hook1D212);
+    InstallOneHook("+0x1DE46", (BYTE *)g_xactBase + 0x1DE46, (void *)ListWalkDetour_0x1DE46,
+                   (void **)&s_realListWalkFn, g_flags.hook1DE46);
 
     ProxyLog("InstallXactGuards: setup complete");
 }

--- a/contrib/xact-crash-fix/src/xact_guards.h
+++ b/contrib/xact-crash-fix/src/xact_guards.h
@@ -1,0 +1,21 @@
+#ifndef XACT_GUARDS_H
+#define XACT_GUARDS_H
+#include <windows.h>
+
+/* Installs the process-wide VEH safety net plus the three targeted MinHook
+ * guards at the known crash sites (+0x1D751 UAF, +0x1D212 null-deref,
+ * +0x1DE46 list-walk - see the plan doc §2.7/§2.7b/§2.7c for the analysis
+ * this is based on). Call once xactengine2_9.dll is confirmed loaded. */
+void InstallXactGuards(HMODULE xactBase);
+
+/* Convenience entry point for ANY loader (the BugSplat-proxy injection
+ * vector, or in principle a debugger like FADeepProbe injecting this
+ * module directly - see StartXactGuardsWatcher below) - spawns a
+ * background thread that polls for xactengine2_9.dll and calls
+ * InstallXactGuards() once it appears. Safe to call from DllMain (does
+ * not do real work on the calling thread, respects the loader-lock rule).
+ * `selfModule` is this module's own HMODULE, used only to init logging/
+ * path resolution (ProxyLogInit) - pass whatever HMODULE DllMain received. */
+void StartXactGuardsWatcher(HMODULE selfModule);
+
+#endif


### PR DESCRIPTION
## What this is

A community-found and root-caused fix for a long-standing crash: repeated `ACCESS_VIOLATION` crashes during play (and occasionally on exit), several minutes into a match, since forever. Confirmed the root cause via static analysis (Ghidra) and live testing — this fix has caught and contained real crashes during actual play sessions today.

## Root cause

Component: `xactengine2_9.dll`, Microsoft's XACT audio engine (DirectX Aug 2007 redistributable, not an OS file — same version regardless of Windows version). Three known fault sites, all traced to one wave-bank reload function (`FUN_0041d60e`):

- A missing-lock **race condition**: the reload function correctly frees+nulls a resource pointer under its own lock, but two other functions read that same pointer without ever acquiring that lock — depending on timing this manifests as a **use-after-free** or a **null-pointer dereference**.
- A separate **iterator-invalidation** bug: a linked-list walk calls the same reload function on every node, which can free/mutate nodes later in the list that the walk hasn't reached yet.

## The fix

A proxy `BugSplat.dll` (the client already imports this by name from its own bin directory — confirmed via `GameBinariesUpdateTaskImpl.java`'s `BINARIES_TO_COPY` list) forwards all 19 real BugSplat exports transparently, and additionally installs 3 targeted hooks (MinHook) at the known fault offsets inside `xactengine2_9.dll` once it loads. Each hook wraps the risky call in a recovery point (GCC doesn't support MSVC's `__try`/`__except`, so this uses `setjmp`/`longjmp` from inside a Vectored Exception Handler instead) — a caught fault means that one sound/cue operation gets skipped and logged, instead of crashing the whole game.

The actual protection logic is split out (`xact_guards.c`) from the injection vector (`dllmain.c`) — a standalone `xact_guards.dll` build target also exists with zero BugSplat dependency, in case another loader (e.g. [FADeepProbe](https://github.com/faforever/fadeepprobe), which already launches the game as a debugged child process) ever wanted to inject it directly instead.

## What's NOT done here (deliberately)

This is added under `contrib/xact-crash-fix/` as a standalone, buildable proposal — **not wired into the client's actual binary-update path.** See `contrib/xact-crash-fix/INTEGRATION.md` for the concrete integration point I found (a small addition to `GameBinariesUpdateTaskImpl.java`) and why I didn't just implement it: it needs an opt-in mechanism (this patches behavior around a Microsoft-owned DLL, not something in this codebase, and shouldn't be silently forced on everyone), and ideally a runtime version check against the on-disk `xactengine2_9.dll` so a mismatched DLL version fails safe instead of hooking wrong offsets — that's not yet verified across different players' machines, only confirmed on mine plus one matching community bug report.

## Why draft

I don't have visibility into whether a native DLL hook is something this project wants to take on at all, or how you'd want it gated/shipped if so — opening this as a concrete starting point for that conversation rather than presenting it as finished/mergeable. Happy to iterate based on feedback, including moving this out of the Java repo entirely if that's preferred (standalone tool + a link from here, for example).